### PR TITLE
fix: disable auto-labeling in release-please to prevent GraphQL errors

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "labels": [],
+  "release-labels": [],
   "packages": {
     ".": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

- Add `"labels": []` and `"release-labels": []` to `release-please-config.json`
- Prevents the `googleapis/release-please-action` from attempting GraphQL label mutations on PRs
- Fixes the recurring "Could not resolve to a node with the global id of 'PR_...'" error

## Root Cause

The release-please action tries to add `autorelease: pending` / `autorelease: tagged` labels to release PRs via GitHub GraphQL. The label lookup or mutation fails — likely because the `autorelease: pending` label does not exist in the repository — causing the "Could not resolve to a node" GraphQL error.

Setting `labels` and `release-labels` to empty arrays disables this label mutation step entirely.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `release-please` workflow runs successfully on the next push to main
- [ ] Verify a "chore(release):" PR is created without errors