### PR TITLE
fix: resolve 4 GitHub code scanning security alerts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,12 @@ type ServerConfig struct {
 }
 
 type SSHConnection struct {
-	Host    string `yaml:"host"`
-	Port    int    `yaml:"port"`
-	User    string `yaml:"user"`
-	KeyFile string `yaml:"key_file"`
-	Password string `yaml:"password,omitempty"`
+	Host           string `yaml:"host"`
+	Port           int    `yaml:"port"`
+	User           string `yaml:"user"`
+	KeyFile        string `yaml:"key_file"`
+	Password       string `yaml:"password,omitempty"`
+	KnownHostsFile string `yaml:"known_hosts_file,omitempty" json:"known_hosts_file,omitempty"`
 }
 
 type DisplayConfig struct {
@@ -119,11 +120,14 @@ func Default() *Config {
 
 func (c *Config) expandPaths() {
 	for key, conn := range c.SSHConnections {
+		home, _ := os.UserHomeDir()
 		if strings.HasPrefix(conn.KeyFile, "~/") {
-			home, _ := os.UserHomeDir()
 			conn.KeyFile = filepath.Join(home, conn.KeyFile[2:])
-			c.SSHConnections[key] = conn
 		}
+		if strings.HasPrefix(conn.KnownHostsFile, "~/") {
+			conn.KnownHostsFile = filepath.Join(home, conn.KnownHostsFile[2:])
+		}
+		c.SSHConnections[key] = conn
 	}
 	expandPanesCwd(c.Layout.Children)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -305,6 +305,36 @@ layout:
 	assert.False(t, strings.HasPrefix(cfg.Layout.Children[0].Pane.Cwd, "~/"))
 }
 
+func TestValidate_LocalPaneShellRelativePath_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.Shell = "bash" // relative, not absolute
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute path")
+}
+
+func TestValidate_LocalPaneShellAbsolutePath_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.Shell = "/bin/bash"
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_TmuxSessionInvalidChars_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.Type = "tmux"
+	cfg.Layout.Children[0].Pane.TmuxSession = "foo;bar"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid characters")
+}
+
+func TestValidate_TmuxSessionValidChars_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.Type = "tmux"
+	cfg.Layout.Children[0].Pane.TmuxSession = "my-session.1"
+	assert.NoError(t, cfg.Validate())
+}
+
 // helpers
 
 func validConfig() *Config {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,8 +3,11 @@ package config
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
+
+var tmuxSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // Validate checks the configuration for correctness.
 // It collects all errors and returns them as a single combined error.
@@ -115,9 +118,15 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 		}
 	}
 
+	if p.Type == "local" && p.Shell != "" && !strings.HasPrefix(p.Shell, "/") {
+		errs = append(errs, fmt.Sprintf("pane %q: shell must be an absolute path, got %q", p.ID, p.Shell))
+	}
+
 	if p.Type == "tmux" || p.Type == "ssh_tmux" {
 		if p.TmuxSession == "" {
 			errs = append(errs, fmt.Sprintf("pane %q: tmux_session must not be empty", p.ID))
+		} else if !tmuxSessionNameRe.MatchString(p.TmuxSession) {
+			errs = append(errs, fmt.Sprintf("pane %q: tmux_session %q contains invalid characters (allowed: a-z A-Z 0-9 - _ .)", p.ID, p.TmuxSession))
 		}
 	}
 

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -18,11 +18,12 @@ func CreateFromConfig(pane *config.PaneConfig, sshConns map[string]config.SSHCon
 			return nil, fmt.Errorf("ssh connection %q not found", pane.Connection)
 		}
 		return NewSSH(pane.ID, pane.Title, SSHConfig{
-			Host:     conn.Host,
-			Port:     conn.Port,
-			User:     conn.User,
-			KeyFile:  conn.KeyFile,
-			Password: conn.Password,
+			Host:           conn.Host,
+			Port:           conn.Port,
+			User:           conn.User,
+			KeyFile:        conn.KeyFile,
+			Password:       conn.Password,
+			KnownHostsFile: conn.KnownHostsFile,
 		})
 
 	case TypeTmux:
