### PR TITLE
feat: full-window drag in edit mode; lock terminal input during edit

### DIFF
--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -1,0 +1,105 @@
+# UI Design
+
+This document describes the visual design decisions for the PaneMux frontend, covering edit mode, drag-and-drop, and the principles behind them.
+
+## Design Principles
+
+Three core principles guide the interactive UI:
+
+**State Visibility** — the user must always know what mode the application is in and what action is in progress. When edit mode is active, every pane should look different from the normal operating state without requiring the user to look at a toggle button. When a drag is in flight, the source and destination must be unambiguous.
+
+**Affordances** — visual cues should match physical intuition. Grab cursors indicate draggable elements. Faded, translucent panes feel "lifted away" from the surface. Bright outlines show where something can land.
+
+**Feedback** — transitions between states are animated (0.15–0.2 s) to prevent abrupt jumps and to make cause-and-effect legible. Immediate opacity changes on drag start give instant confirmation that the drag has begun.
+
+---
+
+## Color Palette
+
+| Role | Value | Usage |
+|---|---|---|
+| Interactive blue | `#569cd6` | drop-target outline, drag handle, toggle border |
+| Edit mode blue-tint dark | `rgba(10, 20, 38, 0.54)` | terminal overlay in edit mode |
+| Edit header background | `#1d2b3a` | pane header in edit mode |
+| Edit header border | `#2a3f55` | header bottom border in edit mode |
+| Normal header background | `#252526` | pane header in normal mode |
+| Normal header border | `#333` | header bottom border in normal mode |
+| Drag handle icon | `#4a7ea5` | ⠿ icon in edit mode header |
+| Pane frame (edit mode) | `rgba(86, 156, 214, 0.18)` | inset box-shadow border |
+| Drag source outline | `rgba(86, 156, 214, 0.7)` | dashed outline on pane being dragged |
+
+---
+
+## Edit Mode
+
+Edit mode is toggled by the fixed button in the bottom-right corner. When active, the application switches from a "use terminals" context to a "rearrange layout" context. Terminal input is blocked for the duration.
+
+### Why block terminal input
+
+Allowing simultaneous terminal interaction and layout editing creates two problems: accidental keystrokes sent to a shell while trying to drag, and ambiguous gesture ownership (is the user clicking to focus, or clicking to start a drag?). Blocking input during edit mode eliminates both.
+
+### Visual changes per pane
+
+| Element | Normal | Edit mode |
+|---|---|---|
+| Header background | `#252526` | `#1d2b3a` (blue-gray) |
+| Header border | `#333` | `#2a3f55` |
+| Drag handle `⠿` | hidden | visible, color `#4a7ea5` |
+| Header cursor | `default` | `grab` |
+| Pane frame | none | `inset 0 0 0 1px rgba(86,156,214,0.18)` |
+| Terminal overlay | none | `rgba(10,20,38,0.54)` blocking layer |
+
+The header shifts toward a blue-gray tone (`#1d2b3a`) to signal the different mode without disrupting readability. A 0.2 s transition on `background-color` and `border-color` makes the switch feel intentional rather than abrupt.
+
+The terminal overlay is a `position: absolute` layer over the xterm.js canvas. It serves two purposes: it intercepts all pointer events (preventing the terminal from gaining focus) and it visually dims the terminal content so users understand the pane is locked. The blue-tinted dark color (`rgba(10,20,38,0.54)`) is distinct from the session-ended overlay (`rgba(0,0,0,0.6)`) so the two states are not confused.
+
+The inset `box-shadow` border marks every pane as part of an "edit zone" without affecting layout geometry. Using `box-shadow` rather than `border` or `outline` keeps the frame cosmetic and avoids shifting sibling sizes.
+
+---
+
+## Drag and Drop
+
+Drag-and-drop pane reordering is active only in edit mode. The entire pane is the drag surface — not just the header — making it easy to initiate a drag on any visible part of the pane.
+
+### States
+
+**Normal (edit mode, not dragging)**
+
+Panes show the edit-mode frame and overlay. The grab cursor is visible on the header.
+
+**Drag source** (`isDragging: true` on the pane being dragged)
+
+- `opacity: 0.35` — the pane becomes translucent, evoking a "picked up from the surface" metaphor
+- `outline: 2px dashed rgba(86,156,214,0.7)` — a dashed border reinforces that this slot is now empty/occupied
+- The browser generates a ghost image from the element for the pointer to carry; the ghost and the faded source together communicate "this pane is moving"
+- 0.15 s `opacity` transition ensures the fade starts immediately on drag initiation
+
+**Drop target** (`isDragOver: true` on the hovered pane)
+
+- `outline: 2px solid #569cd6` — solid bright blue contrasts clearly with the dashed source outline
+- Outline uses `outlineOffset: -2px` to render inside the element boundary, keeping the box model unchanged
+
+**After drop / drag cancel**
+
+Both states reset: `isDragging` and `isDragOver` return to `false`, opacity returns to 1, and outlines clear. The drag source and target revert to normal edit-mode appearance within one animation frame.
+
+### Why entire-pane drag instead of header-only
+
+A header spanning 22–24 px at 11 px font size is a narrow target, especially on high-density layouts with many small panes. Making the full pane draggable removes precision requirements and matches the grab-cursor affordance visible on the header. The edit-mode overlay already covers the terminal area and intercepts pointer events, so making it the drag initiator adds no new event conflicts.
+
+### Drag handle icon
+
+The `⠿` (braille pattern) icon in the header is a drag handle affordance adopted from editors such as VSCode and Notion. It communicates "this element can be moved" without consuming much space. In edit mode it is rendered in `#4a7ea5`, which is visible against the `#1d2b3a` header background while staying subdued enough not to compete with the session type label.
+
+---
+
+## Edit Mode Toggle
+
+The toggle button (`EditModeToggle`) lives at `position: fixed; bottom: 12px; right: 12px; z-index: 1000`.
+
+| State | Background | Border | Color | Opacity | Shadow |
+|---|---|---|---|---|---|
+| OFF | `#3f3f46` | `#52525b` | `#888` | 0.65 | `0 2px 8px rgba(0,0,0,0.5)` |
+| ON | `#1a3040` | `#569cd6` | `#569cd6` | 1.0 | `0 0 0 1px #569cd6, 0 2px 8px rgba(0,0,0,0.6)` |
+
+The reduced opacity (0.65) in OFF state pushes the button into the background so it does not compete with terminal content. The full opacity, blue border, and blue glow in ON state make the active edit context unmistakable from the corner of the eye. Transitions on `opacity`, `box-shadow`, `border-color`, and `color` run at 0.2 s.

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -72,17 +72,19 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
         fontSize: '11px',
         fontFamily: TERMINAL_FONT_FAMILY,
         color: '#888',
