### PR TITLE
fix: break CodeQL taint chain for go/command-injection alert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,18 @@ Sessions are started at server startup from the YAML config (`main.go: startSess
 - When adding new generated artifacts, caches, release outputs, or other non-source resources, update `.gitignore` in the same change.
 - Do not leave new build or release byproducts such as `dist/` as recurring untracked files.
 
+### CodeQL compliance (`go/command-injection`)
+
+When writing code that passes user-supplied values to `exec.Command`:
+
+- **The first argument (command) must never be user input.** Use a hardcoded literal or a value read from a trusted system source (`/etc/shells`, `/etc/passwd`, etc.).
+- **Avoid `os.Getenv` for values that flow to exec.** Environment variables are CodeQL taint sources. Use hardcoded defaults instead.
+- **Returning `m[1]` from `FindStringSubmatch(userInput)` does not break taint.** The submatch is still derived from user input in CodeQL's data-flow model.
+- **Returning a key `s` from `for s := range trustedMap` breaks taint**, provided no other code path in the same function returns the user-supplied value directly (including fallbacks).
+- **Regex `MatchString` as a guard is the CodeQL-recommended sanitization pattern** for subsequent arguments; for the command itself, a system-registry lookup (returning the registry's own value) is required.
+
+See `docs/architecture.md` → *Security Design* for the full rationale and the `/etc/shells` pattern used in this codebase.
+
 ### Pull request test plan
 - After creating a PR, run every item in the test plan locally and verify it passes.
 - Update the PR description with all checkboxes checked (`- [x]`) before considering the task complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,8 @@ Sessions are started at server startup from the YAML config (`main.go: startSess
 ### Ignore generated resources
 - When adding new generated artifacts, caches, release outputs, or other non-source resources, update `.gitignore` in the same change.
 - Do not leave new build or release byproducts such as `dist/` as recurring untracked files.
+
+### Pull request test plan
+- After creating a PR, run every item in the test plan locally and verify it passes.
+- Update the PR description with all checkboxes checked (`- [x]`) before considering the task complete.
+- Do not leave test plan items unchecked — the description must reflect actual verified results.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,32 @@ Why Zod:
 - TypeScript types are inferred from schemas, reducing drift
 - keeps API and WebSocket assumptions explicit
 
+## Security Design
+
+### Session command execution
+
+All session types that execute a local process use `exec.Command` with user-configurable values (shell path, tmux session name). These values must be sanitized before reaching the exec sink. The rules are:
+
+**Shell path (`local`, `ssh` sessions)**
+
+`validateShell` in `internal/session/local.go` applies three layers:
+
+1. **Absolute-path check** — rejects relative paths outright.
+2. **Regex character allowlist** — `^(/[a-zA-Z0-9._\-/]+)$` rejects shell metacharacters (spaces, semicolons, quotes, etc.).
+3. **`/etc/shells` allowlist** — iterates the system shell registry and returns the **key from the map** (`s`), not the caller-supplied value.
+
+The third point is critical for CodeQL's `go/command-injection` analysis. CodeQL tracks data flow from taint sources (environment variables, HTTP request bodies) to exec sinks. A sanitization function only breaks the taint chain if its **return value has no data-flow path back to user input**. Returning `m[1]` from `regexp.FindStringSubmatch(shell)` is insufficient because the submatch is still derived from `shell`. Returning the `/etc/shells` map key `s` works because CodeQL does not propagate taint through equality comparisons in a range loop — `s` originates from file I/O, not user input.
+
+For the same reason, `os.Getenv("SHELL")` is not used as a default shell. Environment variables are taint sources in CodeQL's model; if the env-var value were to flow through `exec.Command` even after validation, the alert would remain. The default is always the hardcoded literal `"/bin/sh"`.
+
+**Tmux session name (`tmux`, `ssh_tmux` sessions)**
+
+`validTmuxSessionName` in `internal/session/tmux_ssh.go` uses a strict regex (`^[a-zA-Z0-9_.-]+$`) validated at construction time, and arguments are passed as discrete `exec.Command` args (not via `sh -c`), so no shell interpolation occurs.
+
+**General rule**
+
+When adding new session types or new `exec.Command` calls: the value passed as the command (first argument) must come from a hardcoded literal or from a trusted system source (file, registry) with no data-flow path to user input. Arguments after the command may be user-supplied if they cannot be interpreted as commands by the target binary.
+
 ## Tradeoffs and Intentional Limits
 
 - One WebSocket per pane is simple and isolates failures, but increases connection count with many panes.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -5,12 +5,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
 
 	"github.com/creack/pty"
 )
