### PR TITLE
fix: show error message and suppress write spam when tmux session exits

### DIFF
--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -20,7 +20,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
     setContainerEl(el)
   }, [])
 
-  const { handleResize, connected, dims } = useTerminal({
+  const { handleResize, connected, dims, sessionExited, restartSession } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
   })
@@ -62,8 +62,36 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
           flex: 1,
           overflow: 'hidden',
           padding: '4px',
+          position: 'relative',
         }}
-      />
+      >
+        {sessionExited && (
+          <div style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'rgba(0, 0, 0, 0.6)',
+            zIndex: 10,
+          }}>
+            <button
+              onClick={restartSession}
+              style={{
+                padding: '6px 18px',
+                backgroundColor: '#3f3f46',
+                color: '#d4d4d4',
+                border: '1px solid #52525b',
+                borderRadius: '4px',
+                fontSize: '13px',
+                cursor: 'pointer',
+              }}
+            >
+              Restart Session
+            </button>
+          </div>
+        )}
+      </div>
       <PaneStatusBar
         pane={pane}
         displayConfig={displayConfig}

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -353,6 +353,57 @@ describe('useTerminal', () => {
     expect(document.execCommand).toHaveBeenCalledWith('copy')
   })
 
+  it('sessionExited is false initially', () => {
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
+    expect(result.current.sessionExited).toBe(false)
+  })
+
+  it('sessionExited is true after exited status frame', () => {
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'exited' })
+      )
+    )
+    expect(result.current.sessionExited).toBe(true)
+  })
+
+  it('sessionExited resets to false when WebSocket reconnects', () => {
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'exited' })
+      )
+    )
+    expect(result.current.sessionExited).toBe(true)
+
+    // Simulate WebSocket reconnecting
+    act(() => MockWebSocket.instances[0].simulateOpen())
+    expect(result.current.sessionExited).toBe(false)
+  })
+
+  it('restartSession calls restart API then reconnects', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 'pane1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const countBefore = MockWebSocket.instances.length
+    await act(async () => { await result.current.restartSession() })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/sessions/pane1/restart', { method: 'POST' })
+    expect(MockWebSocket.instances.length).toBeGreaterThan(countBefore)
+  })
+
   it('reuses the same terminal instance across remounts for the same session', () => {
     const firstContainer = makeContainer()
     const secondContainer = makeContainer()

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -232,6 +232,22 @@ describe('useTerminal', () => {
     )
   })
 
+  it('writes session ended message to terminal on exited status', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    mockWrite.mockClear()
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'exited' })
+      )
+    )
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.stringContaining('[Session ended]')
+    )
+  })
+
   it('does not write to terminal on status control frame', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -37,8 +37,10 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
       try {
         const msg = JSON.parse(data as string)
         if (msg.type === 'status') {
-          // Could show status overlay; for now just log
           console.log(`Session ${sessionId} status:`, msg.state)
+          if (msg.state === 'exited') {
+            termRef.current.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
+          }
         } else if (msg.type === 'error') {
           termRef.current.write(`\r\n\x1b[31mError: ${msg.message}\x1b[0m\r\n`)
         }

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -27,6 +27,7 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   const sendRef = useRef<((data: string | ArrayBuffer | Uint8Array) => void) | null>(null)
   const entryRef = useRef<TerminalEntry | null>(null)
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null)
+  const [sessionExited, setSessionExited] = useState(false)
 
   const handleMessage = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
     if (!termRef.current) return
@@ -39,6 +40,7 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
         if (msg.type === 'status') {
           console.log(`Session ${sessionId} status:`, msg.state)
           if (msg.state === 'exited') {
+            setSessionExited(true)
             termRef.current.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
           }
         } else if (msg.type === 'error') {
@@ -52,9 +54,10 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   }, [sessionId])
 
   const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/${sessionId}`
-  const { send, connected } = useWebSocket(wsUrl, {
+  const { send, connected, reconnect } = useWebSocket(wsUrl, {
     onMessage: handleMessage,
     onOpen: () => {
+      setSessionExited(false)
       if (fitAddonRef.current && termRef.current) {
         fitAddonRef.current.fit()
         const { cols, rows } = termRef.current
@@ -110,6 +113,13 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     }
   }, [container, sessionId])
 
+  const restartSession = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/restart`, { method: 'POST' })
+      if (res.ok) reconnect()
+    } catch { /* ignore network errors */ }
+  }, [sessionId, reconnect])
+
   // Handle resize
   const handleResize = useCallback(() => {
     const entry = entryRef.current
@@ -124,7 +134,7 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     }
   }, [send, connected])
 
