### PR TITLE
feat: add pane settings dialog for UI-based connection configuration

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
 import { EditModeToggle } from './components/EditModeToggle'
+import { PaneSettingsDialog } from './components/PaneSettingsDialog'
 import { useLayout } from './hooks/useLayout'
 import { useEditMode } from './hooks/useEditMode'
+import { usePaneSettings } from './hooks/usePaneSettings'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
+import { findPaneById } from './utils/layoutTree'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
 
@@ -12,6 +15,8 @@ export const App: React.FC = () => {
   const { layout, displayConfig, error, updateSizes, splitPane, closePane } = useLayout()
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
+  const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings } =
+    usePaneSettings(layout, updateSizes)
 
   if (error) {
     return (
@@ -50,6 +55,10 @@ export const App: React.FC = () => {
       onSplit: splitPane,
       onClose: closePane,
       onMaximize: setMaximizedPaneId,
+      onSettings: (paneId: string) => {
+        const pane = findPaneById(layout, paneId)
+        if (pane) openSettings(pane)
+      },
       maximizedPaneId,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
       editMode,
@@ -57,6 +66,15 @@ export const App: React.FC = () => {
       <div style={{ position: 'relative', width: '100%', height: '100%' }}>
         <SplitContainer layout={layout} onLayoutChange={updateSizes} />
         <EditModeToggle editMode={editMode} onToggle={toggleEditMode} />
+        <PaneSettingsDialog
+          isOpen={isOpen}
+          pane={currentPane}
+          sshConnectionNames={sshConnectionNames}
+          saveError={saveError}
+          isSaving={isSaving}
+          onSave={saveSettings}
+          onClose={closeSettings}
+        />
       </div>
     </LayoutActionsContext.Provider>
   )

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -7,9 +7,11 @@ interface PaneHeaderProps {
   connected: boolean
   displayConfig: DisplayConfig
   isMaximized: boolean
+  editMode: boolean
   onSplit: (direction: 'horizontal' | 'vertical') => void
   onClose: () => void
   onMaximize: () => void
+  onSettings: () => void
 }
 
 const TYPE_COLORS: Record<string, string> = {
@@ -47,9 +49,11 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
   connected,
   displayConfig,
   isMaximized,
+  editMode,
   onSplit,
   onClose,
   onMaximize,
+  onSettings,
 }) => {
   const showHeader = pane.show_header ?? displayConfig.show_header
   if (!showHeader) return null
@@ -87,6 +91,15 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
       {!connected && <span style={{ color: '#555' }}>reconnecting…</span>}
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '4px' }}>
+        {editMode && (
+          <button
+            title="Pane settings"
+            onClick={onSettings}
+            style={buttonStyle}
+          >
+            ⚙
+          </button>
+        )}
         <button
           title={isMaximized ? 'Restore' : 'Maximize'}
           onClick={onMaximize}

--- a/frontend/src/components/PaneSettingsDialog.tsx
+++ b/frontend/src/components/PaneSettingsDialog.tsx
@@ -1,0 +1,267 @@
+import React, { useState, useEffect } from 'react'
+import type { PaneConfig } from '../types'
+import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+
+interface PaneSettingsDialogProps {
+  isOpen: boolean
+  pane: PaneConfig | null
+  sshConnectionNames: string[]
+  saveError: string | null
+  isSaving: boolean
+  onSave: (updated: PaneConfig) => Promise<void>
+  onClose: () => void
+}
+
+const PANE_TYPES: Array<{ value: PaneConfig['type']; label: string }> = [
+  { value: 'local', label: 'Local' },
+  { value: 'ssh', label: 'SSH' },
+  { value: 'tmux', label: 'Tmux (local)' },
+  { value: 'ssh_tmux', label: 'SSH + Tmux' },
+]
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '5px 8px',
+  backgroundColor: '#3c3c3c',
+  color: '#d4d4d4',
+  border: '1px solid #555',
+  borderRadius: '3px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '13px',
+  boxSizing: 'border-box',
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '11px',
+  color: '#888',
+  marginBottom: '4px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+}
+
+const fieldStyle: React.CSSProperties = {
+  marginBottom: '12px',
+}
+
+export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
+  isOpen,
+  pane,
+  sshConnectionNames,
+  saveError,
+  isSaving,
+  onSave,
+  onClose,
+}) => {
+  const [type, setType] = useState<PaneConfig['type']>('local')
+  const [shell, setShell] = useState('')
+  const [connection, setConnection] = useState('')
+  const [tmuxSession, setTmuxSession] = useState('')
+  const [cwd, setCwd] = useState('')
+  const [title, setTitle] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (pane) {
+      setType(pane.type)
+      setShell(pane.shell ?? '')
+      setConnection(pane.connection ?? '')
+      setTmuxSession(pane.tmux_session ?? '')
+      setCwd(pane.cwd ?? '')
+      setTitle(pane.title ?? '')
+      setValidationError(null)
+    }
+  }, [pane])
+
+  if (!isOpen || !pane) return null
+
+  const needsConnection = type === 'ssh' || type === 'ssh_tmux'
+  const needsTmux = type === 'tmux' || type === 'ssh_tmux'
+  const needsShell = type === 'local'
+
+  const handleSave = async () => {
+    setValidationError(null)
+    if (needsConnection && !connection) {
+      setValidationError('Connection is required for SSH panes.')
+      return
+    }
+    if (needsTmux && !tmuxSession) {
+      setValidationError('Tmux session name is required.')
+      return
+    }
+
+    const updated: PaneConfig = {
+      id: pane.id,
+      type,
+      title: title || undefined,
+      cwd: cwd || undefined,
+      show_header: pane.show_header,
+      show_status_bar: pane.show_status_bar,
+      ...(needsShell ? { shell: shell || undefined } : {}),
+      ...(needsConnection ? { connection } : {}),
+      ...(needsTmux ? { tmux_session: tmuxSession } : {}),
+    }
+    await onSave(updated)
+  }
+
+  const error = validationError ?? saveError
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pane settings"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        style={{
+          backgroundColor: '#252526',
+          border: '1px solid #444',
+          borderRadius: '6px',
+          padding: '20px 24px',
+          width: '360px',
+          fontFamily: TERMINAL_FONT_FAMILY,
+          color: '#d4d4d4',
+        }}
+      >
+        <div style={{ fontSize: '14px', fontWeight: 600, marginBottom: '16px', color: '#e0e0e0' }}>
+          Pane Settings
+          <span style={{ fontSize: '11px', color: '#666', marginLeft: '8px' }}>({pane.id})</span>
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Type</label>
+          <select
+            value={type}
+            onChange={(e) => { setType(e.target.value as PaneConfig['type']); setValidationError(null) }}
+            style={inputStyle}
+          >
+            {PANE_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {needsShell && (
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Shell</label>
+            <input
+              type="text"
+              value={shell}
+              onChange={(e) => setShell(e.target.value)}
+              placeholder="/bin/zsh"
+              style={inputStyle}
+            />
+          </div>
+        )}
+
+        {needsConnection && (
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Connection</label>
+            {sshConnectionNames.length === 0 ? (
+              <div style={{ fontSize: '12px', color: '#666', fontStyle: 'italic' }}>
+                No SSH connections configured in config.yaml
+              </div>
+            ) : (
+              <select
+                value={connection}
+                onChange={(e) => { setConnection(e.target.value); setValidationError(null) }}
+                style={inputStyle}
+              >
+                <option value="">— select connection —</option>
+                {sshConnectionNames.map((name) => (
+                  <option key={name} value={name}>{name}</option>
+                ))}
+              </select>
+            )}
+          </div>
+        )}
+
+        {needsTmux && (
+          <div style={fieldStyle}>
+            <label style={labelStyle}>Tmux Session</label>
+            <input
+              type="text"
+              value={tmuxSession}
+              onChange={(e) => { setTmuxSession(e.target.value); setValidationError(null) }}
+              placeholder="session-name"
+              style={inputStyle}
+            />
+          </div>
+        )}
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Working Directory</label>
+          <input
+            type="text"
+            value={cwd}
+            onChange={(e) => setCwd(e.target.value)}
+            placeholder="~/projects/myapp"
+            style={inputStyle}
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label style={labelStyle}>Title</label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="My Terminal"
+            style={inputStyle}
+          />
+        </div>
+
+        {error && (
+          <div style={{ fontSize: '12px', color: '#f44747', marginBottom: '12px' }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onClose}
+            disabled={isSaving}
+            style={{
+              padding: '5px 14px',
+              backgroundColor: 'transparent',
+              color: '#888',
+              border: '1px solid #555',
+              borderRadius: '3px',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: '13px',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving || (needsConnection && sshConnectionNames.length === 0)}
+            style={{
+              padding: '5px 14px',
+              backgroundColor: '#0e639c',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '3px',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: '13px',
+              cursor: 'pointer',
+              opacity: isSaving ? 0.6 : 1,
+            }}
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -23,6 +23,7 @@ function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
     onSplit: vi.fn(),
     onClose: vi.fn(),
     onMaximize: vi.fn(),
+    onSettings: vi.fn(),
     maximizedPaneId,
     displayConfig: { show_header: false, show_status_bar: false },
     editMode: false,

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -7,6 +7,7 @@ export interface LayoutActionsContextValue {
   onSplit: (paneId: string, direction: 'horizontal' | 'vertical') => void
   onClose: (paneId: string) => void
   onMaximize: (paneId: string | null) => void
+  onSettings: (paneId: string) => void
   maximizedPaneId: string | null
   displayConfig: DisplayConfig
   editMode: boolean

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -52,9 +52,11 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
         connected={connected}
         displayConfig={displayConfig}
         isMaximized={ctx?.maximizedPaneId === pane.id}
+        editMode={ctx?.editMode ?? false}
         onSplit={(direction) => ctx?.onSplit(pane.id, direction)}
         onClose={() => ctx?.onClose(pane.id)}
         onMaximize={() => ctx?.onMaximize(ctx.maximizedPaneId === pane.id ? null : pane.id)}
+        onSettings={() => ctx?.onSettings(pane.id)}
       />
       <div
         ref={setRef}

--- a/frontend/src/hooks/usePaneSettings.test.ts
+++ b/frontend/src/hooks/usePaneSettings.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { usePaneSettings } from './usePaneSettings'
+import type { LayoutNode, PaneConfig } from '../schemas'
+
+const mockLayout: LayoutNode = {
+  direction: 'horizontal',
+  children: [
+    { size: 50, pane: { id: 'pane-1', type: 'local' } },
+    { size: 50, pane: { id: 'pane-2', type: 'ssh', connection: 'prod' } },
+  ],
+}
+
+const mockPane: PaneConfig = { id: 'pane-1', type: 'local' }
+
+function makeFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(body),
+  })
+}
+
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('usePaneSettings', () => {
+  it('fetches ssh connection names on mount', async () => {
+    vi.stubGlobal('fetch', makeFetchOk({ names: ['prod', 'dev'] }))
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    await waitFor(() => expect(result.current.sshConnectionNames).toEqual(['prod', 'dev']))
+  })
+
+  it('returns empty names when API returns empty', async () => {
+    vi.stubGlobal('fetch', makeFetchOk({ names: [] }))
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
+  })
+
+  it('openSettings sets isOpen true with the given pane', () => {
+    vi.stubGlobal('fetch', makeFetchOk({ names: [] }))
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    act(() => result.current.openSettings(mockPane))
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.currentPane).toEqual(mockPane)
+  })
+
+  it('closeSettings sets isOpen false', () => {
+    vi.stubGlobal('fetch', makeFetchOk({ names: [] }))
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    act(() => result.current.openSettings(mockPane))
+    act(() => result.current.closeSettings())
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.currentPane).toBeNull()
+  })
+
+  it('saveSettings calls PUT /api/layout then POST restart on success', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) }) // GET ssh-connections
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockLayout) })     // PUT layout
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })             // POST restart
+
+    vi.stubGlobal('fetch', fetchMock)
+    const onLayoutChange = vi.fn()
+    const { result } = renderHook(() => usePaneSettings(mockLayout, onLayoutChange))
+
+    act(() => result.current.openSettings(mockPane))
+    await act(async () => {
+      await result.current.saveSettings({ ...mockPane, type: 'local', shell: '/bin/zsh' })
+    })
+
+    // PUT layout called
+    expect(fetchMock).toHaveBeenCalledWith('/api/layout', expect.objectContaining({ method: 'PUT' }))
+    // POST restart called
+    expect(fetchMock).toHaveBeenCalledWith(`/api/sessions/${mockPane.id}/restart`, expect.objectContaining({ method: 'POST' }))
+    expect(onLayoutChange).toHaveBeenCalled()
+  })
+
+  it('saveSettings closes dialog on success', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockLayout) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+    act(() => result.current.openSettings(mockPane))
+    await act(async () => {
+      await result.current.saveSettings(mockPane)
+    })
+
+    expect(result.current.isOpen).toBe(false)
+  })
+
+  it('saveSettings shows error and keeps dialog open on PUT failure', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 422, json: () => Promise.resolve({ error: 'invalid layout' }) })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+    act(() => result.current.openSettings(mockPane))
+    await act(async () => {
+      await result.current.saveSettings(mockPane)
+    })
+
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.saveError).toBe('invalid layout')
+  })
+
+  it('saveSettings does not call restart if PUT failed', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+      .mockResolvedValueOnce({ ok: false, status: 422, json: () => Promise.resolve({ error: 'fail' }) })
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+    act(() => result.current.openSettings(mockPane))
+    await act(async () => {
+      await result.current.saveSettings(mockPane)
+    })
+
+    // Only 2 calls: GET ssh-connections + PUT layout (no restart)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('restart failure is non-fatal and dialog closes', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockLayout) })
+      .mockRejectedValueOnce(new Error('network error')) // restart fails
+
+    vi.stubGlobal('fetch', fetchMock)
+    const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+    act(() => result.current.openSettings(mockPane))
+    await act(async () => {
+      await result.current.saveSettings(mockPane)
+    })
+
+    // Dialog should still close even if restart fails
+    expect(result.current.isOpen).toBe(false)
+  })
+})