+
+// validShellPath matches a valid absolute shell path.
+// Only alphanumeric characters, dots, underscores, hyphens, and slashes are permitted.
+// This character allowlist is the sanitizer CodeQL requires for go/command-injection.
+var validShellPath = regexp.MustCompile(`^(/[a-zA-Z0-9._\-/]+)$`)
 
 // LocalSession is a local PTY-based terminal session.
 type LocalSession struct {
@@ -105,29 +111,29 @@ func (s *LocalSession) Close() error {
 	return nil
 }
 
-// validateShell ensures the shell path is absolute, exists, and is listed in
-// /etc/shells. It returns the shell path as read from /etc/shells (a trusted
-// source), not the original user-supplied value. This breaks the taint-tracked
-// data flow that CodeQL's go/command-injection rule follows from user config to
-// exec.Command — the returned string originates from file I/O, not user input.
+// validateShell ensures the shell path is safe to execute.
+// It validates the path against a character allowlist regex (per CodeQL's
+// go/command-injection recommendation), verifies the binary exists, and
+// cross-checks against /etc/shells. Returns the regex-sanitized path m[1],
+// whose value is constructed by the regex engine rather than copied from
+// user input, which satisfies CodeQL's taint-flow analysis.
 func validateShell(shell string) (string, error) {
 	if !filepath.IsAbs(shell) {
 		return "", fmt.Errorf("shell must be an absolute path: %q", shell)
 	}
-	if _, err := exec.LookPath(shell); err != nil {
+	m := validShellPath.FindStringSubmatch(shell)
+	if m == nil {
+		return "", fmt.Errorf("shell path contains invalid characters: %q (must match %s)", shell, validShellPath)
+	}
+	sanitized := m[1] // value constructed by regex engine from the safe character class
+	if _, err := exec.LookPath(sanitized); err != nil {
 		return "", fmt.Errorf("shell not found: %w", err)
 	}
 	allowed, err := readEtcShells()
-	if err != nil {
-		// /etc/shells not readable; accept any valid absolute path that exists.
-		return shell, nil
+	if err == nil && !allowed[sanitized] {
+		return "", fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", sanitized)
 	}
-	for s := range allowed {
-		if s == shell {
-			return s, nil // s originates from /etc/shells, breaking the taint chain
-		}
-	}
-	return "", fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", shell)
+	return sanitized, nil
 }
 
 // readEtcShells parses /etc/shells and returns the set of listed shell paths.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -31,11 +31,12 @@ func NewLocal(id, shell, cwd, title string) (*LocalSession, error) {
 		}
 	}
 
-	if err := validateShell(shell); err != nil {
+	sanitizedShell, err := validateShell(shell)
+	if err != nil {
 		return nil, err
 	}
 
-	cmd := exec.Command(shell)
+	cmd := exec.Command(sanitizedShell)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 	if cwd != "" {
 		cmd.Dir = cwd
@@ -105,21 +106,28 @@ func (s *LocalSession) Close() error {
 }
 
 // validateShell ensures the shell path is absolute, exists, and is listed in
-// /etc/shells. Validating against the system allowlist breaks the taint-tracked
+// /etc/shells. It returns the shell path as read from /etc/shells (a trusted
+// source), not the original user-supplied value. This breaks the taint-tracked
 // data flow that CodeQL's go/command-injection rule follows from user config to
-// exec.Command.
-func validateShell(shell string) error {
+// exec.Command — the returned string originates from file I/O, not user input.
+func validateShell(shell string) (string, error) {
 	if !filepath.IsAbs(shell) {
-		return fmt.Errorf("shell must be an absolute path: %q", shell)
+		return "", fmt.Errorf("shell must be an absolute path: %q", shell)
 	}
 	if _, err := exec.LookPath(shell); err != nil {
-		return fmt.Errorf("shell not found: %w", err)
+		return "", fmt.Errorf("shell not found: %w", err)
 	}
 	allowed, err := readEtcShells()
-	if err == nil && !allowed[shell] {
-		return fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", shell)
+	if err != nil {
+		// /etc/shells not readable; accept any valid absolute path that exists.
+		return shell, nil
 	}
-	return nil
+	for s := range allowed {
+		if s == shell {
+			return s, nil // s originates from /etc/shells, breaking the taint chain
+		}
+	}
+	return "", fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", shell)
 }
 
 // readEtcShells parses /etc/shells and returns the set of listed shell paths.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -31,10 +31,7 @@ type LocalSession struct {
 // NewLocal creates and starts a new local PTY session.
 func NewLocal(id, shell, cwd, title string) (*LocalSession, error) {
 	if shell == "" {
-		shell = os.Getenv("SHELL")
-		if shell == "" {
-			shell = "/bin/sh"
-		}
+		shell = "/bin/sh"
 	}
 
 	sanitizedShell, err := validateShell(shell)
@@ -112,28 +109,34 @@ func (s *LocalSession) Close() error {
 }
 
 // validateShell ensures the shell path is safe to execute.
-// It validates the path against a character allowlist regex (per CodeQL's
-// go/command-injection recommendation), verifies the binary exists, and
-// cross-checks against /etc/shells. Returns the regex-sanitized path m[1],
-// whose value is constructed by the regex engine rather than copied from
-// user input, which satisfies CodeQL's taint-flow analysis.
+// It applies three checks in order:
+//  1. Character allowlist regex — rejects paths with shell metacharacters.
+//  2. exec.LookPath — confirms the binary exists.
+//  3. /etc/shells lookup — returns the entry directly from the system allowlist.
+//
+// The return value is the key read from /etc/shells (not the caller-supplied
+// value), so CodeQL's taint-flow analysis sees no path from user input to
+// exec.Command.
 func validateShell(shell string) (string, error) {
 	if !filepath.IsAbs(shell) {
 		return "", fmt.Errorf("shell must be an absolute path: %q", shell)
 	}
-	m := validShellPath.FindStringSubmatch(shell)
-	if m == nil {
+	if !validShellPath.MatchString(shell) {
 		return "", fmt.Errorf("shell path contains invalid characters: %q (must match %s)", shell, validShellPath)
 	}
-	sanitized := m[1] // value constructed by regex engine from the safe character class
-	if _, err := exec.LookPath(sanitized); err != nil {
+	if _, err := exec.LookPath(shell); err != nil {
 		return "", fmt.Errorf("shell not found: %w", err)
 	}
 	allowed, err := readEtcShells()
-	if err == nil && !allowed[sanitized] {
-		return "", fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", sanitized)
+	if err != nil {
+		return "", fmt.Errorf("cannot validate shell (failed to read /etc/shells): %w", err)
 	}
-	return sanitized, nil
+	for s := range allowed {
+		if s == shell {
+			return s, nil // s is a key from /etc/shells — not derived from user input
+		}
+	}
+	return "", fmt.Errorf("not an allowed shell: %q (not listed in /etc/shells)", shell)
 }
 
 // readEtcShells parses /etc/shells and returns the set of listed shell paths.

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -106,8 +106,9 @@ func TestNewLocal_WithCwd(t *testing.T) {
 }
 
 func TestValidateShell_InEtcShells_OK(t *testing.T) {
-	err := validateShell("/bin/sh")
+	got, err := validateShell("/bin/sh")
 	assert.NoError(t, err)
+	assert.Equal(t, "/bin/sh", got)
 }
 
 func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
@@ -116,7 +117,7 @@ func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
 	fakePath := dir + "/fakeshell"
 	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755))
 
-	err := validateShell(fakePath)
+	_, err := validateShell(fakePath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not an allowed shell")
 }

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -121,3 +121,9 @@ func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not an allowed shell")
 }
+
+func TestValidateShell_InvalidChars_Error(t *testing.T) {
+	_, err := validateShell("/bin/sh; rm -rf /")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid characters")
+}


### PR DESCRIPTION
## Summary

Two root causes kept the \`go/command-injection\` alert alive after the initial fix:

1. **\`os.Getenv("SHELL")\` is a CodeQL taint source** (environment variable). Replaced with a hardcoded \`"/bin/sh"\` default; users who want a different shell should set it explicitly in their config file.

2. **\`validateShell\` returned \`m[1]\` from \`FindStringSubmatch\`**, which is still derived from user input in CodeQL's data-flow model. Now uses \`MatchString\` as a guard (per CodeQL's own recommendation) and returns the key \`s\` read directly from \`/etc/shells\` — a value with no data-flow path from user input. The \`/etc/shells\`-unavailable fallback that previously returned the user-supplied shell is replaced with an error.

## Test plan

- [x] \`go test ./internal/session/... -v -race\` — all tests pass
- [x] \`make check\` — lint + all tests + Go coverage 86.9% ≥ 80% + frontend coverage ≥ 80%
- [x] GitHub code scanning alert #1 (\`go/command-injection\`) — CodeQL check passes on PR