-  return { handleResize, connected, dims }
+  return { handleResize, connected, dims, sessionExited, restartSession }
 }
 
 function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -178,6 +178,33 @@ describe('useWebSocket', () => {
     expect(MockWebSocket.instances[0].sent).toHaveLength(0)
   })
 
+  it('reconnect creates a new WebSocket connection', () => {
+    const onMessage = vi.fn()
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/ws/s1', { onMessage })
+    )
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const countBefore = MockWebSocket.instances.length
+    act(() => result.current.reconnect())
+
+    expect(MockWebSocket.instances.length).toBeGreaterThan(countBefore)
+  })
+
+  it('reconnect works even after max attempts are exhausted', () => {
+    const onMessage = vi.fn()
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/ws/s1', { onMessage, reconnectDelay: 100, maxReconnectAttempts: 1 })
+    )
+    // Exhaust reconnect attempts
+    act(() => MockWebSocket.instances[0].simulateClose())
+    act(() => vi.advanceTimersByTime(200))
+    expect(MockWebSocket.instances).toHaveLength(1) // stopped reconnecting
+
+    act(() => result.current.reconnect())
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
   it('passes binary messages through without validation', () => {
     const onMessage = vi.fn()
     renderHook(() => useWebSocket('ws://localhost/ws/s1', { onMessage }))

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -85,5 +85,20 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
     }
   }, [])
 
-  return { send, connected }
+  // Imperatively reconnect: detach the current socket (without triggering the
+  // onclose reconnect loop), reset the attempt counter, then connect fresh.
+  const reconnect = useCallback(() => {
+    const ws = wsRef.current
+    if (ws) {
+      ws.onclose = null
+      ws.onerror = null
+      ws.close()
+      wsRef.current = null
+      setConnected(false)
+    }
+    attemptsRef.current = 0
+    connect()
+  }, [connect])
+
+  return { send, connected, reconnect }
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -113,6 +113,33 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// RestartSession recreates a session from its original config.
+func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+
+	var found *config.PaneConfig
+	for _, p := range h.cfg.AllPanes() {
+		if p.ID == id {
+			found = p
+			break
+		}
+	}
+	if found == nil {
+		http.Error(w, "session config not found", http.StatusNotFound)
+		return
+	}
+
+	h.manager.Remove(id) //nolint:errcheck -- ok if already gone
+
+	sess, err := session.CreateFromConfig(found, h.cfg.SSHConnections)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	h.manager.Add(sess)
+	w.WriteHeader(http.StatusOK)
+}
+
 // GetDisplay returns the display configuration.
 func (h *Handler) GetDisplay(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, h.cfg.Display)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -44,6 +44,7 @@ func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 	r.Get("/api/sessions", h.GetSessions)
 	r.Post("/api/sessions", h.PostSession)
 	r.Delete("/api/sessions/{id}", h.DeleteSession)
+	r.Post("/api/sessions/{id}/restart", h.RestartSession)
 	r.Get("/api/display", h.GetDisplay)
 	return r
 }