-        backgroundColor: '#252526',
-        borderBottom: '1px solid #333',
+        // Shift header toward a blue-gray tint in edit mode for clear mode indication
+        backgroundColor: editMode ? '#1d2b3a' : '#252526',
+        borderBottom: editMode ? '1px solid #2a3f55' : '1px solid #333',
         userSelect: 'none',
         flexShrink: 0,
         cursor: editMode ? 'grab' : 'default',
+        transition: 'background-color 0.2s ease, border-color 0.2s ease',
       }}
     >
       {editMode && (
         <span
           title="Drag to move pane"
-          style={{ color: '#555', fontSize: '13px', lineHeight: '1', flexShrink: 0 }}
+          style={{ color: '#4a7ea5', fontSize: '13px', lineHeight: '1', flexShrink: 0 }}
         >
           ⠿
         </span>

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -1,7 +1,6 @@
-import React, { useContext, useState } from 'react'
+import React from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
-import { LayoutActionsContext } from './SplitContainer'
 
 interface PaneHeaderProps {
   pane: PaneConfig
@@ -57,52 +56,14 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
   onSettings,
 }) => {
   const showHeader = pane.show_header ?? displayConfig.show_header
-  const layoutCtx = useContext(LayoutActionsContext)
-  const [isDragOver, setIsDragOver] = useState(false)
 
   if (!showHeader) return null
 
   const color = TYPE_COLORS[pane.type] ?? '#888'
   const label = TYPE_LABELS[pane.type] ?? pane.type.toUpperCase()
 
-  const handleDragStart = (e: React.DragEvent) => {
-    e.dataTransfer.effectAllowed = 'move'
-    layoutCtx?.setDragSourcePaneId(pane.id)
-  }
-
-  const handleDragEnd = () => {
-    layoutCtx?.setDragSourcePaneId(null)
-    setIsDragOver(false)
-  }
-
-  const handleDragOver = (e: React.DragEvent) => {
-    if (!layoutCtx?.dragSourcePaneId || layoutCtx.dragSourcePaneId === pane.id) return
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    setIsDragOver(true)
-  }
-
-  const handleDragLeave = () => {
-    setIsDragOver(false)
-  }
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragOver(false)
-    const sourceId = layoutCtx?.dragSourcePaneId
-    if (!sourceId || sourceId === pane.id) return
-    layoutCtx?.onSwapPanes(sourceId, pane.id)
-    layoutCtx?.setDragSourcePaneId(null)
-  }
-
   return (
     <div
-      draggable={editMode}
-      onDragStart={editMode ? handleDragStart : undefined}
-      onDragEnd={editMode ? handleDragEnd : undefined}
-      onDragOver={editMode ? handleDragOver : undefined}
-      onDragLeave={editMode ? handleDragLeave : undefined}
-      onDrop={editMode ? handleDrop : undefined}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -116,8 +77,6 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
         userSelect: 'none',
         flexShrink: 0,
         cursor: editMode ? 'grab' : 'default',
-        outline: isDragOver ? '2px solid #569cd6' : 'none',
-        outlineOffset: '-2px',
       }}
     >
       {editMode && (

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -15,6 +15,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [containerEl, setContainerEl] = React.useState<HTMLElement | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
 
   const setRef = useCallback((el: HTMLDivElement | null) => {
     containerRef.current = el
@@ -44,11 +45,13 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move'
     ctx?.setDragSourcePaneId(pane.id)
+    setIsDragging(true)
   }
 
   const handleDragEnd = () => {
     ctx?.setDragSourcePaneId(null)
     setIsDragOver(false)
+    setIsDragging(false)
   }
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -84,8 +87,20 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
         height: '100%',
         overflow: 'hidden',
         backgroundColor: '#1a1b1e',
-        outline: isDragOver ? '2px solid #569cd6' : 'none',
+        // Outline priority: drop-target > drag-source > none
+        outline: isDragOver
+          ? '2px solid #569cd6'
+          : isDragging
+          ? '2px dashed rgba(86, 156, 214, 0.7)'
+          : 'none',
         outlineOffset: '-2px',
+        // Subtle inset frame to mark pane as "in edit zone"
+        boxShadow: editMode && !isDragOver
+          ? 'inset 0 0 0 1px rgba(86, 156, 214, 0.18)'
+          : 'none',
+        // "Lifted" appearance when this pane is the drag source
+        opacity: isDragging ? 0.35 : 1,
+        transition: 'opacity 0.15s ease, box-shadow 0.2s ease',
       }}
     >
       <PaneHeader
@@ -113,8 +128,9 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
             position: 'absolute',
             inset: 0,
             zIndex: 5,
-            cursor: 'grab',
-            backgroundColor: 'rgba(0, 0, 0, 0.25)',
+            cursor: isDragging ? 'grabbing' : 'grab',
+            // Blue-tinted dark overlay — clearly dims terminal content
+            backgroundColor: 'rgba(10, 20, 38, 0.54)',
           }} />
         )}
         {sessionExited && (

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -15,7 +15,6 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [containerEl, setContainerEl] = React.useState<HTMLElement | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
-  const [isDragging, setIsDragging] = useState(false)
 
   const setRef = useCallback((el: HTMLDivElement | null) => {
     containerRef.current = el
@@ -25,6 +24,11 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const ctx = useContext(LayoutActionsContext)
   const displayConfig = ctx?.displayConfig ?? DEFAULT_DISPLAY
   const editMode = ctx?.editMode ?? false
+  // Derive from context rather than local state: when the DOM element is moved
+  // by React during a swap, the browser may not fire dragend on the source pane,
+  // leaving local isDragging=true permanently. Using the global dragSourcePaneId
+  // (cleared by handleDrop before dragend would fire) avoids this.
+  const isDragging = ctx?.dragSourcePaneId === pane.id
 
   const { handleResize, connected, dims, sessionExited, restartSession } = useTerminal({
     sessionId: pane.id,
@@ -45,13 +49,11 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const handleDragStart = (e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move'
     ctx?.setDragSourcePaneId(pane.id)
-    setIsDragging(true)
   }
 
   const handleDragEnd = () => {
     ctx?.setDragSourcePaneId(null)
     setIsDragOver(false)
-    setIsDragging(false)
   }
 
   const handleDragOver = (e: React.DragEvent) => {

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react'
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
 import { useTerminal } from '../hooks/useTerminal'
 import { PaneHeader } from './PaneHeader'
@@ -14,19 +14,22 @@ interface TerminalPaneProps {
 export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [containerEl, setContainerEl] = React.useState<HTMLElement | null>(null)
+  const [isDragOver, setIsDragOver] = useState(false)
 
   const setRef = useCallback((el: HTMLDivElement | null) => {
     containerRef.current = el
     setContainerEl(el)
   }, [])
 
+  const ctx = useContext(LayoutActionsContext)
+  const displayConfig = ctx?.displayConfig ?? DEFAULT_DISPLAY
+  const editMode = ctx?.editMode ?? false
+
   const { handleResize, connected, dims, sessionExited, restartSession } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
+    editMode,
   })
-
-  const ctx = useContext(LayoutActionsContext)
-  const displayConfig = ctx?.displayConfig ?? DEFAULT_DISPLAY
 
   // Observe resize events for this pane
   useEffect(() => {
@@ -38,21 +41,59 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
     return () => observer.disconnect()
   }, [containerEl, handleResize])
 
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.effectAllowed = 'move'
+    ctx?.setDragSourcePaneId(pane.id)
+  }
+
+  const handleDragEnd = () => {
+    ctx?.setDragSourcePaneId(null)
+    setIsDragOver(false)
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!ctx?.dragSourcePaneId || ctx.dragSourcePaneId === pane.id) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = () => setIsDragOver(false)
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const sourceId = ctx?.dragSourcePaneId
+    if (!sourceId || sourceId === pane.id) return
+    ctx?.onSwapPanes(sourceId, pane.id)
+    ctx?.setDragSourcePaneId(null)
+  }
+
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      width: '100%',
-      height: '100%',
-      overflow: 'hidden',
-      backgroundColor: '#1a1b1e',
-    }}>
+    <div
+      draggable={editMode}
+      onDragStart={editMode ? handleDragStart : undefined}
+      onDragEnd={editMode ? handleDragEnd : undefined}
+      onDragOver={editMode ? handleDragOver : undefined}
+      onDragLeave={editMode ? handleDragLeave : undefined}
+      onDrop={editMode ? handleDrop : undefined}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        backgroundColor: '#1a1b1e',
+        outline: isDragOver ? '2px solid #569cd6' : 'none',
+        outlineOffset: '-2px',
+      }}
+    >
       <PaneHeader
         pane={pane}
         connected={connected}
         displayConfig={displayConfig}
         isMaximized={ctx?.maximizedPaneId === pane.id}
