### PR TITLE
feat: add edit mode toggle to gate config file persistence

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -3,7 +3,7 @@
 ## Startup Sequence
 
 1. Parse `--config`, `--open`, and `--port`.
-2. Load the specified YAML config, or create the built-in default config.
+2. Load config: if `--config` is given, load that file; otherwise try `~/.config/panemux/config.yaml`; if that file does not exist, use the built-in default config with `~/.config/panemux/config.yaml` as the save path.
 3. Override the configured port if `--port` is set.
 4. Create the in-memory session manager.
 5. Traverse the configured layout and create each pane session.
@@ -36,7 +36,8 @@ Path behavior:
 Persistence behavior:
 
 - `PUT /api/layout` updates in-memory layout always
-- file persistence happens only when the config came from a real file path
+- file persistence happens only when edit mode is ON (`PUT /api/edit-mode {"editMode":true}`)
+- when no `--config` is given, the default save path is `~/.config/panemux/config.yaml`; the directory is created automatically on first save
 
 ## REST API
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
+import { EditModeToggle } from './components/EditModeToggle'
 import { useLayout } from './hooks/useLayout'
+import { useEditMode } from './hooks/useEditMode'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
 
@@ -8,6 +10,7 @@ const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: fal
 
 export const App: React.FC = () => {
   const { layout, displayConfig, error, updateSizes, splitPane, closePane } = useLayout()
+  const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
 
   if (error) {
@@ -49,9 +52,11 @@ export const App: React.FC = () => {
       onMaximize: setMaximizedPaneId,
       maximizedPaneId,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
+      editMode,
     }}>
       <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <SplitContainer layout={layout} onLayoutChange={updateSizes} />
+        <EditModeToggle editMode={editMode} onToggle={toggleEditMode} />
       </div>
     </LayoutActionsContext.Provider>
   )

--- a/frontend/src/components/EditModeToggle.tsx
+++ b/frontend/src/components/EditModeToggle.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+interface EditModeToggleProps {
+  editMode: boolean
+  onToggle: () => void
+}
+
+export const EditModeToggle: React.FC<EditModeToggleProps> = ({ editMode, onToggle }) => {
+  return (
+    <button
+      onClick={onToggle}
+      title={editMode ? 'Edit mode ON: changes are saved to config' : 'Edit mode OFF: changes are not saved to config'}
+      data-testid="edit-mode-toggle"
+      style={{
+        position: 'fixed',
+        top: '8px',
+        right: '8px',
+        zIndex: 1000,
+        background: editMode ? '#2d4a2d' : '#2d2d2d',
+        border: `1px solid ${editMode ? '#4a8a4a' : '#555'}`,
+        borderRadius: '4px',
+        color: editMode ? '#7ec87e' : '#aaa',
+        cursor: 'pointer',
+        fontSize: '14px',
+        padding: '4px 8px',
+        fontFamily: 'monospace',
+        lineHeight: 1,
+      }}
+    >
+      {editMode ? '🔓' : '🔒'}
+    </button>
+  )
+}

--- a/frontend/src/components/EditModeToggle.tsx
+++ b/frontend/src/components/EditModeToggle.tsx
@@ -13,23 +13,30 @@ export const EditModeToggle: React.FC<EditModeToggleProps> = ({ editMode, onTogg
       data-testid="edit-mode-toggle"
       style={{
         position: 'fixed',
-        bottom: '8px',
-        right: '8px',
+        bottom: '12px',
+        right: '12px',
         zIndex: 1000,
-        background: editMode ? '#2d4a2d' : '#2d2d2d',
-        border: `1px solid ${editMode ? '#4a8a4a' : '#555'}`,
+        background: editMode ? '#1a3040' : '#3f3f46',
+        border: `1px solid ${editMode ? '#569cd6' : '#52525b'}`,
         borderRadius: '4px',
-        color: editMode ? '#7ec87e' : '#aaa',
+        color: editMode ? '#569cd6' : '#888',
         cursor: 'pointer',
-        fontSize: '14px',
-        padding: '4px 8px',
+        fontSize: '12px',
+        padding: '5px 10px',
         fontFamily: 'monospace',
         lineHeight: 1,
-        opacity: editMode ? 1 : 0.4,
-        transition: 'opacity 0.2s',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '5px',
+        opacity: editMode ? 1 : 0.65,
+        boxShadow: editMode
+          ? '0 0 0 1px #569cd6, 0 2px 8px rgba(0,0,0,0.6)'
+          : '0 2px 8px rgba(0,0,0,0.5)',
+        transition: 'opacity 0.2s, box-shadow 0.2s, border-color 0.2s, color 0.2s',
       }}
     >
-      {editMode ? '🔓' : '🔒'}
+      <span>{editMode ? '🔓' : '🔒'}</span>
+      <span>{editMode ? 'EDIT' : 'EDIT'}</span>
     </button>
   )
 }

