### PR TITLE
feat: add pane maximize/restore feature

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,16 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
+import { TerminalPane } from './components/TerminalPane'
 import { useLayout } from './hooks/useLayout'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
+import { findPaneById } from './utils/layoutTree'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
 
 export const App: React.FC = () => {
   const { layout, displayConfig, error, updateSizes, splitPane, closePane } = useLayout()
+  const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
 
   if (error) {
     return (
@@ -41,14 +44,23 @@ export const App: React.FC = () => {
     )
   }
 
+  const maximizedPane = maximizedPaneId ? findPaneById(layout, maximizedPaneId) : null
+
   return (
     <LayoutActionsContext.Provider value={{
       onSplit: splitPane,
       onClose: closePane,
+      onMaximize: setMaximizedPaneId,
+      maximizedPaneId,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
     }}>
-      <div style={{ width: '100%', height: '100%' }}>
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <SplitContainer layout={layout} onLayoutChange={updateSizes} />
+        {maximizedPane && (
+          <div style={{ position: 'absolute', inset: 0, zIndex: 10, backgroundColor: '#1a1b1e' }}>
+            <TerminalPane pane={maximizedPane} />
+          </div>
+        )}
       </div>
     </LayoutActionsContext.Provider>
   )

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -6,8 +6,10 @@ interface PaneHeaderProps {
   pane: PaneConfig
   connected: boolean
   displayConfig: DisplayConfig
+  isMaximized: boolean
   onSplit: (direction: 'horizontal' | 'vertical') => void
   onClose: () => void
+  onMaximize: () => void
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -38,8 +40,10 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
   pane,
   connected,
   displayConfig,
+  isMaximized,
   onSplit,
   onClose,
+  onMaximize,
 }) => {
   const showHeader = pane.show_header ?? displayConfig.show_header
   if (!showHeader) return null
@@ -77,6 +81,13 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
       {!connected && <span style={{ color: '#555' }}>reconnecting…</span>}
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '2px' }}>
+        <button
+          title={isMaximized ? 'Restore' : 'Maximize'}
+          onClick={onMaximize}
+          style={buttonStyle}
+        >
+          {isMaximized ? '⤡' : '⤢'}
+        </button>
         <button
           title="Split horizontal"
           onClick={() => onSplit('horizontal')}

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -6,6 +6,8 @@ import { TerminalPane } from './TerminalPane'
 export interface LayoutActionsContextValue {
   onSplit: (paneId: string, direction: 'horizontal' | 'vertical') => void
   onClose: (paneId: string) => void
+  onMaximize: (paneId: string | null) => void
+  maximizedPaneId: string | null
   displayConfig: DisplayConfig
 }
 

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -51,8 +51,10 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
         pane={pane}
         connected={connected}
         displayConfig={displayConfig}
+        isMaximized={ctx?.maximizedPaneId === pane.id}
         onSplit={(direction) => ctx?.onSplit(pane.id, direction)}
         onClose={() => ctx?.onClose(pane.id)}
+        onMaximize={() => ctx?.onMaximize(ctx.maximizedPaneId === pane.id ? null : pane.id)}
       />
       <div
         ref={setRef}

--- a/frontend/src/utils/layoutTree.test.ts
+++ b/frontend/src/utils/layoutTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { splitPaneInTree, removePaneFromTree, generatePaneId } from './layoutTree'
+import { splitPaneInTree, removePaneFromTree, generatePaneId, findPaneById } from './layoutTree'
 import type { LayoutNode } from '../schemas'
 
 const simpleLayout: LayoutNode = {
@@ -120,6 +120,42 @@ describe('removePaneFromTree', () => {
   it('returns unchanged layout when pane not found', () => {
     const result = removePaneFromTree(twoChildLayout, 'nonexistent')
     expect(result!.children).toHaveLength(2)
+  })
+})
+
+describe('findPaneById', () => {
+  it('finds a top-level pane', () => {
+    const result = findPaneById(simpleLayout, 'main')
+    expect(result?.id).toBe('main')
+  })
+
+  it('finds a pane among siblings', () => {
+    const result = findPaneById(twoChildLayout, 'right')
+    expect(result?.id).toBe('right')
+  })
+
+  it('finds a deeply nested pane', () => {
+    const nested: LayoutNode = {
+      direction: 'horizontal',
+      children: [
+        { size: 50, pane: { id: 'left', type: 'local' } },
+        {
+          size: 50,
+          direction: 'vertical',
+          children: [
+            { size: 50, pane: { id: 'top-right', type: 'local' } },
+            { size: 50, pane: { id: 'bottom-right', type: 'local' } },
+          ],
+        },
+      ],
+    }
+    const result = findPaneById(nested, 'bottom-right')
+    expect(result?.id).toBe('bottom-right')
+  })
+
+  it('returns null when pane not found', () => {
+    const result = findPaneById(simpleLayout, 'nonexistent')
+    expect(result).toBeNull()
   })
 })
 

--- a/frontend/src/utils/layoutTree.ts
+++ b/frontend/src/utils/layoutTree.ts
@@ -94,6 +94,21 @@ function removeFromChildren(
 }
 
 /**
+ * Finds and returns the PaneConfig with the given id in the layout tree.
+ * Returns null if not found.
+ */
+export function findPaneById(layout: LayoutNode, paneId: string): PaneConfig | null {
+  for (const child of layout.children) {
+    if (child.pane?.id === paneId) return child.pane
+    if (child.children?.length) {
+      const found = findPaneById({ ...layout, children: child.children }, paneId)
+      if (found) return found
+    }
+  }
+  return null
+}
+
+/**
  * Generates a unique pane ID.
  */
 export function generatePaneId(): string {


### PR DESCRIPTION
## Summary

- ペインヘッダーに ⤢/⤡ ボタンを追加。クリックで対象ペインをフルサイズのオーバーレイ表示し、再クリックで元のレイアウトに戻る
- バックグラウンドのターミナルセッションは維持されたまま（`useTerminal` のグローバル Map に保持）
- サーバー側の変更なし・永続化なし — UI 専用の state のみ

## Changes

| File | Change |
|------|--------|
| `utils/layoutTree.ts` | `findPaneById()` ヘルパーを追加 |
| `components/SplitContainer.tsx` | `LayoutActionsContext` に `onMaximize` / `maximizedPaneId` を追加 |
| `components/PaneHeader.tsx` | maximize/restore ボタンを追加 |
| `components/TerminalPane.tsx` | コンテキストから maximize コールバックを `PaneHeader` に渡す |
| `App.tsx` | `maximizedPaneId` state の管理とオーバーレイ `TerminalPane` のレンダリング |

## Test plan

- [ ] `cd frontend && npm test` — 全テストパス
- [ ] `cd frontend && npm run coverage` — カバレッジ ≥ 80%
- [ ] `cd frontend && npx tsc --noEmit` — 型エラーなし
- [ ] 複数ペインがある状態で ⤢ をクリック → 対象ペインが全面表示される
- [ ] 最大化中に ⤡ をクリック → 元のレイアウトに戻る
- [ ] バックグラウンドのターミナルセッションが最大化前後で維持される