-        editMode={ctx?.editMode ?? false}
+        editMode={editMode}
         onSplit={(direction) => ctx?.onSplit(pane.id, direction)}
         onClose={() => ctx?.onClose(pane.id)}
         onMaximize={() => ctx?.onMaximize(ctx.maximizedPaneId === pane.id ? null : pane.id)}
@@ -67,6 +108,15 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
           position: 'relative',
         }}
       >
+        {editMode && (
+          <div style={{
+            position: 'absolute',
+            inset: 0,
+            zIndex: 5,
+            cursor: 'grab',
+            backgroundColor: 'rgba(0, 0, 0, 0.25)',
+          }} />
+        )}
         {sessionExited && (
           <div style={{
             position: 'absolute',

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -441,4 +441,33 @@ describe('useTerminal', () => {
     act(() => onDataCallback('hello'))
     expect(ws.sent.length).toBeGreaterThan(sentBefore)
   })
+
+  it('editMode blocks binary input', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container, editMode: true }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const ws = MockWebSocket.instances[0]
+    const sentBefore = ws.sent.length
+    const onBinaryCallback = mockTerm.onBinary.mock.calls[0][0] as (data: string) => void
+    act(() => onBinaryCallback('ABC'))
+    expect(ws.sent.length).toBe(sentBefore)
+  })
+
+  it('re-enables terminal input when editMode is turned off after mount', () => {
+    const container = makeContainer()
+    const { rerender } = renderHook(
+      ({ editMode }: { editMode: boolean }) => useTerminal({ sessionId: 's1', container, editMode }),
+      { initialProps: { editMode: true } },
+    )
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    rerender({ editMode: false })
+
+    const ws = MockWebSocket.instances[0]
+    const sentBefore = ws.sent.length
+    const onDataCallback = mockTerm.onData.mock.calls[0][0] as (data: string) => void
+    act(() => onDataCallback('hello after unlock'))
+    expect(ws.sent.length).toBeGreaterThan(sentBefore)
+  })
 })

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -417,4 +417,28 @@ describe('useTerminal', () => {
     expect(mockTerm.dispose).not.toHaveBeenCalled()
     expect(secondContainer.contains(mockTerm.element as HTMLElement)).toBe(true)
   })