--- a/frontend/src/components/EditModeToggle.tsx
+++ b/frontend/src/components/EditModeToggle.tsx
@@ -13,7 +13,7 @@ export const EditModeToggle: React.FC<EditModeToggleProps> = ({ editMode, onTogg
       data-testid="edit-mode-toggle"
       style={{
         position: 'fixed',
-        top: '8px',
+        bottom: '8px',
         right: '8px',
         zIndex: 1000,
         background: editMode ? '#2d4a2d' : '#2d2d2d',
@@ -25,6 +25,8 @@ export const EditModeToggle: React.FC<EditModeToggleProps> = ({ editMode, onTogg
         padding: '4px 8px',
         fontFamily: 'monospace',
         lineHeight: 1,
+        opacity: editMode ? 1 : 0.4,
+        transition: 'opacity 0.2s',
       }}
     >
       {editMode ? '🔓' : '🔒'}

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -25,6 +25,7 @@ function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
     onMaximize: vi.fn(),
     maximizedPaneId,
     displayConfig: { show_header: false, show_status_bar: false },
+    editMode: false,
   }
 }
 

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -9,6 +9,7 @@ export interface LayoutActionsContextValue {
   onMaximize: (paneId: string | null) => void
   maximizedPaneId: string | null
   displayConfig: DisplayConfig
+  editMode: boolean
 }
 
 export const LayoutActionsContext = React.createContext<LayoutActionsContextValue | null>(null)

--- a/frontend/src/hooks/useEditMode.test.ts
+++ b/frontend/src/hooks/useEditMode.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { useEditMode } from './useEditMode'
+
+describe('useEditMode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches initial editMode false on mount', async () => {
+    window.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ editMode: false }),
+    } as Response)
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.editMode).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('fetches initial editMode true on mount', async () => {
+    window.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ editMode: true }),
+    } as Response)
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.editMode).toBe(true)
+  })
+
+  it('sets error on fetch failure', async () => {
+    window.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response)
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.error).toContain('500')
+  })
+
+  it('toggleEditMode calls PUT with toggled value and updates state on success', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ editMode: false }) } as Response) // initial GET
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ editMode: true }) } as Response) // PUT
+
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.editMode).toBe(false)
+
+    await act(async () => {
+      await result.current.toggleEditMode()
+    })
+
+    expect(result.current.editMode).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [putUrl, putInit] = fetchMock.mock.calls[1]
+    expect(putUrl).toBe('/api/edit-mode')
+    expect(putInit?.method).toBe('PUT')
+    expect(JSON.parse(putInit?.body as string)).toEqual({ editMode: true })
+  })
+
+  it('toggleEditMode reverts state on server error', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ editMode: false }) } as Response) // initial GET
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response) // PUT fails
+
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.editMode).toBe(false)
+
+    await act(async () => {
+      await result.current.toggleEditMode()
+    })
+
+    // Should revert to false after server error
+    expect(result.current.editMode).toBe(false)
+  })
+
+  it('setEditMode sets the value directly', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ editMode: false }) } as Response) // initial GET
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ editMode: true }) } as Response) // PUT
+
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useEditMode())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.setEditMode(true)
+    })
+
+    expect(result.current.editMode).toBe(true)
+  })
+})

