### PR TITLE
feat: drag & drop pane reordering in edit mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,9 +12,10 @@ import { findPaneById } from './utils/layoutTree'
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
 
 export const App: React.FC = () => {
-  const { layout, displayConfig, error, updateSizes, splitPane, closePane } = useLayout()
+  const { layout, displayConfig, error, updateSizes, splitPane, closePane, swapPanes } = useLayout()
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
+  const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
   const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings } =
     usePaneSettings(layout, updateSizes)
 
@@ -59,7 +60,10 @@ export const App: React.FC = () => {
         const pane = findPaneById(layout, paneId)
         if (pane) openSettings(pane)
       },
+      onSwapPanes: swapPanes,
       maximizedPaneId,
+      dragSourcePaneId,
+      setDragSourcePaneId,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
       editMode,
     }}>

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useContext, useState } from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+import { LayoutActionsContext } from './SplitContainer'
 
 interface PaneHeaderProps {
   pane: PaneConfig
@@ -56,13 +57,52 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
   onSettings,
 }) => {
   const showHeader = pane.show_header ?? displayConfig.show_header
+  const layoutCtx = useContext(LayoutActionsContext)
+  const [isDragOver, setIsDragOver] = useState(false)
+
   if (!showHeader) return null
 
   const color = TYPE_COLORS[pane.type] ?? '#888'
   const label = TYPE_LABELS[pane.type] ?? pane.type.toUpperCase()
 
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = 'move'
+    layoutCtx?.setDragSourcePaneId(pane.id)
+  }
+
+  const handleDragEnd = () => {
+    layoutCtx?.setDragSourcePaneId(null)
+    setIsDragOver(false)
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!layoutCtx?.dragSourcePaneId || layoutCtx.dragSourcePaneId === pane.id) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = () => {
+    setIsDragOver(false)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const sourceId = layoutCtx?.dragSourcePaneId
+    if (!sourceId || sourceId === pane.id) return
+    layoutCtx?.onSwapPanes(sourceId, pane.id)
+    layoutCtx?.setDragSourcePaneId(null)
+  }
+
   return (
     <div
+      draggable={editMode}
+      onDragStart={editMode ? handleDragStart : undefined}
+      onDragEnd={editMode ? handleDragEnd : undefined}
+      onDragOver={editMode ? handleDragOver : undefined}
+      onDragLeave={editMode ? handleDragLeave : undefined}
+      onDrop={editMode ? handleDrop : undefined}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -75,8 +115,19 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
         borderBottom: '1px solid #333',
         userSelect: 'none',
         flexShrink: 0,
+        cursor: editMode ? 'grab' : 'default',
+        outline: isDragOver ? '2px solid #569cd6' : 'none',
+        outlineOffset: '-2px',
       }}
     >
+      {editMode && (
+        <span
+          title="Drag to move pane"
+          style={{ color: '#555', fontSize: '13px', lineHeight: '1', flexShrink: 0 }}
+        >
+          ⠿
+        </span>
+      )}
       <span
         style={{
           display: 'inline-block',

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -24,7 +24,10 @@ function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
     onClose: vi.fn(),
     onMaximize: vi.fn(),
     onSettings: vi.fn(),
+    onSwapPanes: vi.fn(),
     maximizedPaneId,
+    dragSourcePaneId: null,
+    setDragSourcePaneId: vi.fn(),
     displayConfig: { show_header: false, show_status_bar: false },
     editMode: false,
   }

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -8,7 +8,10 @@ export interface LayoutActionsContextValue {
   onClose: (paneId: string) => void
   onMaximize: (paneId: string | null) => void
   onSettings: (paneId: string) => void
+  onSwapPanes: (paneIdA: string, paneIdB: string) => void
   maximizedPaneId: string | null
+  dragSourcePaneId: string | null
+  setDragSourcePaneId: (id: string | null) => void
   displayConfig: DisplayConfig
   editMode: boolean
 }

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -171,4 +171,53 @@ describe('useLayout', () => {
       expect(result.current.layout).toBeNull()
     })
   })
