### PR TITLE
docs: update config.example.yaml with all parameters and pane types

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,45 +1,116 @@
-server:
-  port: 8080
-  host: "127.0.0.1"
+# panemux configuration reference
+# All fields are documented below. Copy this file, adjust values, and run:
+#   panemux --config config.yaml
 
-# SSH connection definitions (reference by name in layout panes)
+# ── Server ────────────────────────────────────────────────────────────────────
+server:
+  port: 8080          # 1–65535  (default: 8080)
+  host: "127.0.0.1"  # bind address (default: 127.0.0.1)
+
+# ── Display ───────────────────────────────────────────────────────────────────
+# Global defaults for all panes. Individual panes can override these values.
+display:
+  show_header: true      # show pane header with title and controls (default: true)
+  show_status_bar: false # show terminal dimensions bar at the bottom (default: false)
+
+# ── SSH connections ────────────────────────────────────────────────────────────
+# Define named SSH connections here; reference them in panes with `connection:`.
 ssh_connections:
+
+  # Key-based authentication (recommended)
   prod-web:
     host: "192.168.1.10"
     port: 22
     user: "deploy"
-    key_file: "~/.ssh/id_ed25519"
-  # Password authentication example:
-  # staging:
-  #   host: "10.0.0.5"
-  #   port: 22
-  #   user: "ubuntu"
-  #   password: "secret"
+    key_file: "~/.ssh/id_ed25519"  # ~/  is expanded to $HOME
 
-# Layout tree: direction + children (each with size 0-100, summing to 100)
+  # Key-based auth with an explicit known_hosts file
+  bastion:
+    host: "bastion.example.com"
+    port: 22
+    user: "ops"
+    key_file: "~/.ssh/id_ed25519"
+    known_hosts_file: "~/.ssh/known_hosts"  # omit to accept any host key (insecure)
+
+  # Password authentication
+  staging:
+    host: "10.0.0.5"
+    port: 22
+    user: "ubuntu"
+    password: "secret"
+
+# ── Layout ────────────────────────────────────────────────────────────────────
+# Recursive tree of splits and panes.
+#
+# Split node  — has `direction` and `children` (no `pane`)
+# Leaf node   — has `pane` (no `direction` / `children`)
+#
+# `size` values of sibling children must sum to 100 (percentages).
+# Directions: horizontal (side-by-side) | vertical (stacked)
+#
+# Pane types: local | ssh | tmux | ssh_tmux
+#
+# ┌─────────────────────┬──────────────────────────────────────────────┐
+# │                     │  ssh                                         │
+# │  local              ├──────────────────────┬───────────────────────┤
+# │                     │  tmux                │  ssh_tmux             │
+# └─────────────────────┴──────────────────────┴───────────────────────┘
+
 layout:
   direction: horizontal
   children:
+
+    # ── local pane ──────────────────────────────────────────────────────────
+    # Spawns a local shell process via PTY.
     - size: 50
       pane:
         id: "local-main"
-        type: local        # local | ssh | tmux | ssh_tmux
-        shell: "/bin/zsh"
-        cwd: "~/development"
-        title: "Dev Shell"
+        type: local
+        shell: "/bin/zsh"       # optional; must be an absolute path
+        cwd: "~/development"    # optional; ~/ is expanded
+        title: "Dev Shell"      # optional; shown in the pane header
+        # Per-pane display overrides (uncomment to override global display settings):
+        # show_header: false
+        show_status_bar: true   # show dimensions bar for this pane only
+
+    # ── right half: vertical split ──────────────────────────────────────────
     - size: 50
-      # Nested vertical split on the right half
       direction: vertical
       children:
-        - size: 60
+
+        # ── ssh pane ─────────────────────────────────────────────────────────
+        # Opens a remote shell via SSH. `connection` must match a key under
+        # ssh_connections above.
+        - size: 40
           pane:
             id: "ssh-prod"
             type: ssh
-            connection: prod-web   # references ssh_connections key
+            connection: prod-web  # references ssh_connections key
+            cwd: "/var/www"       # optional; remote working directory
             title: "Prod Web"
-        - size: 40
-          pane:
-            id: "tmux-local"
-            type: tmux
-            tmux_session: "work"   # tmux session name
-            title: "Tmux Work"
+
+        # ── bottom half: horizontal split ─────────────────────────────────
+        - size: 60
+          direction: horizontal
+          children:
+
+            # ── tmux pane ──────────────────────────────────────────────────
+            # Attaches to a local tmux session (creates it if it doesn't exist).
+            - size: 50
+              pane:
+                id: "tmux-local"
+                type: tmux
+                tmux_session: "work"  # tmux session name; created if absent
+                title: "Tmux Work"
+
+            # ── ssh_tmux pane ──────────────────────────────────────────────
+            # SSHs to a remote host, then attaches to a tmux session there
+            # (creates the session if it doesn't exist).
+            - size: 50
+              pane:
+                id: "ssh-tmux-bastion"
+                type: ssh_tmux
+                connection: bastion       # references ssh_connections key
+                tmux_session: "monitor"   # remote tmux session name
+                title: "Bastion Monitor"
+                show_header: false        # hide header for this pane only


### PR DESCRIPTION
## Summary

- Added `display` section (global `show_header` / `show_status_bar` defaults)
- Added `ssh_tmux` pane type example (SSH → remote tmux session)
- Added password-based SSH auth variant (`staging` connection)
- Added `known_hosts_file` to `bastion` SSH connection
- Added per-pane display overrides (`show_header: false`, `show_status_bar: true`)
- Layout now demonstrates all 4 pane types in a 3-level nested split
- All fields are commented with type, default, and notes

## Test plan

- [x] All required YAML keys present (server, display, ssh_connections with 3 variants, all 4 pane types, per-pane overrides)
- [x] `go test ./internal/config/... -v` passes