--- a/frontend/src/hooks/useEditMode.ts
+++ b/frontend/src/hooks/useEditMode.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react'
+import { EditModeResponseSchema } from '../schemas'
+
+export function useEditMode() {
+  const [editMode, setEditModeState] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/edit-mode')
+      .then(r => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      })
+      .then(data => {
+        setEditModeState(EditModeResponseSchema.parse(data).editMode)
+      })
+      .catch(e => setError((e as Error).message))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const setEditMode = useCallback(async (value: boolean) => {
+    const prev = editMode
+    setEditModeState(value)
+    try {
+      const r = await fetch('/api/edit-mode', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ editMode: value }),
+      })
+      if (!r.ok) throw new Error(`HTTP ${r.status}`)
+      const data = EditModeResponseSchema.parse(await r.json())
+      setEditModeState(data.editMode)
+    } catch {
+      setEditModeState(prev)
+    }
+  }, [editMode])
+
+  const toggleEditMode = useCallback(() => setEditMode(!editMode), [editMode, setEditMode])
+
+  return { editMode, isLoading, error, toggleEditMode, setEditMode }
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -68,3 +68,9 @@ export const WSControlMessageSchema = z.discriminatedUnion('type', [
 ])
 
 export type WSControlMessage = z.infer<typeof WSControlMessageSchema>
+
+export const EditModeResponseSchema = z.object({
+  editMode: z.boolean(),
+})
+
+export type EditModeResponse = z.infer<typeof EditModeResponseSchema>

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/go-chi/chi/v5"
 