+
+  describe('swapPanes', () => {
+    it('swaps two panes and PUTs updated layout', async () => {
+      const twoChildLayout: LayoutNode = {
+        direction: 'horizontal',
+        children: [
+          { size: 50, pane: { id: 'left', type: 'local' } },
+          { size: 50, pane: { id: 'right', type: 'ssh' } },
+        ],
+      }
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(twoChildLayout) } as Response) // GET /api/layout
+        .mockResolvedValueOnce({ ok: false } as Response) // GET /api/display
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response) // PUT /api/layout
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.layout).not.toBeNull())
+
+      await act(async () => {
+        await result.current.swapPanes('left', 'right')
+      })
+
+      expect(result.current.layout?.children[0].pane?.id).toBe('right')
+      expect(result.current.layout?.children[1].pane?.id).toBe('left')
+      const putCall = fetchMock.mock.calls.find(
+        (c) => c[0] === '/api/layout' && (c[1] as RequestInit)?.method === 'PUT',
+      )
+      expect(putCall).toBeDefined()
+    })
+
+    it('does nothing when layout is null', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response) // GET /api/layout fails
+        .mockResolvedValueOnce({ ok: false } as Response) // GET /api/display
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.error).not.toBeNull())
+
+      const callsBefore = fetchMock.mock.calls.length
+      await act(async () => {
+        await result.current.swapPanes('a', 'b')
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(callsBefore)
+    })
+  })
 })

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DisplayConfig, DisplayConfigSchema, LayoutNode, LayoutNodeSchema, PaneConfig } from '../schemas'
-import { generatePaneId, removePaneFromTree, splitPaneInTree } from '../utils/layoutTree'
+import { generatePaneId, removePaneFromTree, splitPaneInTree, swapPanesInTree } from '../utils/layoutTree'
 
 export function useLayout() {
   const [layout, setLayout] = useState<LayoutNode | null>(null)
@@ -87,5 +87,19 @@ export function useLayout() {
     [layout],
   )
 
-  return { layout, displayConfig, error, updateSizes, splitPane, closePane }
+  const swapPanes = useCallback(
+    async (paneIdA: string, paneIdB: string) => {
+      if (!layout) return
+      const newLayout = swapPanesInTree(layout, paneIdA, paneIdB)
+      setLayout(newLayout)
+      await fetch('/api/layout', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newLayout),
+      }).catch(console.error)
+    },
+    [layout],
+  )
+
+  return { layout, displayConfig, error, updateSizes, splitPane, closePane, swapPanes }
 }

--- a/frontend/src/utils/layoutTree.test.ts
+++ b/frontend/src/utils/layoutTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { splitPaneInTree, removePaneFromTree, generatePaneId, findPaneById, replacePaneInTree } from './layoutTree'
+import { splitPaneInTree, removePaneFromTree, generatePaneId, findPaneById, replacePaneInTree, swapPanesInTree } from './layoutTree'
 import type { LayoutNode } from '../schemas'
 
 const simpleLayout: LayoutNode = {
@@ -191,6 +191,61 @@ describe('replacePaneInTree', () => {
     const result = replacePaneInTree(simpleLayout, { id: 'nonexistent', type: 'ssh' })
     expect(result.children[0].pane?.id).toBe('main')
     expect(result.children[0].pane?.type).toBe('local')
+  })
+})
+
+describe('swapPanesInTree', () => {
+  it('swaps two sibling panes at root level', () => {
+    const result = swapPanesInTree(twoChildLayout, 'left', 'right')
+    expect(result.children[0].pane?.id).toBe('right')
+    expect(result.children[1].pane?.id).toBe('left')
+  })
+
+  it('preserves sizes when swapping', () => {
+    const uneven: LayoutNode = {
+      direction: 'horizontal',
+      children: [
+        { size: 30, pane: { id: 'a', type: 'local' } },
+        { size: 70, pane: { id: 'b', type: 'local' } },
+      ],
+    }
+    const result = swapPanesInTree(uneven, 'a', 'b')
+    expect(result.children[0].size).toBe(30)
+    expect(result.children[1].size).toBe(70)
+    expect(result.children[0].pane?.id).toBe('b')
+    expect(result.children[1].pane?.id).toBe('a')
+  })
+
+  it('swaps a root pane with a nested pane', () => {
+    const nested: LayoutNode = {
+      direction: 'horizontal',
+      children: [
+        { size: 50, pane: { id: 'left', type: 'local' } },
+        {
+          size: 50,
+          direction: 'vertical',
+          children: [
+            { size: 50, pane: { id: 'top-right', type: 'ssh' } },
+            { size: 50, pane: { id: 'bottom-right', type: 'tmux' } },
+          ],
+        },
+      ],
+    }
+    const result = swapPanesInTree(nested, 'left', 'top-right')
+    expect(result.children[0].pane?.id).toBe('top-right')
+    expect(result.children[0].pane?.type).toBe('ssh')
+    expect(result.children[1].children![0].pane?.id).toBe('left')
+    expect(result.children[1].children![0].pane?.type).toBe('local')
+  })
+
+  it('returns unchanged layout when same id given', () => {
+    const result = swapPanesInTree(twoChildLayout, 'left', 'left')
+    expect(result).toBe(twoChildLayout)
+  })
+
+  it('returns unchanged layout when a pane id is not found', () => {
+    const result = swapPanesInTree(twoChildLayout, 'left', 'nonexistent')
+    expect(result).toBe(twoChildLayout)
   })
 })
 