@@ -34,11 +35,12 @@ func CreateFromConfig(pane *config.PaneConfig, sshConns map[string]config.SSHCon
 			return nil, fmt.Errorf("ssh connection %q not found", pane.Connection)
 		}
 		return NewTmuxSSH(pane.ID, pane.Title, pane.TmuxSession, SSHConfig{
-			Host:     conn.Host,
-			Port:     conn.Port,
-			User:     conn.User,
-			KeyFile:  conn.KeyFile,
-			Password: conn.Password,
+			Host:           conn.Host,
+			Port:           conn.Port,
+			User:           conn.User,
+			KeyFile:        conn.KeyFile,
+			Password:       conn.Password,
+			KnownHostsFile: conn.KnownHostsFile,
 		})
 
 	default:

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"syscall"
 
@@ -27,6 +28,13 @@ func NewLocal(id, shell, cwd, title string) (*LocalSession, error) {
 		if shell == "" {
 			shell = "/bin/sh"
 		}
+	}
+
+	if !filepath.IsAbs(shell) {
+		return nil, fmt.Errorf("shell must be an absolute path: %q", shell)
+	}
+	if _, err := exec.LookPath(shell); err != nil {
+		return nil, fmt.Errorf("shell not found: %w", err)
 	}
 
 	cmd := exec.Command(shell)

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -90,6 +90,12 @@ func TestNewLocal_Close(t *testing.T) {
 	assert.Equal(t, StateExited, sess.State())
 }
 
+func TestNewLocal_RelativeShell_Error(t *testing.T) {
+	_, err := NewLocal("test-id", "sh", "", "relative shell")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute path")
+}
+
 func TestNewLocal_WithCwd(t *testing.T) {
 	tmpDir := os.TempDir()
 	sess, err := NewLocal("cwd-test", "/bin/sh", tmpDir, "cwd")

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // SSHSession manages an SSH connection with a PTY.
@@ -26,11 +28,12 @@ type SSHSession struct {
 
 // SSHConfig holds parameters for establishing an SSH connection.
 type SSHConfig struct {
-	Host     string
-	Port     int
-	User     string
-	KeyFile  string
-	Password string
+	Host           string
+	Port           int
+	User           string
+	KeyFile        string
+	Password       string
+	KnownHostsFile string
 }
 
 // NewSSH creates and starts a new SSH terminal session.
@@ -40,10 +43,15 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		return nil, err
 	}
 
+	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
+	if err != nil {
+		return nil, err
+	}
+
 	sshCfg := &ssh.ClientConfig{
 		User:            cfg.User,
 		Auth:            authMethods,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // TODO: use known_hosts in production
+		HostKeyCallback: hkCallback,
 	}
 
 	port := cfg.Port
@@ -120,6 +128,21 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	}()
 
 	return s, nil
+}
+
+func buildHostKeyCallback(knownHostsFile string) (ssh.HostKeyCallback, error) {
+	if knownHostsFile == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("getting home dir: %w", err)
+		}
+		knownHostsFile = filepath.Join(home, ".ssh", "known_hosts")
+	}
+	cb, err := knownhosts.New(knownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading known_hosts %s: %w", knownHostsFile, err)
+	}
+	return cb, nil
 }
 
 func buildAuthMethods(cfg SSHConfig) ([]ssh.AuthMethod, error) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -1,0 +1,25 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {
+	_, err := buildHostKeyCallback("/nonexistent/path/known_hosts")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "known_hosts")
+}
+
+func TestBuildHostKeyCallback_ValidFile_NoError(t *testing.T) {
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(""), 0600))
+
+	_, err := buildHostKeyCallback(knownHostsPath)
+	assert.NoError(t, err)
+}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -23,3 +23,15 @@ func TestBuildHostKeyCallback_ValidFile_NoError(t *testing.T) {
 	_, err := buildHostKeyCallback(knownHostsPath)
 	assert.NoError(t, err)
 }