@@ -12,8 +13,13 @@ import (
 
 // Handler provides REST API endpoints.
 type Handler struct {
-	cfg     *config.Config
-	manager *session.Manager
+	cfg      *config.Config
+	manager  *session.Manager
+	editMode atomic.Bool
+}
+
+type editModeResponse struct {
+	EditMode bool `json:"editMode"`
 }
 
 // NewHandler creates a new API handler.
@@ -41,9 +47,13 @@ func (h *Handler) PutLayout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.cfg.SaveLayout(layout); err != nil {
-		http.Error(w, "failed to save layout", http.StatusInternalServerError)
-		return
+	if h.editMode.Load() {
+		if err := h.cfg.SaveLayout(layout); err != nil {
+			http.Error(w, "failed to save layout", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		h.cfg.UpdateLayout(layout)
 	}
 
 	writeJSON(w, layout)
@@ -109,7 +119,9 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.cfg.RemovePaneFromLayout(id)
-	h.cfg.SaveLayout(h.cfg.Layout) //nolint:errcheck
+	if h.editMode.Load() {
+		h.cfg.SaveLayout(h.cfg.Layout) //nolint:errcheck
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -143,6 +155,28 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 // GetDisplay returns the display configuration.
 func (h *Handler) GetDisplay(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, h.cfg.Display)
+}
+
+// GetEditMode returns the current edit mode state.
+func (h *Handler) GetEditMode(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, editModeResponse{EditMode: h.editMode.Load()})
+}
+
+// PutEditMode sets the edit mode state.
+func (h *Handler) PutEditMode(w http.ResponseWriter, r *http.Request) {
+	var req editModeResponse
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	h.editMode.Store(req.EditMode)
+	if req.EditMode {
+		if err := h.cfg.SaveLayout(h.cfg.Layout); err != nil {
+			http.Error(w, "failed to save layout", http.StatusInternalServerError)
+			return
+		}
+	}
+	writeJSON(w, editModeResponse{EditMode: h.editMode.Load()})
 }
 
 type sessionInfo struct {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -46,6 +46,8 @@ func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 	r.Delete("/api/sessions/{id}", h.DeleteSession)
 	r.Post("/api/sessions/{id}/restart", h.RestartSession)
 	r.Get("/api/display", h.GetDisplay)
+	r.Get("/api/edit-mode", h.GetEditMode)
+	r.Put("/api/edit-mode", h.PutEditMode)
 	return r
 }
 
@@ -226,6 +228,158 @@ func TestRestartSession_NotFound_404(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/nonexistent/restart", nil)
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetEditMode_DefaultFalse(t *testing.T) {
+	r := setupRouter(defaultTestConfig(), session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/edit-mode", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp editModeResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.EditMode)
+}
+
+func TestPutEditMode_TurnOn(t *testing.T) {
+	r := setupRouter(defaultTestConfig(), session.NewManager())
+	body, _ := json.Marshal(editModeResponse{EditMode: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp editModeResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.EditMode)
+
+	// Subsequent GET should also return true
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/edit-mode", nil)
+	r.ServeHTTP(rec2, req2)
+	var resp2 editModeResponse
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&resp2))
+	assert.True(t, resp2.EditMode)
+}
+
+func TestPutEditMode_TurnOff(t *testing.T) {
+	r := setupRouter(defaultTestConfig(), session.NewManager())
+
+	// Turn on first
+	body, _ := json.Marshal(editModeResponse{EditMode: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Now turn off
+	body2, _ := json.Marshal(editModeResponse{EditMode: false})
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	var resp editModeResponse
+	require.NoError(t, json.NewDecoder(rec2.Body).Decode(&resp))
+	assert.False(t, resp.EditMode)
+}
+
+func TestPutEditMode_InvalidBody_400(t *testing.T) {
+	r := setupRouter(defaultTestConfig(), session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewBufferString("not json"))
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPutLayout_EditModeOff_DoesNotPersist(t *testing.T) {
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+
+	// editMode is false by default
+	layout := config.LayoutNode{
+		Direction: "vertical",
+		Children:  []config.LayoutChild{{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}}},
+	}
+	body, _ := json.Marshal(layout)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// In-memory layout should be updated
+	assert.Equal(t, "vertical", cfg.Layout.Direction)
+}
+
+func TestPutLayout_EditModeOn_Persists(t *testing.T) {
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+
+	// Turn on edit mode
+	body, _ := json.Marshal(editModeResponse{EditMode: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	layout := config.LayoutNode{
+		Direction: "vertical",
+		Children:  []config.LayoutChild{{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}}},
+	}
+	body2, _ := json.Marshal(layout)
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, "vertical", cfg.Layout.Direction)
+}
+
+func TestDeleteSession_EditModeOff_DoesNotSave(t *testing.T) {
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("s1"))
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, mgr)
+
+	// editMode is false by default
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/s1", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// session removed
+	_, ok := mgr.Get("s1")
+	assert.False(t, ok)
+}
+
+func TestDeleteSession_EditModeOn_Saves(t *testing.T) {
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("s1"))
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, mgr)
+
+	// Turn on edit mode
+	body, _ := json.Marshal(editModeResponse{EditMode: true})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodDelete, "/api/sessions/s1", nil)
+	r.ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusNoContent, rec2.Code)
+	_, ok := mgr.Get("s1")
+	assert.False(t, ok)
 }
 
 func TestGetDisplay_ReturnsJSON(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,11 @@ func (c *Config) SaveLayout(layout LayoutNode) error {
 	return os.WriteFile(c.filePath, data, 0644)
 }
 
+// UpdateLayout updates the in-memory layout without persisting to disk.
+func (c *Config) UpdateLayout(layout LayoutNode) {
+	c.Layout = layout
+}
+
 // AllPanes returns a flat list of all pane configs.
 func (c *Config) AllPanes() []*PaneConfig {
 	var panes []*PaneConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,11 +142,44 @@ func expandPanesCwd(children []LayoutChild) {
 	}
 }
 
+// DefaultConfigPath returns the default config file path: ~/.config/panemux/config.yaml.
+func DefaultConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", "config.yaml"), nil
+}
+
+// LoadOrDefault loads from the default config path if the file exists,
+// otherwise returns a Default config with filePath set to the default path
+// so that future saves go there.
+func LoadOrDefault() (*Config, error) {
+	path, err := DefaultConfigPath()
+	if err != nil {
+		return Default(), nil
+	}
+	return loadOrDefaultAt(path)
+}
+
+func loadOrDefaultAt(path string) (*Config, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		cfg := Default()
+		cfg.filePath = path
+		return cfg, nil
+	}
+	return Load(path)
+}
+
 // SaveLayout updates the layout section and writes back to file, preserving comments.
 func (c *Config) SaveLayout(layout LayoutNode) error {
 	c.Layout = layout
 	if c.filePath == "" {
 		return nil // no file to save to
+	}
+
+	if err := os.MkdirAll(filepath.Dir(c.filePath), 0750); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
 	}
 
 	data, err := yaml.Marshal(c)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -335,6 +335,58 @@ func TestValidate_TmuxSessionValidChars_NoError(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 }
 