@@ -193,6 +194,38 @@ func TestPostSession_DuplicateID_409(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestRestartSession_Found_200(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main")) // pre-existing (exited) session
+	r := setupRouter(cfg, mgr)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// New session must be in the manager
+	_, ok := mgr.Get("main")
+	assert.True(t, ok)
+}
+
+func TestRestartSession_NotFound_404(t *testing.T) {
+	r := setupRouter(defaultTestConfig(), session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/nonexistent/restart", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestGetDisplay_ReturnsJSON(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,7 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Get("/sessions", apiHandler.GetSessions)
 		r.Post("/sessions", apiHandler.PostSession)
 		r.Delete("/sessions/{id}", apiHandler.DeleteSession)
+		r.Post("/sessions/{id}/restart", apiHandler.RestartSession)
 		r.Get("/display", apiHandler.GetDisplay)
 	})
 

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -19,6 +20,8 @@ type TmuxLocalSession struct {
 	state       State
 	cmd         *exec.Cmd
 	ptmx        *os.File
+	pr          *io.PipeReader // Read() reads from here
+	pw          *io.PipeWriter // background goroutine writes output then closes
 }
 
 // NewTmuxLocal creates a new session that attaches to a local tmux session.
@@ -36,6 +39,8 @@ func NewTmuxLocal(id, title, tmuxSession string) (*TmuxLocalSession, error) {
 		return nil, fmt.Errorf("starting tmux pty: %w", err)
 	}
 
+	pr, pw := io.Pipe()
+
 	s := &TmuxLocalSession{
 		id:          id,
 		title:       title,
@@ -43,13 +48,27 @@ func NewTmuxLocal(id, title, tmuxSession string) (*TmuxLocalSession, error) {
 		state:       StateConnected,
 		cmd:         cmd,
 		ptmx:        ptmx,
+		pr:          pr,
+		pw:          pw,
 	}
 
+	// Bridge PTY output to the pipe. After the PTY is closed (EIO on macOS),
+	// inject an error message when tmux exited with a non-zero status so that
+	// the WebSocket reader always delivers the exit reason to the browser.
 	go func() {
-		cmd.Wait()
+		io.Copy(pw, ptmx) //nolint:errcheck -- EIO is expected when slave closes
+		exitErr := cmd.Wait()
 		s.mu.Lock()
 		s.state = StateExited
 		s.mu.Unlock()
+		if exitErr != nil {
+			msg := fmt.Sprintf(
+				"\r\n\x1b[31m[panemux] tmux session %q exited: %v\x1b[0m\r\n",
+				tmuxSession, exitErr,
+			)
+			pw.Write([]byte(msg)) //nolint:errcheck -- pw may be closed if Close() was called first
+		}
+		pw.Close()
 	}()
 
 	return s, nil
@@ -66,7 +85,7 @@ func (s *TmuxLocalSession) State() State {
 }
 
 func (s *TmuxLocalSession) Read(p []byte) (int, error) {
-	return s.ptmx.Read(p)
+	return s.pr.Read(p)
 }
 
 func (s *TmuxLocalSession) Write(p []byte) (int, error) {
@@ -85,6 +104,9 @@ func (s *TmuxLocalSession) Close() error {
 	s.state = StateExited
 	s.mu.Unlock()
 
+	// Close the write end of the pipe (causes pr.Read to return EOF) before
+	// closing the PTY, so the bridge goroutine unblocks cleanly.
+	s.pw.Close()
 	s.ptmx.Close()
 	if s.cmd.Process != nil {
 		s.cmd.Process.Kill()

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -30,7 +30,7 @@ func NewTmuxLocal(id, title, tmuxSession string) (*TmuxLocalSession, error) {
 		tmuxSession = "0"
 	}
 
-	cmd := exec.Command("tmux", "attach-session", "-t", tmuxSession)
+	cmd := exec.Command("tmux", "new-session", "-A", "-s", tmuxSession)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -97,8 +97,9 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	sess.Stdout = pw
 	sess.Stderr = pw
 
-	// Attach to existing tmux session (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
-	if err := sess.Start(fmt.Sprintf("tmux attach-session -t '%s'", tmuxSession)); err != nil {
+	// Attach to existing tmux session or create it if absent.
+	// (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
+	if err := sess.Start(fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)); err != nil {
 		sess.Close()
 		client.Close()
 		return nil, fmt.Errorf("starting tmux attach: %w", err)

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -93,7 +93,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		switch msgType {
 		case websocket.BinaryMessage:
-			// Raw terminal input
+			// Raw terminal input — discard silently if the session is already gone.
+			if sess.State() == session.StateExited {
+				continue
+			}
 			if _, err := sess.Write(data); err != nil {
 				log.Printf("session %s write error: %v", sessionID, err)
 			}

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -20,6 +20,7 @@ import (
 // wsMockSession implements session.Session for WebSocket handler tests.
 type wsMockSession struct {
 	id      string
+	state   session.State // configurable; defaults to StateConnected
 	out     chan []byte   // data sent to WS client (session output)
 	in      chan []byte   // data received from WS client (session input)
 	resizes chan [2]uint16
@@ -29,6 +30,7 @@ type wsMockSession struct {
 func newWsMock(id string) *wsMockSession {
 	return &wsMockSession{
 		id:      id,
+		state:   session.StateConnected,
 		out:     make(chan []byte, 64),
 		in:      make(chan []byte, 64),
 		resizes: make(chan [2]uint16, 8),
@@ -38,7 +40,7 @@ func newWsMock(id string) *wsMockSession {
 func (m *wsMockSession) ID() string           { return m.id }
 func (m *wsMockSession) Type() session.Type   { return session.TypeLocal }
 func (m *wsMockSession) Title() string        { return m.id }
-func (m *wsMockSession) State() session.State { return session.StateConnected }
+func (m *wsMockSession) State() session.State { return m.state }
 
 func (m *wsMockSession) Read(p []byte) (int, error) {
 	data, ok := <-m.out
@@ -225,6 +227,36 @@ func TestWS_ResizeWithZeroCols_Ignored(t *testing.T) {
 		t.Fatalf("unexpected resize received: %v", size)
 	case <-time.After(100 * time.Millisecond):
 		// expected: no resize was sent
+	}
+}
+
+func TestWS_Write_ToExitedSession_Silent(t *testing.T) {
+	mgr := session.NewManager()
+	sess := newWsMock("s1")
+	sess.state = session.StateExited
+	mgr.Add(sess)
+
+	srv := setupWSServer(mgr)
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv, "s1"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	defer sess.Close()
+
+	// Drain the initial status message
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	conn.ReadMessage()
+
+	// Send a binary frame to an exited session
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, []byte("hello")))
+
+	// The session must NOT receive the write
+	select {
+	case got := <-sess.in:
+		t.Fatalf("unexpected write to exited session: %v", got)
+	case <-time.After(100 * time.Millisecond):
+		// expected: input was silently discarded
 	}
 }
 


### PR DESCRIPTION
## Summary

### Fix: tmux pane showing nothing + write error spam
- `TmuxLocalSession`: bridges PTY output through an `io.Pipe`. After tmux exits with a non-zero status, injects a red `[panemux] tmux session "work" exited: ...` message into the pipe before closing. This guarantees the error is delivered to the browser even on macOS where the kernel discards the PTY buffer on EIO.
- \`ws/handler\`: binary frames are silently discarded when the session is \`StateExited\`, eliminating \`write /dev/ptmx: input/output error\` log spam.
- \`useTerminal\`: writes \`[Session ended]\` to the terminal when a \`status:exited\` frame is received.

### Feat: auto-create tmux session + Restart Session button
- \`tmux new-session -A -s <name>\` replaces \`attach-session -t <name>\` (local and SSH+tmux). Session is created automatically if absent.
- New API endpoint \`POST /api/sessions/{id}/restart\` recreates a session from its original YAML config.
- \`useWebSocket\` exposes \`reconnect()\` — cleanly replaces the current socket and resets the attempt counter.
- \`useTerminal\` tracks \`sessionExited\` state and exposes \`restartSession()\`.
- \`TerminalPane\` shows a "Restart Session" button overlay when the session exits.

## Test plan

- [x] Start panemux with \`config.example.yaml\` (no \`work\` tmux session) — pane auto-creates the session and attaches
- [x] Type \`exit\` inside the tmux pane — pane shows \`[Session ended]\` + "Restart Session" button
- [x] Click "Restart Session" — new tmux session is created, pane is live again
- [x] No \`write error\` log lines after session exits
- [x] \`go test ./... -v -race\` passes (new tests: \`TestRestartSession_Found_200\`, \`TestRestartSession_NotFound_404\`, \`TestWS_Write_ToExitedSession_Silent\`)
- [x] \`cd frontend && npm test\` passes (new tests: sessionExited state, restartSession, reconnect)
- [x] \`make check\` passes (Go coverage 87 %, frontend coverage 95 %)