### PR TITLE
fix: make check build frontend first so it always tests latest code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,12 @@ lint-frontend:
 
 # ── Quality gate (lint + test + coverage) ─────────────────────────────────────
 
-check: lint test coverage
+check: build-frontend lint test coverage
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
-# build requires check (lint + test + coverage) to pass first.
-build: check build-frontend build-backend
+# build requires check (build-frontend + lint + test + coverage) to pass first.
+build: check build-backend
 
 build-frontend:
 	cd frontend && npm run build


### PR DESCRIPTION
## Summary
- `check` now depends on `build-frontend` as its first step
- `build` drops the redundant `build-frontend` dep (already included via `check`)

## Problem
`go vet ./...` and `go test ./...` compile `main.go` which has `//go:embed frontend/dist`. Without a pre-built dist:
- `make check` failed on a clean checkout
- `make build` ran `check` against a stale dist from a previous build, then rebuilt the frontend after the fact

## Fix
```
check: build-frontend lint test coverage   # was: lint test coverage
build: check build-backend                 # was: check build-frontend build-backend
```

## Test plan
- [x] `make clean && make check` succeeds from scratch
- [x] `make clean && make build` succeeds from scratch