--- a/frontend/src/hooks/usePaneSettings.ts
+++ b/frontend/src/hooks/usePaneSettings.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback } from 'react'
+import { SSHConnectionsResponseSchema } from '../schemas'
+import type { LayoutNode, PaneConfig } from '../schemas'
+import { replacePaneInTree } from '../utils/layoutTree'
+
+export function usePaneSettings(
+  layout: LayoutNode | null,
+  onLayoutChange: (layout: LayoutNode) => void,
+) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [currentPane, setCurrentPane] = useState<PaneConfig | null>(null)
+  const [sshConnectionNames, setSshConnectionNames] = useState<string[]>([])
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/ssh-connections')
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((data) => setSshConnectionNames(SSHConnectionsResponseSchema.parse(data).names))
+      .catch(() => {
+        // Non-fatal; dropdown will be empty
+      })
+  }, [])
+
+  const openSettings = useCallback((pane: PaneConfig) => {
+    setSaveError(null)
+    setCurrentPane(pane)
+    setIsOpen(true)
+  }, [])
+
+  const closeSettings = useCallback(() => {
+    setIsOpen(false)
+    setCurrentPane(null)
+    setSaveError(null)
+  }, [])
+
+  const saveSettings = useCallback(
+    async (updated: PaneConfig) => {
+      if (!layout) return
+      const newLayout = replacePaneInTree(layout, updated)
+      setIsSaving(true)
+      try {
+        const r = await fetch('/api/layout', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(newLayout),
+        })
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}))
+          setSaveError((body as { error?: string }).error ?? `HTTP ${r.status}`)
+          return
+        }
+        onLayoutChange(newLayout)
+        setIsOpen(false)
+        setCurrentPane(null)
+        setSaveError(null)
+        // Restart is best-effort; failure is non-fatal
+        fetch(`/api/sessions/${updated.id}/restart`, { method: 'POST' }).catch(() => {})
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [layout, onLayoutChange],
+  )
+
+  return { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings }
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -74,3 +74,9 @@ export const EditModeResponseSchema = z.object({
 })
 
 export type EditModeResponse = z.infer<typeof EditModeResponseSchema>