+
+  it('editMode blocks terminal input', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container, editMode: true }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const ws = MockWebSocket.instances[0]
+    const sentBefore = ws.sent.length
+    const onDataCallback = mockTerm.onData.mock.calls[0][0] as (data: string) => void
+    act(() => onDataCallback('hello'))
+    expect(ws.sent.length).toBe(sentBefore)
+  })
+
+  it('normal mode passes terminal input', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container, editMode: false }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const ws = MockWebSocket.instances[0]
+    const sentBefore = ws.sent.length
+    const onDataCallback = mockTerm.onData.mock.calls[0][0] as (data: string) => void
+    act(() => onDataCallback('hello'))
+    expect(ws.sent.length).toBeGreaterThan(sentBefore)
+  })
 })

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -229,7 +229,11 @@ function attachTerminal(entry: TerminalEntry, container: HTMLElement) {
   }
 
   if (entry.term.element.parentElement !== container) {
-    container.replaceChildren()
+    // Use appendChild (not replaceChildren) so that React-managed siblings
+    // (edit-mode overlay, session-exited overlay) are preserved.  replaceChildren()
+    // would remove those React-owned DOM nodes, causing React to crash when it
+    // next tries to reconcile them (e.g. removeChild on a detached node when
+    // edit mode is toggled off).
     container.appendChild(entry.term.element)
   }
 }

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -8,6 +8,7 @@ import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 interface UseTerminalOptions {
   sessionId: string
   container: HTMLElement | null
+  editMode?: boolean
 }
 
 interface TerminalEntry {
@@ -16,11 +17,12 @@ interface TerminalEntry {
   attachedContainer: HTMLElement | null
   disposeTimer: ReturnType<typeof setTimeout> | null
   send: ((data: string | ArrayBuffer | Uint8Array) => void) | null
+  editMode: boolean
 }
 
 const terminalEntries = new Map<string, TerminalEntry>()
 
-export function useTerminal({ sessionId, container }: UseTerminalOptions) {
+export function useTerminal({ sessionId, container, editMode = false }: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const initializedRef = useRef(false)
@@ -74,6 +76,11 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     }
   }, [send])
 
