### PR TITLE
fix: trigger release workflow on release published event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- **Root cause**: `release-please` uses `GITHUB_TOKEN` to push tags. GitHub Actions prevents workflows triggered by `GITHUB_TOKEN` push events from spawning further workflow runs. So `release.yml` (triggered on `push: tags: v*`) was never executing, leaving the GitHub Release without binary assets.
- **Fix**: Change trigger from `push: tags: v*` to `release: types: [published]`. When release-please publishes a GitHub Release via the API, this event does trigger other workflows even with `GITHUB_TOKEN`.
- GoReleaser will find the existing release for the tag and upload the binary assets (4 binaries + checksums.txt) to it.

## Test plan

- [ ] Merge this PR
- [ ] Manually trigger the workflow for existing v0.2.0: `gh workflow run release.yml --ref v0.2.0`
- [ ] Verify v0.2.0 Release Assets contain 4 binaries (`darwin/linux × amd64/arm64`) and `checksums.txt`
- [ ] Verify `install.sh --repo tomo-chan/panemux` downloads and installs correctly
- [ ] On next release-please PR merge, confirm `release.yml` runs automatically