### PR TITLE
fix: hide split divider when a pane is maximized

### DIFF
--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -37,6 +37,26 @@ function getWrapperDivs(container: HTMLElement): HTMLElement[] {
   ) as HTMLElement[]
 }
 
+describe('LayoutRenderer divider visibility', () => {
+  it('hides the divider when a pane is maximized', () => {
+    const { container } = render(
+      <LayoutActionsContext.Provider value={makeCtx('p1')}>
+        <LayoutRenderer direction="horizontal" children={children} onChildrenChange={vi.fn()} />
+      </LayoutActionsContext.Provider>,
+    )
+    expect(container.querySelector('[data-divider]')).toBeNull()
+  })
+
+  it('shows the divider when no pane is maximized', () => {
+    const { container } = render(
+      <LayoutActionsContext.Provider value={makeCtx(null)}>
+        <LayoutRenderer direction="horizontal" children={children} onChildrenChange={vi.fn()} />
+      </LayoutActionsContext.Provider>,
+    )
+    expect(container.querySelector('[data-divider]')).not.toBeNull()
+  })
+})
+
 describe('LayoutRenderer maximize CSS', () => {
   it('applies absolute positioning to the maximized child wrapper only', () => {
     const { container } = render(

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -101,7 +101,7 @@ export const LayoutRenderer: React.FC<LayoutRendererProps> = ({ direction, child
                 }}
               />
             </div>
-            {!isLast && (
+            {!isLast && !layoutCtx?.maximizedPaneId && (
               <SplitDivider direction={direction} onDrag={(d) => handleDrag(index, d)} />
             )}
           </React.Fragment>


### PR DESCRIPTION
## Summary

- When the **left** pane was maximized, its wrapper div left the flex flow (`position: absolute`), but the `SplitDivider` rendered after it remained visible in the layout.
- The right pane's `z-index: 10` happened to cover the divider, so the bug only appeared on the left side.
- Fix: add `&& !layoutCtx?.maximizedPaneId` to the divider render condition — one line change.

## Test plan

- [x] `cd frontend && npm test` — all 80 tests pass (2 new divider visibility tests)
- [x] Maximize left pane → no divider visible ✅ (manually verified)
- [x] Maximize right pane → no divider visible ✅ (manually verified)
- [x] Restore → divider reappears ✅ (manually verified)