+  // Sync editMode into the entry so onData/onBinary handlers can read it
+  useLayoutEffect(() => {
+    if (entryRef.current) entryRef.current.editMode = editMode
+  }, [editMode])
+
   // Initialize terminal
   useEffect(() => {
     if (!container || initializedRef.current) return
@@ -87,6 +94,7 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
 
     entry.attachedContainer = container
     entry.send = sendRef.current
+    entry.editMode = editMode
     entryRef.current = entry
     termRef.current = entry.term
     fitAddonRef.current = entry.fitAddon
@@ -180,6 +188,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     attachedContainer: null,
     disposeTimer: null,
     send: null,
+    editMode: false,
   }
 
   term.loadAddon(fitAddon)
@@ -196,15 +205,17 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
 
   // Use the entry send ref so the same terminal instance can survive pane remounts.
   term.onData((data) => {
-    entry.send?.(new TextEncoder().encode(data))
+    if (!entry.editMode) entry.send?.(new TextEncoder().encode(data))
   })
 
   term.onBinary((data) => {
-    const bytes = new Uint8Array(data.length)
-    for (let i = 0; i < data.length; i++) {
-      bytes[i] = data.charCodeAt(i) & 0xff
+    if (!entry.editMode) {
+      const bytes = new Uint8Array(data.length)
+      for (let i = 0; i < data.length; i++) {
+        bytes[i] = data.charCodeAt(i) & 0xff
+      }
+      entry.send?.(bytes)
     }
-    entry.send?.(bytes)
   })
 
   terminalEntries.set(sessionId, entry)


### PR DESCRIPTION
## Summary

- Drag & drop pane reordering now works by dragging the **entire pane** (not just the header) in edit mode
- Terminal keyboard input is **blocked** while edit mode is active (guarded in `onData`/`onBinary` via a new `editMode` flag on `TerminalEntry`)
- A semi-transparent overlay is rendered over each terminal in edit mode, intercepting pointer events so the terminal cannot gain focus, making the locked state visually obvious

## Changes

- **`TerminalPane.tsx`**: Moved drag source + drop target logic here (outer pane div); added `isDragOver` blue-outline feedback; added edit-mode overlay; passes `editMode` to `useTerminal`
- **`PaneHeader.tsx`**: Removed all drag event handlers and state; kept `⠿` icon and `cursor: grab` as visual affordance only
- **`useTerminal.ts`**: Added `editMode?: boolean` option; added `editMode` field to `TerminalEntry`; guards `onData`/`onBinary` behind `\!entry.editMode`; syncs flag via `useLayoutEffect`
- **`useTerminal.test.ts`**: Two new tests — edit mode blocks input, normal mode passes input

## Test plan

- [x] `cd frontend && npm test` — all 140 tests pass
- [x] `cd frontend && npx tsc --noEmit` — no type errors
- [x] Normal mode: dragging a pane does nothing; clicking terminal → input works
- [x] Edit mode ON: drag anywhere on a pane → panes swap correctly; clicking terminal area → no keystrokes sent; semi-transparent overlay + grab cursor visible
- [x] Edit mode OFF: overlay gone, terminal interactive again