+
+export const SSHConnectionsResponseSchema = z.object({
+  names: z.array(z.string()),
+})
+
+export type SSHConnectionsResponse = z.infer<typeof SSHConnectionsResponseSchema>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,4 +7,5 @@ export type {
   LayoutNode,
   SessionInfo,
   WSControlMessage,
+  SSHConnectionsResponse,
 } from '../schemas'

--- a/frontend/src/utils/layoutTree.test.ts
+++ b/frontend/src/utils/layoutTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { splitPaneInTree, removePaneFromTree, generatePaneId, findPaneById } from './layoutTree'
+import { splitPaneInTree, removePaneFromTree, generatePaneId, findPaneById, replacePaneInTree } from './layoutTree'
 import type { LayoutNode } from '../schemas'
 
 const simpleLayout: LayoutNode = {
@@ -156,6 +156,41 @@ describe('findPaneById', () => {
   it('returns null when pane not found', () => {
     const result = findPaneById(simpleLayout, 'nonexistent')
     expect(result).toBeNull()
+  })
+})
+
+describe('replacePaneInTree', () => {
+  it('replaces a matching pane at root level', () => {
+    const result = replacePaneInTree(simpleLayout, { id: 'main', type: 'ssh', connection: 'prod' })
+    expect(result.children[0].pane?.type).toBe('ssh')
+    expect(result.children[0].pane?.connection).toBe('prod')
+  })
+
+  it('replaces a matching pane nested inside a split', () => {
+    const nested: LayoutNode = {
+      direction: 'horizontal',
+      children: [
+        { size: 50, pane: { id: 'left', type: 'local' } },
+        {
+          size: 50,
+          direction: 'vertical',
+          children: [
+            { size: 50, pane: { id: 'top-right', type: 'local' } },
+            { size: 50, pane: { id: 'bottom-right', type: 'local' } },
+          ],
+        },
+      ],
+    }
+    const result = replacePaneInTree(nested, { id: 'bottom-right', type: 'tmux', tmux_session: 'mysess' })
+    const bottomRight = result.children[1].children![1]
+    expect(bottomRight.pane?.type).toBe('tmux')
+    expect(bottomRight.pane?.tmux_session).toBe('mysess')
+  })
+
+  it('returns tree unchanged when id not found', () => {
+    const result = replacePaneInTree(simpleLayout, { id: 'nonexistent', type: 'ssh' })
+    expect(result.children[0].pane?.id).toBe('main')
+    expect(result.children[0].pane?.type).toBe('local')
   })
 })
 

--- a/frontend/src/utils/layoutTree.ts
+++ b/frontend/src/utils/layoutTree.ts
@@ -109,6 +109,22 @@ export function findPaneById(layout: LayoutNode, paneId: string): PaneConfig | n
 }
 
 /**
+ * Replaces the pane matching `updated.id` in the layout tree with `updated`.
+ * Returns the tree unchanged if the id is not found.
+ */
+export function replacePaneInTree(layout: LayoutNode, updated: PaneConfig): LayoutNode {
+  return { ...layout, children: replaceInChildren(layout.children, updated) }
+}
+
+function replaceInChildren(children: LayoutChild[], updated: PaneConfig): LayoutChild[] {
+  return children.map((child) => {
+    if (child.pane?.id === updated.id) return { ...child, pane: updated }
+    if (child.children?.length) return { ...child, children: replaceInChildren(child.children, updated) }
+    return child
+  })
+}
+
+/**
  * Generates a unique pane ID.
  */
 export function generatePaneId(): string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"sync/atomic"
 
 	"github.com/go-chi/chi/v5"