+
+func TestNewTmuxSSH_InvalidSessionName_Error(t *testing.T) {
+	cfg := SSHConfig{
+		Host:     "127.0.0.1",
+		Port:     22,
+		User:     "user",
+		Password: "pass",
+	}
+	_, err := NewTmuxSSH("id", "title", "foo;bar$(evil)", cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tmux session name")
+}

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -33,10 +33,15 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		return nil, err
 	}
 
+	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
+	if err != nil {
+		return nil, err
+	}
+
 	sshCfg := &ssh.ClientConfig{
 		User:            cfg.User,
 		Auth:            authMethods,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hkCallback,
 	}
 
 	port := cfg.Port
@@ -86,8 +91,8 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	sess.Stdout = pw
 	sess.Stderr = pw
 
-	// Attach to existing tmux session
-	if err := sess.Start(fmt.Sprintf("tmux attach-session -t %s", tmuxSession)); err != nil {
+	// Attach to existing tmux session (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
+	if err := sess.Start(fmt.Sprintf("tmux attach-session -t '%s'", tmuxSession)); err != nil {
 		sess.Close()
 		client.Close()
 		return nil, fmt.Errorf("starting tmux attach: %w", err)

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"regexp"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
 )
+
+var validTmuxSessionName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // TmuxSSHSession attaches to a tmux session on a remote host via SSH.
 type TmuxSSHSession struct {
@@ -26,6 +29,9 @@ type TmuxSSHSession struct {
 func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, error) {
 	if tmuxSession == "" {
 		tmuxSession = "0"
+	}
+	if !validTmuxSessionName.MatchString(tmuxSession) {
+		return nil, fmt.Errorf("invalid tmux session name %q: must match ^[a-zA-Z0-9_.-]+$", tmuxSession)
 	}
 
 	authMethods, err := buildAuthMethods(cfg)


### PR DESCRIPTION
## Summary

- **command-injection** (`local.go`): Validate `shell` is an absolute path via `filepath.IsAbs` + `exec.LookPath` before passing to `exec.Command`. Added config validation to reject relative shell paths.
- **command-injection** (`tmux_ssh.go`): Single-quote `tmuxSession` in the remote shell command string. Added regex validation in config to restrict session names to `[a-zA-Z0-9_.-]+`.
- **insecure-hostkeycallback** (`ssh.go`, `tmux_ssh.go`): Replace `ssh.InsecureIgnoreHostKey()` with `knownhosts.New()`. Defaults to `~/.ssh/known_hosts`; overridable per SSH connection via `known_hosts_file` in YAML config.

## Changes

| File | Change |
|------|--------|
| `internal/config/validate.go` | Shell absolute path check; tmux session name regex validation |
| `internal/config/config.go` | `KnownHostsFile` field on `SSHConnection`; path expansion for `~/` |
| `internal/session/local.go` | `filepath.IsAbs` + `exec.LookPath` guard before `exec.Command` |
| `internal/session/ssh.go` | `KnownHostsFile` in `SSHConfig`; `buildHostKeyCallback()` helper; replace insecure callback |
| `internal/session/tmux_ssh.go` | Use `buildHostKeyCallback()`; single-quote tmux session name |
| `internal/session/factory.go` | Pass `KnownHostsFile` to `SSHConfig` |

## Test plan

- [x] New tests written first (TDD), confirmed failing before implementation
- [x] `TestValidate_LocalPaneShellRelativePath_Error` — rejects relative shell paths in config
- [x] `TestValidate_TmuxSessionInvalidChars_Error` — rejects shell metacharacters in session names
- [x] `TestNewLocal_RelativeShell_Error` — `NewLocal` rejects relative shell at runtime
- [x] `TestBuildHostKeyCallback_NonexistentFile_Error` — error when known_hosts file is missing
- [x] `TestBuildHostKeyCallback_ValidFile_NoError` — succeeds with valid (empty) known_hosts
- [x] `go test ./internal/... -race` passes
- [x] Coverage gate `make coverage-go` passes (86.9% ≥ 80%)
- [x] `go vet ./internal/...` clean