+func TestDefaultConfigPath_ContainsExpectedSuffix(t *testing.T) {
+	path, err := DefaultConfigPath()
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(path, filepath.Join(".config", "panemux", "config.yaml")),
+		"expected path to end with .config/panemux/config.yaml, got %s", path)
+}
+
+func TestLoadOrDefault_FileNotExist_ReturnsDefaultWithPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent", "config.yaml")
+	cfg, err := loadOrDefaultAt(path)
+	require.NoError(t, err)
+	assert.Equal(t, 8080, cfg.Server.Port)
+	assert.Equal(t, path, cfg.filePath)
+}
+
+func TestLoadOrDefault_FileExists_LoadsIt(t *testing.T) {
+	content := `
+server:
+  port: 9999
+  host: "127.0.0.1"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+	f := writeTempFile(t, content)
+	cfg, err := loadOrDefaultAt(f)
+	require.NoError(t, err)
+	assert.Equal(t, 9999, cfg.Server.Port)
+	assert.Equal(t, f, cfg.filePath)
+}
+
+func TestLoadOrDefault_FileExistsButInvalid_ReturnsError(t *testing.T) {
+	f := writeTempFile(t, "::invalid yaml::")
+	_, err := loadOrDefaultAt(f)
+	assert.Error(t, err)
+}
+
+func TestSaveLayout_CreatesParentDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dirs")
+	path := filepath.Join(dir, "config.yaml")
+	cfg := Default()
+	cfg.filePath = path
+	err := cfg.SaveLayout(cfg.Layout)
+	require.NoError(t, err)
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr, "config file should have been created")
+}
+
 func TestUpdateLayout_UpdatesMemoryOnly(t *testing.T) {
 	cfg := &Config{}
 	newLayout := LayoutNode{Direction: "horizontal", Children: []LayoutChild{{Size: 100}}}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -335,6 +335,15 @@ func TestValidate_TmuxSessionValidChars_NoError(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 }
 
+func TestUpdateLayout_UpdatesMemoryOnly(t *testing.T) {
+	cfg := &Config{}
+	newLayout := LayoutNode{Direction: "horizontal", Children: []LayoutChild{{Size: 100}}}
+	cfg.UpdateLayout(newLayout)
+	if cfg.Layout.Direction != "horizontal" {
+		t.Errorf("expected horizontal, got %s", cfg.Layout.Direction)
+	}
+}
+
 // helpers
 
 func validConfig() *Config {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,8 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Delete("/sessions/{id}", apiHandler.DeleteSession)
 		r.Post("/sessions/{id}/restart", apiHandler.RestartSession)
 		r.Get("/display", apiHandler.GetDisplay)
+		r.Get("/edit-mode", apiHandler.GetEditMode)
+		r.Put("/edit-mode", apiHandler.PutEditMode)
 	})
 
 	// WebSocket

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"embed"
 	"net/http"
 	"net/http/httptest"
@@ -69,18 +70,32 @@ func TestCorsMiddleware_OptionsReturns204(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rr.Code)
 }
 
+func TestServer_EditModeRoutesWired(t *testing.T) {
+	cfg := testConfig()
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, emptyFS)
+	require.NotNil(t, srv)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/edit-mode", nil)
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewBufferString(`{"editMode":true}`))
+	req2.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+}
+
 func TestServer_APIRoutesWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
 	srv := New(cfg, mgr, emptyFS)
 	require.NotNil(t, srv)
 
-	// Use the internal httpSrv handler to make requests without binding a port
-	ts := httptest.NewServer(srv.httpSrv.Handler)
-	defer ts.Close()
-
-	resp, err := http.Get(ts.URL + "/api/layout")
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/layout", nil)
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/main.go
+++ b/main.go
@@ -45,7 +45,11 @@ func main() {
 			log.Fatalf("Failed to load config: %v", err)
 		}
 	} else {
-		cfg = config.Default()
+		var err error
+		cfg, err = config.LoadOrDefault()
+		if err != nil {
+			log.Fatalf("Failed to load config: %v", err)
+		}
 	}
 
 	if *port != 0 {


### PR DESCRIPTION
## Summary

- Add \`editMode\` boolean flag (default \`false\`) to the API server, controlling whether window operations persist to the config YAML file
- When OFF (default): drag-resize, split, and close operations update in-memory layout but do NOT write to disk
- When ON: every layout change is persisted immediately
- Frontend shows a 🔒/🔓 \`EDIT\` toggle button (bottom-right, fixed position) — dimmed when OFF, highlighted when ON
- When no \`--config\` is given, the default config path is \`~/.config/panemux/config.yaml\`; the directory is created automatically on first save

## Changes

**Backend:**
- \`internal/config/config.go\`: Added \`DefaultConfigPath()\`, \`LoadOrDefault()\`, \`UpdateLayout()\`; \`SaveLayout()\` now creates parent directories automatically
- \`internal/api/handler.go\`: Added \`editMode atomic.Bool\` to \`Handler\`; new \`GET/PUT /api/edit-mode\` endpoints; \`PutLayout\` and \`DeleteSession\` gate \`SaveLayout()\` on \`editMode\`
- \`internal/server/server.go\`: Wired two new routes
- \`main.go\`: Use \`LoadOrDefault()\` when \`--config\` is not given

**Frontend:**
- \`frontend/src/schemas/index.ts\`: Added \`EditModeResponseSchema\`
- \`frontend/src/hooks/useEditMode.ts\`: New hook with optimistic update + error rollback
- \`frontend/src/components/EditModeToggle.tsx\`: Lock/unlock button, bottom-right, dimmed (opacity 0.65) when OFF
- \`frontend/src/components/SplitContainer.tsx\`: Added \`editMode\` to \`LayoutActionsContextValue\`
- \`frontend/src/App.tsx\`: Wired \`useEditMode\` and \`EditModeToggle\`

**Docs:**
- \`docs/behavior.md\`: Updated startup sequence and config rules to document new behavior

## Test plan

- [x] \`go test ./internal/config/... ./internal/api/... ./internal/server/...\` — all edit mode and config path tests pass
- [x] \`cd frontend && npm test\` — 93 tests pass (7 test files)
- [x] \`TestGetEditMode_DefaultFalse\` — returns \`{"editMode":false}\` by default
- [x] \`TestPutEditMode_TurnOn/TurnOff\` — toggle works correctly
- [x] \`TestPutLayout_EditModeOff_DoesNotPersist\` / \`TestPutLayout_EditModeOn_Persists\`
- [x] \`TestDeleteSession_EditModeOff_DoesNotSave\` / \`TestDeleteSession_EditModeOn_Saves\`
- [x] \`TestServer_EditModeRoutesWired\`
- [x] \`TestDefaultConfigPath_ContainsExpectedSuffix\`
- [x] \`TestLoadOrDefault_FileNotExist_ReturnsDefaultWithPath\`
- [x] \`TestLoadOrDefault_FileExists_LoadsIt\`
- [x] \`TestSaveLayout_CreatesParentDirectory\`
- [x] \`useEditMode.test.ts\` — 6 tests covering fetch, toggle, error rollback