@@ -20,6 +21,10 @@ type Handler struct {
 
 type editModeResponse struct {
 	EditMode bool `json:"editMode"`
+}
+
+type sshConnectionsResponse struct {
+	Names []string `json:"names"`
 }
 
 // NewHandler creates a new API handler.
@@ -184,6 +189,16 @@ type sessionInfo struct {
 	Type  string `json:"type"`
 	Title string `json:"title"`
 	State string `json:"state"`
+}
+
+// GetSSHConnections returns the sorted names of configured SSH connections.
+func (h *Handler) GetSSHConnections(w http.ResponseWriter, r *http.Request) {
+	names := make([]string, 0, len(h.cfg.SSHConnections))
+	for k := range h.cfg.SSHConnections {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	writeJSON(w, sshConnectionsResponse{Names: names})
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -45,6 +45,8 @@ func (h *Handler) PutLayout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	config.ExpandLayoutPaths(&layout)
+
 	if err := config.ValidateLayout(layout); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
@@ -86,6 +88,8 @@ func (h *Handler) PostSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
+
+	config.ExpandPanePaths(&pane)
 
 	if err := config.ValidatePane(&pane); err != nil {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -48,6 +48,7 @@ func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 	r.Get("/api/display", h.GetDisplay)
 	r.Get("/api/edit-mode", h.GetEditMode)
 	r.Put("/api/edit-mode", h.PutEditMode)
+	r.Get("/api/ssh-connections", h.GetSSHConnections)
 	return r
 }
 
@@ -395,4 +396,52 @@ func TestGetDisplay_ReturnsJSON(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&display))
 	assert.True(t, display.ShowHeader)
 	assert.False(t, display.ShowStatusBar)
+}
+
+func TestGetSSHConnections_Empty(t *testing.T) {
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-connections", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConnectionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotNil(t, resp.Names)
+	assert.Empty(t, resp.Names)
+}
+
+func TestGetSSHConnections_WithConnections(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.SSHConnections = map[string]config.SSHConnection{
+		"prod": {Host: "prod.example.com", Port: 22, User: "admin"},
+		"dev":  {Host: "dev.example.com", Port: 22, User: "dev"},
+	}
+	r := setupRouter(cfg, session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-connections", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConnectionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.ElementsMatch(t, []string{"prod", "dev"}, resp.Names)
+	// Must be sorted
+	assert.Equal(t, []string{"dev", "prod"}, resp.Names)
+}
+
+func TestGetSSHConnections_NilMap(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.SSHConnections = nil
+	r := setupRouter(cfg, session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-connections", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConnectionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotNil(t, resp.Names)
+	assert.Empty(t, resp.Names)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -396,6 +398,62 @@ func TestGetDisplay_ReturnsJSON(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&display))
 	assert.True(t, display.ShowHeader)
 	assert.False(t, display.ShowStatusBar)
+}
+
+func TestPutLayout_ExpandsTildeCwd(t *testing.T) {
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	layout := config.LayoutNode{
+		Direction: "horizontal",
+		Children: []config.LayoutChild{
+			{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local", Cwd: "~/mydir"}},
+		},
+	}
+	body, _ := json.Marshal(layout)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, filepath.Join(home, "mydir"), cfg.Layout.Children[0].Pane.Cwd)
+}
+
+func TestPutLayout_NestedTildeCwd_Expanded(t *testing.T) {
+	cfg := defaultTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	layout := config.LayoutNode{
+		Direction: "horizontal",
+		Children: []config.LayoutChild{
+			{
+				Size:      50,
+				Direction: "vertical",
+				Children: []config.LayoutChild{
+					{Size: 50, Pane: &config.PaneConfig{ID: "pane-a", Type: "local", Cwd: "~/projects/a"}},
+					{Size: 50, Pane: &config.PaneConfig{ID: "pane-b", Type: "local", Cwd: "~/projects/b"}},
+				},
+			},
+			{Size: 50, Pane: &config.PaneConfig{ID: "pane-c", Type: "local"}},
+		},
+	}
+	body, _ := json.Marshal(layout)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, filepath.Join(home, "projects/a"), cfg.Layout.Children[0].Children[0].Pane.Cwd)
+	assert.Equal(t, filepath.Join(home, "projects/b"), cfg.Layout.Children[0].Children[1].Pane.Cwd)
+	assert.Empty(t, cfg.Layout.Children[1].Pane.Cwd) // no cwd, unchanged
 }
 
 func TestGetSSHConnections_Empty(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,12 +134,25 @@ func (c *Config) expandPaths() {
 
 func expandPanesCwd(children []LayoutChild) {
 	for i := range children {
-		if children[i].Pane != nil && strings.HasPrefix(children[i].Pane.Cwd, "~/") {
-			home, _ := os.UserHomeDir()
-			children[i].Pane.Cwd = filepath.Join(home, children[i].Pane.Cwd[2:])
+		if children[i].Pane != nil {
+			ExpandPanePaths(children[i].Pane)
 		}
 		expandPanesCwd(children[i].Children)
 	}
+}
+
+// ExpandPanePaths expands ~/  in the pane's CWD to an absolute path.
+func ExpandPanePaths(pane *PaneConfig) {
+	if strings.HasPrefix(pane.Cwd, "~/") {
+		home, _ := os.UserHomeDir()
+		pane.Cwd = filepath.Join(home, pane.Cwd[2:])
+	}
+}
+
+// ExpandLayoutPaths expands ~/  in all pane CWDs within layout, mirroring
+// the expansion done at config load time via Load().
+func ExpandLayoutPaths(layout *LayoutNode) {
+	expandPanesCwd(layout.Children)
 }
 
 // DefaultConfigPath returns the default config file path: ~/.config/panemux/config.yaml.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Get("/display", apiHandler.GetDisplay)
 		r.Get("/edit-mode", apiHandler.GetEditMode)
 		r.Put("/edit-mode", apiHandler.PutEditMode)
+		r.Get("/ssh-connections", apiHandler.GetSSHConnections)
 	})
 
 	// WebSocket


### PR DESCRIPTION
## Summary

- Adds a **⚙ gear button** to each pane header (visible only in edit mode) that opens a modal settings dialog
- Users can now change a pane's type (local/ssh/tmux/ssh_tmux), connection, tmux session name, shell, working directory, and title directly from the UI
- On save, the layout is updated via `PUT /api/layout` and the session is automatically restarted via `POST /api/sessions/{id}/restart`
- **Bug fix**: `~/` in CWD was not expanded at runtime (only at config load time), causing session restart to fail silently — fixed by calling `ExpandLayoutPaths`/`ExpandPanePaths` in `PutLayout` and `PostSession`

## Changes

- **`GET /api/ssh-connections`**: new backend endpoint returning sorted SSH connection names for the dropdown
- **`ExpandLayoutPaths` / `ExpandPanePaths`** in `config` package: expand `~/` in pane CWDs when layouts are received via API, matching what `Load()` does at startup
- **`usePaneSettings` hook**: manages dialog open/close state, SSH name fetching, and the save orchestration (PUT layout → restart)
- **`PaneSettingsDialog` component**: type-conditional form fields with client-side validation; SSH/tmux fields only shown when relevant
- **`replacePaneInTree`**: new `layoutTree.ts` utility for updating a single pane config within the layout tree
- `LayoutActionsContextValue` extended with `onSettings`; `PaneHeader` extended with `editMode` + `onSettings` props

## Test plan

- [x] Edit mode OFF: ⚙ button is hidden in pane header
- [x] Edit mode ON: ⚙ button appears in pane header
- [x] Click ⚙: dialog opens with current pane config pre-filled
- [x] Change type `local` → `ssh`: shell field disappears, connection dropdown appears
- [x] Connection dropdown populated from `/api/ssh-connections`
- [x] Save with valid config: layout updates, session restarts automatically
- [x] Save with empty required field (e.g. missing connection): inline error, no API call
- [x] Cancel: dialog closes, no changes applied
- [x] PUT `/api/layout` returns 422: error shown in dialog, dialog stays open
- [x] No SSH connections in config: dropdown empty with hint text, save blocked
- [x] Edit existing pane CWD with `~/` path: session restarts in correct directory
- [x] New split pane + set CWD with `~/` path: session starts correctly; Restart Session button works