### PR TITLE
fix: validate shell against /etc/shells to resolve go/command-injection alert

### DIFF
--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -30,11 +31,8 @@ func NewLocal(id, shell, cwd, title string) (*LocalSession, error) {
 		}
 	}
 
-	if !filepath.IsAbs(shell) {
-		return nil, fmt.Errorf("shell must be an absolute path: %q", shell)
-	}
-	if _, err := exec.LookPath(shell); err != nil {
-		return nil, fmt.Errorf("shell not found: %w", err)
+	if err := validateShell(shell); err != nil {
+		return nil, err
 	}
 
 	cmd := exec.Command(shell)
@@ -104,4 +102,38 @@ func (s *LocalSession) Close() error {
 		s.cmd.Process.Kill()
 	}
 	return nil
+}
+
+// validateShell ensures the shell path is absolute, exists, and is listed in
+// /etc/shells. Validating against the system allowlist breaks the taint-tracked
+// data flow that CodeQL's go/command-injection rule follows from user config to
+// exec.Command.
+func validateShell(shell string) error {
+	if !filepath.IsAbs(shell) {
+		return fmt.Errorf("shell must be an absolute path: %q", shell)
+	}
+	if _, err := exec.LookPath(shell); err != nil {
+		return fmt.Errorf("shell not found: %w", err)
+	}
+	allowed, err := readEtcShells()
+	if err == nil && !allowed[shell] {
+		return fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", shell)
+	}
+	return nil
+}
+
+// readEtcShells parses /etc/shells and returns the set of listed shell paths.
+func readEtcShells() (map[string]bool, error) {
+	data, err := os.ReadFile("/etc/shells")
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]bool)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			allowed[line] = true
+		}
+	}
+	return allowed, nil
 }

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -104,3 +104,19 @@ func TestNewLocal_WithCwd(t *testing.T) {
 
 	assert.Equal(t, StateConnected, sess.State())
 }
+
+func TestValidateShell_InEtcShells_OK(t *testing.T) {
+	err := validateShell("/bin/sh")
+	assert.NoError(t, err)
+}
+
+func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
+	// Create a real executable that is not listed in /etc/shells.
+	dir := t.TempDir()
+	fakePath := dir + "/fakeshell"
+	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755))
+
+	err := validateShell(fakePath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an allowed shell")
+}


### PR DESCRIPTION
## Summary

- CodeQL's `go/command-injection` rule flagged `exec.Command(shell)` in `internal/session/local.go` because the shell path flows from user-controlled YAML config
- Added `validateShell` helper that checks the shell against the `/etc/shells` system allowlist, breaking the taint-tracked data flow
- Falls through gracefully when `/etc/shells` is unreadable (e.g. unusual CI environments)
- Existing absolute-path and `exec.LookPath` checks are preserved inside the helper

## Test plan

- [x] `TestValidateShell_InEtcShells_OK` — `/bin/sh` passes validation
- [x] `TestValidateShell_NotInEtcShells_Error` — a real executable not in `/etc/shells` is rejected with `"not an allowed shell"`
- [x] All existing session tests continue to pass (`go test ./internal/session/... -v -race`)
- [x] `make check` passes (lint + test + coverage ≥ 80 %)