--- a/frontend/src/utils/layoutTree.ts
+++ b/frontend/src/utils/layoutTree.ts
@@ -125,6 +125,35 @@ function replaceInChildren(children: LayoutChild[], updated: PaneConfig): Layout
 }
 
 /**
+ * Swaps the pane configs at the two given pane IDs in the layout tree.
+ * Tree structure (sizes, split directions) is preserved; only the pane
+ * configs at each position are exchanged.
+ * Returns the original layout unchanged if either ID is not found or both IDs are the same.
+ */
+export function swapPanesInTree(layout: LayoutNode, paneIdA: string, paneIdB: string): LayoutNode {
+  if (paneIdA === paneIdB) return layout
+  const paneA = findPaneById(layout, paneIdA)
+  const paneB = findPaneById(layout, paneIdB)
+  if (!paneA || !paneB) return layout
+  return { ...layout, children: swapInChildren(layout.children, paneIdA, paneB, paneIdB, paneA) }
+}
+
+function swapInChildren(
+  children: LayoutChild[],
+  idA: string,
+  paneB: PaneConfig,
+  idB: string,
+  paneA: PaneConfig,
+): LayoutChild[] {
+  return children.map((child) => {
+    if (child.pane?.id === idA) return { ...child, pane: paneB }
+    if (child.pane?.id === idB) return { ...child, pane: paneA }
+    if (child.children?.length) return { ...child, children: swapInChildren(child.children, idA, paneB, idB, paneA) }
+    return child
+  })
+}
+
+/**
  * Generates a unique pane ID.
  */
 export function generatePaneId(): string {


### PR DESCRIPTION
## Summary

- Edit mode でペインヘッダーが draggable になり、`⠿` ドラッグハンドルが表示される
- あるペインを別のペインにドラッグ&ドロップすると、2つのペインの設定が入れ替わる（ツリー構造・サイズはそのまま保持）
- ドロップ対象のヘッダーに青いアウトライン（`#569cd6`）でフィードバックを表示

## Test plan

- [x] `swapPanesInTree` のユニットテスト追加・全パス（ルートレベルスワップ、ネストスワップ、同一ID no-op、未知ID no-op）
- [x] `useLayout.swapPanes` のテスト追加・全パス（正常スワップ、layout null 時の no-op）
- [x] `SplitContainer.test.tsx` の context モックを新フィールド対応に更新
- [x] `npx tsc --noEmit` 型エラーなし
- [x] `npm run coverage` 80%+ (80.61% branches)
- [x] `npm run build` 成功
- [ ] 手動確認: `./bin/panemux` → 編集モードON → `⠿` をドラッグ → 別ペインにドロップ → 内容が入れ替わる