### PR TITLE
docs: add OSS-standard README and MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-present panemux contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-present panemux contributors
+Copyright (c) 2026 tomo-chan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,175 @@
 # panemux
+
+**Browser-based terminal multiplexer** — split your terminal into multiple panes, each connecting to a local shell, remote SSH host, or tmux session, all rendered in your browser via xterm.js.
+
+[![CI](https://github.com/tomo-chan/panemux/actions/workflows/ci.yml/badge.svg)](https://github.com/tomo-chan/panemux/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Go 1.24](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go)](https://golang.org)
+[![Releases](https://img.shields.io/github/v/release/tomo-chan/panemux)](https://github.com/tomo-chan/panemux/releases)
+
+---
+
+## Features
+
+- **Four pane types** — `local` (shell), `ssh` (remote), `tmux` (local session attach), `ssh_tmux` (SSH → tmux)
+- **Recursive split layout** — nest horizontal and vertical splits to any depth
+- **Drag-to-resize** — drag dividers in the browser to adjust pane sizes
+- **xterm.js rendering** — full-featured terminal emulation with Unicode and colour support
+- **Single binary** — Go backend embeds the compiled frontend; no separate web server needed
+- **YAML config** — declare your entire layout and SSH connections in one file
+
+---
+
+## Installation
+
+### Pre-built binary
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/tomo-chan/panemux/main/install.sh | sh
+```
+
+Or with options:
+
+```sh
+./install.sh --repo tomo-chan/panemux --version v0.2.0 --install-dir ~/.local/bin
+```
+
+### Build from source
+
+Requirements: **Go 1.24+**, **Node.js 20+**
+
+```sh
+git clone https://github.com/tomo-chan/panemux.git
+cd panemux
+make install-deps   # npm install + go mod download
+make build          # outputs bin/panemux
+```
+
+---
+
+## Quick start
+
+```sh
+# Run with a single local shell (default)
+./bin/panemux
+
+# Load a layout from a config file
+./bin/panemux --config config.yaml
+
+# Override port and open Chrome automatically
+./bin/panemux --port 9090 --open
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+---
+
+## Configuration
+
+Copy `config.example.yaml` as a starting point:
+
+```yaml
+server:
+  port: 8080
+  host: "127.0.0.1"
+
+# Named SSH connections referenced by layout panes
+ssh_connections:
+  prod-web:
+    host: "192.168.1.10"
+    port: 22
+    user: "deploy"
+    key_file: "~/.ssh/id_ed25519"
+
+# Recursive layout tree
+layout:
+  direction: horizontal       # horizontal | vertical
+  children:
+    - size: 50                # percentage (siblings must sum to 100)
+      pane:
+        id: "local-main"
+        type: local           # local | ssh | tmux | ssh_tmux
+        shell: "/bin/zsh"
+        cwd: "~/development"
+        title: "Dev Shell"
+    - size: 50
+      direction: vertical     # nested split
+      children:
+        - size: 60
+          pane:
+            id: "ssh-prod"
+            type: ssh
+            connection: prod-web   # key from ssh_connections
+            title: "Prod Web"
+        - size: 40
+          pane:
+            id: "tmux-local"
+            type: tmux
+            tmux_session: "work"   # existing tmux session name
+            title: "Tmux Work"
+```
+
+### Pane types
+
+| Type | Description |
+|------|-------------|
+| `local` | Local shell process (`shell`, `cwd` optional) |
+| `ssh` | SSH connection defined in `ssh_connections` |
+| `tmux` | Attach to a local tmux session (`tmux_session`) |
+| `ssh_tmux` | SSH to a host, then attach to a tmux session |
+
+---
+
+## Development
+
+### Prerequisites
+
+- Go 1.24+
+- Node.js 20+
+
+### Setup
+
+```sh
+make install-deps   # first time: npm install + go mod download
+```
+
+### Dev servers
+
+```sh
+make dev-backend    # Go backend on :8080
+make dev-frontend   # Vite dev server on :5173 (proxies /api and /ws to :8080)
+```
+
+### Quality gate
+
+```sh
+make check   # lint + test + coverage (must pass before build)
+```
+
+Individual commands:
+
+```sh
+go test ./... -v -race           # Go tests
+cd frontend && npm test          # Frontend tests
+make coverage-go                 # Go coverage (≥ 80 % required)
+cd frontend && npm run coverage  # Frontend coverage (≥ 80 % required)
+go vet ./...                     # Go lint
+cd frontend && npx tsc --noEmit  # TypeScript type check
+```
+
+---
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Make your changes — write tests first, confirm they fail, then implement.
+3. Run `make check` and ensure all checks pass.
+4. Open a pull request against `main` with a description of what and why.
+
+Please keep pull requests focused. One logical change per PR makes review faster and history cleaner.
+
+---
+
+## License
+
+[MIT](LICENSE) — Copyright (c) 2024-present panemux contributors

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@
 - **Four pane types** — `local` (shell), `ssh` (remote), `tmux` (local session attach), `ssh_tmux` (SSH → tmux)
 - **Recursive split layout** — nest horizontal and vertical splits to any depth
 - **Drag-to-resize** — drag dividers in the browser to adjust pane sizes
+- **Edit mode** — lock/unlock toggle controls whether layout changes are saved to disk; edits are always applied in-memory
+- **Session resilience** — tmux sessions are auto-created when absent; exited panes show a Restart button to reconnect without reloading
 - **xterm.js rendering** — full-featured terminal emulation with Unicode and colour support
 - **Single binary** — Go backend embeds the compiled frontend; no separate web server needed
-- **YAML config** — declare your entire layout and SSH connections in one file
+- **YAML config** — declare your entire layout and SSH connections in one file; defaults to `~/.config/panemux/config.yaml`
 
 ---
 
@@ -50,10 +52,10 @@ make build          # outputs bin/panemux
 ## Quick start
 
 ```sh
-# Run with a single local shell (default)
+# Run with defaults (loads ~/.config/panemux/config.yaml if it exists, otherwise a single local shell)
 ./bin/panemux
 
-# Load a layout from a config file
+# Load a specific config file
 ./bin/panemux --config config.yaml
 
 # Override port and open Chrome automatically
@@ -66,7 +68,7 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 
 ## Configuration
 
-Copy `config.example.yaml` as a starting point:
+The default config path is `~/.config/panemux/config.yaml` (created automatically on first save). Copy `config.example.yaml` as a starting point:
 
 ```yaml
 server:
@@ -115,8 +117,12 @@ layout:
 |------|-------------|
 | `local` | Local shell process (`shell`, `cwd` optional) |
 | `ssh` | SSH connection defined in `ssh_connections` |
-| `tmux` | Attach to a local tmux session (`tmux_session`) |
-| `ssh_tmux` | SSH to a host, then attach to a tmux session |
+| `tmux` | Attach to a local tmux session (`tmux_session`); created automatically if absent |
+| `ssh_tmux` | SSH to a host, then attach to a tmux session; created automatically if absent |
+
+### Edit mode
+
+By default, layout changes (drag-resize, close) are applied in-memory only. Click the lock icon in the bottom-right corner to enable **edit mode**, which persists changes back to the config file. Disable edit mode to explore layouts without touching the file.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -178,4 +178,4 @@ Please keep pull requests focused. One logical change per PR makes review faster
 
 ## License
 
-[MIT](LICENSE) — Copyright (c) 2024-present panemux contributors
+[MIT](LICENSE) — Copyright (c) 2026 tomo-chan


### PR DESCRIPTION
## Summary

- Rewrites the placeholder \`README.md\` with full OSS-standard documentation: features, installation (binary + source), quick start, configuration reference with annotated YAML, development guide, and contributing guidelines
- Adds a \`LICENSE\` file (MIT, 2024-present panemux contributors) — the repo had none

## Test plan

- [x] README renders correctly on GitHub (badges, code blocks, table)
- [x] LICENSE file is present and correctly formatted
- [x] \`make lint\` passes (no code changes; existing \`go vet\` failure requires \`make build-frontend\` first and is pre-existing)