### PR TITLE
fix: restore terminal after maximize/restore

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
-import { TerminalPane } from './components/TerminalPane'
 import { useLayout } from './hooks/useLayout'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
-import { findPaneById } from './utils/layoutTree'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
 
@@ -44,8 +42,6 @@ export const App: React.FC = () => {
     )
   }
 
-  const maximizedPane = maximizedPaneId ? findPaneById(layout, maximizedPaneId) : null
-
   return (
     <LayoutActionsContext.Provider value={{
       onSplit: splitPane,
@@ -56,11 +52,6 @@ export const App: React.FC = () => {
     }}>
       <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <SplitContainer layout={layout} onLayoutChange={updateSizes} />
-        {maximizedPane && (
-          <div style={{ position: 'absolute', inset: 0, zIndex: 10, backgroundColor: '#1a1b1e' }}>
-            <TerminalPane pane={maximizedPane} />
-          </div>
-        )}
       </div>
     </LayoutActionsContext.Provider>
   )

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { render, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { LayoutRenderer, LayoutActionsContext, LayoutActionsContextValue } from './SplitContainer'
+import { LayoutChild } from '../types'
+
+// Stub TerminalPane and SplitDivider so we don't need xterm.js or drag logic
+vi.mock('./TerminalPane', () => ({
+  TerminalPane: ({ pane }: { pane: { id: string } }) => (
+    <div data-pane-id={pane.id} />
+  ),
+}))
+vi.mock('./SplitDivider', () => ({
+  SplitDivider: () => <div data-divider />,
+}))
+
+const pane1: LayoutChild = { size: 50, pane: { id: 'p1', type: 'local' } }
+const pane2: LayoutChild = { size: 50, pane: { id: 'p2', type: 'local' } }
+const children = [pane1, pane2]
+
+function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
+  return {
+    onSplit: vi.fn(),
+    onClose: vi.fn(),
+    onMaximize: vi.fn(),
+    maximizedPaneId,
+    displayConfig: { show_header: false, show_status_bar: false },
+  }
+}
+
+/** Returns the direct child wrapper divs of the LayoutRenderer flex container. */
+function getWrapperDivs(container: HTMLElement): HTMLElement[] {
+  // LayoutRenderer renders one flex div; find it regardless of surrounding elements
+  const flex = container.querySelector('[style*="display: flex"]') as HTMLElement
+  return Array.from(flex.children).filter(
+    (el) => !(el as HTMLElement).dataset.divider,
+  ) as HTMLElement[]
+}
+
+describe('LayoutRenderer maximize CSS', () => {
+  it('applies absolute positioning to the maximized child wrapper only', () => {
+    const { container } = render(
+      <LayoutActionsContext.Provider value={makeCtx('p1')}>
+        <LayoutRenderer direction="horizontal" children={children} onChildrenChange={vi.fn()} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    const [wrapper1, wrapper2] = getWrapperDivs(container)
+    expect(wrapper1.style.position).toBe('absolute')
+    expect(wrapper1.style.inset).toBeTruthy()
+    expect(Number(wrapper1.style.zIndex)).toBeGreaterThan(0)
+    expect(wrapper2.style.position).not.toBe('absolute')
+  })
+
+  it('does not apply absolute positioning when no pane is maximized', () => {
+    const { container } = render(
+      <LayoutActionsContext.Provider value={makeCtx(null)}>
+        <LayoutRenderer direction="horizontal" children={children} onChildrenChange={vi.fn()} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    const [wrapper1, wrapper2] = getWrapperDivs(container)
+    expect(wrapper1.style.position).not.toBe('absolute')
+    expect(wrapper2.style.position).not.toBe('absolute')
+  })
+
+  it('toggles maximize CSS when maximizedPaneId changes', () => {
+    function Wrapper() {
+      const [maxId, setMaxId] = useState<string | null>(null)
+      return (
+        <LayoutActionsContext.Provider value={{ ...makeCtx(maxId), onMaximize: setMaxId }}>
+          <button onClick={() => setMaxId(maxId ? null : 'p1')}>toggle</button>
+          <LayoutRenderer direction="horizontal" children={children} onChildrenChange={vi.fn()} />
+        </LayoutActionsContext.Provider>
+      )
+    }
+
+    const { container, getByRole } = render(<Wrapper />)
+
+    // Initially not maximized
+    const [w1a] = getWrapperDivs(container)
+    expect(w1a.style.position).not.toBe('absolute')
+
+    // Maximize p1
+    act(() => { getByRole('button').click() })
+    const [w1b, w2b] = getWrapperDivs(container)
+    expect(w1b.style.position).toBe('absolute')
+    expect(w2b.style.position).not.toBe('absolute')
+
+    // Restore
+    act(() => { getByRole('button').click() })
+    const [w1c] = getWrapperDivs(container)
+    expect(w1c.style.position).not.toBe('absolute')
+  })
+})

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useContext, useRef } from 'react'
 import { DisplayConfig, LayoutChild, LayoutNode } from '../types'
 import { SplitDivider } from './SplitDivider'
 import { TerminalPane } from './TerminalPane'
@@ -34,9 +34,10 @@ interface LayoutRendererProps {
   onChildrenChange: (children: LayoutChild[]) => void
 }
 
-const LayoutRenderer: React.FC<LayoutRendererProps> = ({ direction, children, onChildrenChange }) => {
+export const LayoutRenderer: React.FC<LayoutRendererProps> = ({ direction, children, onChildrenChange }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const isHorizontal = direction === 'horizontal'
+  const layoutCtx = useContext(LayoutActionsContext)
 
   const handleDrag = useCallback((index: number, delta: number) => {
     if (!containerRef.current) return
@@ -73,6 +74,7 @@ const LayoutRenderer: React.FC<LayoutRendererProps> = ({ direction, children, on
       {children.map((child, index) => {
         const key = child.pane?.id ?? `split-${direction}-${index}`
         const isLast = index === children.length - 1
+        const isMaximized = child.pane?.id !== undefined && child.pane.id === layoutCtx?.maximizedPaneId
         return (
           <React.Fragment key={key}>
             <div
@@ -82,6 +84,12 @@ const LayoutRenderer: React.FC<LayoutRendererProps> = ({ direction, children, on
                 flexGrow: 0,
                 overflow: 'hidden',
                 ...(isHorizontal ? { minWidth: 50 } : { minHeight: 50 }),
+                ...(isMaximized ? {
+                  position: 'absolute',
+                  inset: 0,
+                  zIndex: 10,
+                  backgroundColor: '#1a1b1e',
+                } : {}),
               }}
             >
               <ChildRenderer


### PR DESCRIPTION
## Summary

- **Root cause**: maximizing a pane rendered a second TerminalPane for the same sessionId in an overlay div while the original remained mounted in SplitContainer. Both shared the same TerminalEntry. When the overlay unmounted on restore, its cleanup disposed the xterm.js terminal the original pane was still using — blank screen, no input.
- **Fix**: apply CSS absolute positioning to the already-mounted child wrapper div in LayoutRenderer when maximized. Remove the duplicate overlay TerminalPane from App.tsx.
- The existing ResizeObserver fires naturally on CSS size change, so PTY resize message is sent without extra code.

## Test plan

- [ ] `cd frontend && npm test` — all 78 tests pass including 3 new SplitContainer tests
- [ ] Maximize a pane → terminal fills screen, remains functional
- [ ] Restore → terminal returns to split layout, input works
- [ ] Resize browser window after restore → terminal reflows