### PR TITLE
feat: SSH connection management via ~/.ssh/config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,23 @@ Sessions are started at server startup from the YAML config (`main.go: startSess
 - Go: all tests must pass (`go test ./... -v -race`) before moving on.
 - Frontend: all tests must pass (`cd frontend && npm test`) before moving on.
 
+### Test granularity
+
+**Test at the smallest unit that exercises the logic, not at the outermost entry point.**
+
+The following anti-patterns caused bugs to slip through:
+
+| Anti-pattern | Problem | Correct approach |
+|---|---|---|
+| Testing a function that makes real network calls to verify config-resolution logic | Network errors hide config errors; any error is accepted as "expected" | Extract pure config-resolution into a separate function (e.g., `resolveSSHConfig`) and test it directly, asserting exact return values |
+| `if err != nil { assert.NotContains(t, err.Error(), "not found") }` | Accepts *any* error except "not found" — masks setup errors like "no auth methods" or "reading key file ~/..." | Assert the specific happy path: `require.NoError(t, err)` and check returned values. For expected-failure paths, assert the exact error string |
+| Test data that never exercises the real-world variant | e.g., test SSH config with absolute `IdentityFile` paths, never `~/` — the tilde-expansion bug is invisible | Add test cases that cover the exact formats users produce: `~/`-prefixed paths, omitted optional fields |
+| Testing only the error case of a new validation rule, not the passing case | The positive path (new feature works correctly) is never confirmed to pass | For every new validation rule, write *both* a failure test *and* a success test |
+
+**Testability rule:** if production code calls `os.UserHomeDir()`, `DefaultPath()`, or any other global singleton directly, add an injectable override (unexported struct field, function parameter, or interface) so tests can substitute a controlled value without touching the real filesystem or home directory.
+
+Example: `Config.sshConfigPath` (empty = use `sshconfig.DefaultPath()`, non-empty = use in tests).
+
 ### Schema-first
 - **Go**: when changing data structures, update the validation rules and tests in `internal/config/validate.go` first.
 - **Frontend**: when changing types, update the Zod schemas in `frontend/src/schemas/index.ts` first. TypeScript types are derived via `z.infer<>` — do not edit `types/index.ts` manually.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ When writing code that passes user-supplied values to `exec.Command`:
 
 See `docs/architecture.md` → *Security Design* for the full rationale and the `/etc/shells` pattern used in this codebase.
 
+**Remote path arguments (SSH working directory):** user-supplied paths that flow into `sess.Start()` shell commands must be validated with `validRemotePath` (defined in `internal/session/ssh.go`) before use. This regex guard is the CodeQL-recommended sanitization pattern for shell arguments, and it rejects shell metacharacters (`;|&$\`'"<>(){}[]!\`) and control characters while allowing valid Unix path characters including spaces and Unicode.
+
 ### Pull request test plan
 - After creating a PR, run every item in the test plan locally and verify it passes.
 - Update the PR description with all checkboxes checked (`- [x]`) before considering the task complete.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,14 @@ For the same reason, `os.Getenv("SHELL")` is not used as a default shell. Enviro
 
 `validTmuxSessionName` in `internal/session/tmux_ssh.go` uses a strict regex (`^[a-zA-Z0-9_.-]+$`) validated at construction time, and arguments are passed as discrete `exec.Command` args (not via `sh -c`), so no shell interpolation occurs.
 
+**Remote path arguments (SSH working directory)**
+
+When an SSH or SSH+tmux pane has `cwd` set, the path is passed as part of a remote shell command (`cd <cwd> && exec $SHELL`). User-supplied paths that flow into `sess.Start()` must be validated with `validRemotePath` (defined in `internal/session/ssh.go`) before use.
+
+`validRemotePath` is a regex guard (`^(/[^;|&$\`'"<>()\[\]{}!\\\x00-\x1f\x7f]*)+$`) that accepts only absolute Unix paths and rejects shell metacharacters and control characters. This is the CodeQL-recommended sanitization pattern for shell arguments.
+
+After validation, the path is wrapped with `shellQuotePath`, which single-quotes the value and escapes any interior single quotes. This ensures paths containing spaces or unusual (but allowed) characters are safe to embed in a shell string.
+
 **General rule**
 
 When adding new session types or new `exec.Command` calls: the value passed as the command (first argument) must come from a hardcoded literal or from a trusted system source (file, registry) with no data-flow path to user input. Arguments after the command may be user-supplied if they cannot be interpreted as commands by the target binary.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -33,6 +33,71 @@ Path behavior:
 
 - `~/` in SSH key paths and pane working directories is expanded at load time
 
+## SSH Connections
+
+### Defining connections in `ssh_connections`
+
+Each entry under `ssh_connections` in the YAML config has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `host` | yes | Hostname or IP address |
+| `user` | yes | Remote username |
+| `port` | no (default 22) | SSH port |
+| `key_file` | no | Path to private key; `~/` is expanded at load time |
+| `password` | no | Password for password-based authentication |
+| `known_hosts_file` | no (default `~/.ssh/known_hosts`) | Path to known\_hosts file for host-key verification |
+
+Example:
+
+```yaml
+ssh_connections:
+  prod-web:
+    host: 192.168.1.10
+    user: deploy
+    key_file: ~/.ssh/id_ed25519
+  bastion:
+    host: bastion.example.com
+    user: ops
+    key_file: ~/.ssh/id_ed25519
+    known_hosts_file: ~/.ssh/known_hosts
+```
+
+### Using `~/.ssh/config` hosts
+
+Panes can reference host aliases from `~/.ssh/config` directly in the `connection` field without duplicating them under `ssh_connections`. The following fields are read from each non-wildcard `Host` block:
+
+- `HostName` — hostname or IP (defaults to the alias name if omitted)
+- `User` — remote username
+- `Port` — port number (defaults to 22 if omitted)
+- `IdentityFile` — path to private key; `~/` is expanded at session creation time
+
+Wildcard entries (`Host *`, `Host *.example.com`) are skipped.
+
+`ssh_connections` takes precedence over `~/.ssh/config` when the same name appears in both.
+
+### Authentication
+
+When establishing an SSH connection, the following auth methods are attempted in order:
+
+1. Key file specified in `key_file` (if present)
+2. Password specified in `password` (if present)
+3. Default key files in order: `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`
+
+Host-key verification uses `known_hosts_file` if configured, or `~/.ssh/known_hosts` by default. If the known\_hosts file does not exist, the connection is refused (the app does not silently accept unknown hosts).
+
+### SSH pane fields
+
+| Field | Types | Required | Description |
+|---|---|---|---|
+| `connection` | `ssh`, `ssh_tmux` | yes | Name from `ssh_connections` or `~/.ssh/config` |
+| `cwd` | `ssh`, `ssh_tmux` | no | Remote working directory; executes `cd {cwd} && exec $SHELL` |
+| `tmux_session` | `ssh_tmux` | yes | Remote tmux session name to attach or create |
+
+`tmux_session` must match `^[a-zA-Z0-9_.-]+$`.
+
+`cwd` is validated against `validRemotePath` before use: absolute paths only, no shell metacharacters (`;|&$` + "`" + `'"<>(){}[]!`), no control characters. See *Security Design* in `architecture.md`.
+
 Persistence behavior:
 
 - `PUT /api/layout` updates in-memory layout always
@@ -71,6 +136,53 @@ Current product use: the frontend uses this endpoint when the user splits a pane
 ### `DELETE /api/sessions/{id}`
 
 Closes the session, removes its pane from the layout, collapses redundant parent splits, normalizes sibling sizes, and returns `204`.
+
+### `GET /api/ssh-connections`
+
+Returns a sorted list of all known SSH connection names — the union of names defined in `ssh_connections` (YAML) and non-wildcard hosts from `~/.ssh/config`. Names present in both sources are deduplicated, with the YAML entry taking precedence.
+
+Response:
+
+```json
+{ "names": ["bastion", "prod-web"] }
+```
+
+### `GET /api/ssh-config/hosts`
+
+Returns all non-wildcard hosts from `~/.ssh/config` with full field details.
+
+- `500`: unable to read `~/.ssh/config`
+- `200`: list of host records
+
+Response:
+
+```json
+{
+  "hosts": [
+    { "name": "bastion", "hostname": "bastion.example.com", "user": "ops", "port": 22, "identity_file": "~/.ssh/id_ed25519" }
+  ]
+}
+```
+
+Fields `port` and `identity_file` are omitted when not set in `~/.ssh/config`.
+
+### `POST /api/ssh-config/hosts`
+
+Appends a new `Host` block to `~/.ssh/config`.
+
+Request body:
+
+```json
+{ "name": "my-server", "hostname": "192.168.1.5", "user": "deploy", "port": 22, "identity_file": "~/.ssh/id_ed25519" }
+```
+
+- `400`: invalid JSON
+- `409`: a host with the same name already exists in `~/.ssh/config`
+- `422`: validation error (name, hostname, or user missing; name contains invalid characters; port out of range)
+- `500`: unable to read or write `~/.ssh/config`
+- `201`: host appended
+
+`name` must match `^[a-zA-Z0-9_.\-]+$`. `port` defaults to 0 (omitted from the written block) when not specified. `identity_file` is optional.
 
 ### `GET /api/display`
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,15 @@
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
 import { EditModeToggle } from './components/EditModeToggle'
 import { PaneSettingsDialog } from './components/PaneSettingsDialog'
+import { AddSSHHostDialog } from './components/AddSSHHostDialog'
 import { useLayout } from './hooks/useLayout'
 import { useEditMode } from './hooks/useEditMode'
 import { usePaneSettings } from './hooks/usePaneSettings'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
 import { findPaneById } from './utils/layoutTree'
+import type { SSHConfigHost } from './schemas'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
 
@@ -16,8 +18,25 @@ export const App: React.FC = () => {
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
-  const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings } =
+  const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost } =
     usePaneSettings(layout, updateSizes)
+
+  const [isAddSSHHostOpen, setIsAddSSHHostOpen] = useState(false)
+  const [addSSHHostError, setAddSSHHostError] = useState<string | null>(null)
+  const [isAddSSHHostSaving, setIsAddSSHHostSaving] = useState(false)
+
+  const handleAddSSHHost = useCallback(async (host: SSHConfigHost) => {
+    setIsAddSSHHostSaving(true)
+    setAddSSHHostError(null)
+    try {
+      await addSSHConfigHost(host)
+      setIsAddSSHHostOpen(false)
+    } catch (err) {
+      setAddSSHHostError(err instanceof Error ? err.message : 'Failed to add host')
+    } finally {
+      setIsAddSSHHostSaving(false)
+    }
+  }, [addSSHConfigHost])
 
   if (error) {
     return (
@@ -78,6 +97,14 @@ export const App: React.FC = () => {
           isSaving={isSaving}
           onSave={saveSettings}
           onClose={closeSettings}
+          onAddSSHHost={() => setIsAddSSHHostOpen(true)}
+        />
+        <AddSSHHostDialog
+          isOpen={isAddSSHHostOpen}
+          isSaving={isAddSSHHostSaving}
+          saveError={addSSHHostError}
+          onSave={handleAddSSHHost}
+          onClose={() => setIsAddSSHHostOpen(false)}
         />
       </div>
     </LayoutActionsContext.Provider>

--- a/frontend/src/components/AddSSHHostDialog.test.tsx
+++ b/frontend/src/components/AddSSHHostDialog.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AddSSHHostDialog } from './AddSSHHostDialog'
+import type { SSHConfigHost } from '../schemas'
+
+const defaultProps = {
+  isOpen: true,
+  isSaving: false,
+  saveError: null,
+  onSave: vi.fn(),
+  onClose: vi.fn(),
+}
+
+describe('AddSSHHostDialog', () => {
+  it('does not render when isOpen=false', () => {
+    render(<AddSSHHostDialog {...defaultProps} isOpen={false} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders all fields when open', () => {
+    render(<AddSSHHostDialog {...defaultProps} />)
+    expect(screen.getByRole('dialog')).toBeDefined()
+    expect(screen.getByLabelText('Name')).toBeDefined()
+    expect(screen.getByLabelText('Hostname')).toBeDefined()
+    expect(screen.getByLabelText('User')).toBeDefined()
+    expect(screen.getByLabelText('Port')).toBeDefined()
+    expect(screen.getByLabelText('Identity File')).toBeDefined()
+  })
+
+  it('validates required fields before submitting', async () => {
+    render(<AddSSHHostDialog {...defaultProps} onSave={defaultProps.onSave} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/name is required/i)).toBeDefined()
+    })
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+  })
+
+  it('validates hostname is required', async () => {
+    render(<AddSSHHostDialog {...defaultProps} onSave={defaultProps.onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'myhost' } })
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/hostname is required/i)).toBeDefined()
+    })
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+  })
+
+  it('validates user is required', async () => {
+    render(<AddSSHHostDialog {...defaultProps} onSave={defaultProps.onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'myhost' } })
+    fireEvent.change(screen.getByLabelText('Hostname'), { target: { value: 'myhost.example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/user is required/i)).toBeDefined()
+    })
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+  })
+
+  it('validates port range', async () => {
+    render(<AddSSHHostDialog {...defaultProps} onSave={defaultProps.onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'myhost' } })
+    fireEvent.change(screen.getByLabelText('Hostname'), { target: { value: 'myhost.example.com' } })
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'ubuntu' } })
+    fireEvent.change(screen.getByLabelText('Port'), { target: { value: '99999' } })
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/port must be between/i)).toBeDefined()
+    })
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+  })
+
+  it('calls onSave with correct data when valid', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(<AddSSHHostDialog {...defaultProps} onSave={onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'staging' } })
+    fireEvent.change(screen.getByLabelText('Hostname'), { target: { value: 'staging.example.com' } })
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'deploy' } })
+    fireEvent.change(screen.getByLabelText('Port'), { target: { value: '2222' } })
+    fireEvent.change(screen.getByLabelText('Identity File'), { target: { value: '~/.ssh/staging_rsa' } })
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith<[SSHConfigHost]>({
+        name: 'staging',
+        hostname: 'staging.example.com',
+        user: 'deploy',
+        port: 2222,
+        identity_file: '~/.ssh/staging_rsa',
+      })
+    })
+  })
+
+  it('calls onSave without port and identity_file when not provided', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(<AddSSHHostDialog {...defaultProps} onSave={onSave} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'simple' } })
+    fireEvent.change(screen.getByLabelText('Hostname'), { target: { value: 'simple.example.com' } })
+    fireEvent.change(screen.getByLabelText('User'), { target: { value: 'ubuntu' } })
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith<[SSHConfigHost]>({
+        name: 'simple',
+        hostname: 'simple.example.com',
+        user: 'ubuntu',
+      })
+    })
+  })
+
+  it('shows saveError', () => {
+    render(<AddSSHHostDialog {...defaultProps} saveError="host already exists" />)
+    expect(screen.getByText(/host already exists/i)).toBeDefined()
+  })
+
+  it('cancel calls onClose', () => {
+    const onClose = vi.fn()
+    render(<AddSSHHostDialog {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('resets form to empty on each open', () => {
+    const { rerender } = render(<AddSSHHostDialog {...defaultProps} isOpen={false} />)
+
+    // Open dialog
+    rerender(<AddSSHHostDialog {...defaultProps} isOpen={true} />)
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'typed-name' } })
+
+    // Close and re-open
+    rerender(<AddSSHHostDialog {...defaultProps} isOpen={false} />)
+    rerender(<AddSSHHostDialog {...defaultProps} isOpen={true} />)
+
+    // Form should be reset
+    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('')
+  })
+
+  it('disables Save button while saving', () => {
+    render(<AddSSHHostDialog {...defaultProps} isSaving={true} />)
+    const saveBtn = screen.getByRole('button', { name: /saving/i })
+    expect(saveBtn).toBeDefined()
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/frontend/src/components/AddSSHHostDialog.tsx
+++ b/frontend/src/components/AddSSHHostDialog.tsx
@@ -1,0 +1,243 @@
+import React, { useState, useEffect } from 'react'
+import type { SSHConfigHost } from '../schemas'
+import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+
+interface AddSSHHostDialogProps {
+  isOpen: boolean
+  isSaving: boolean
+  saveError: string | null
+  onSave: (host: SSHConfigHost) => Promise<void>
+  onClose: () => void
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '5px 8px',
+  backgroundColor: '#3c3c3c',
+  color: '#d4d4d4',
+  border: '1px solid #555',
+  borderRadius: '3px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '13px',
+  boxSizing: 'border-box',
+}
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '11px',
+  color: '#888',
+  marginBottom: '4px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+}
+
+const fieldStyle: React.CSSProperties = {
+  marginBottom: '12px',
+}
+
+export const AddSSHHostDialog: React.FC<AddSSHHostDialogProps> = ({
+  isOpen,
+  isSaving,
+  saveError,
+  onSave,
+  onClose,
+}) => {
+  const [name, setName] = useState('')
+  const [hostname, setHostname] = useState('')
+  const [user, setUser] = useState('')
+  const [port, setPort] = useState('')
+  const [identityFile, setIdentityFile] = useState('')
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  // Reset form to empty every time dialog opens
+  useEffect(() => {
+    if (isOpen) {
+      setName('')
+      setHostname('')
+      setUser('')
+      setPort('')
+      setIdentityFile('')
+      setValidationError(null)
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const handleSave = async () => {
+    setValidationError(null)
+
+    if (!name.trim()) {
+      setValidationError('Name is required.')
+      return
+    }
+    if (!hostname.trim()) {
+      setValidationError('Hostname is required.')
+      return
+    }
+    if (!user.trim()) {
+      setValidationError('User is required.')
+      return
+    }
+
+    let portNum: number | undefined
+    if (port.trim() !== '') {
+      portNum = parseInt(port, 10)
+      if (isNaN(portNum) || portNum < 1 || portNum > 65535) {
+        setValidationError('Port must be between 1 and 65535.')
+        return
+      }
+    }
+
+    const host: SSHConfigHost = {
+      name: name.trim(),
+      hostname: hostname.trim(),
+      user: user.trim(),
+      ...(portNum !== undefined ? { port: portNum } : {}),
+      ...(identityFile.trim() ? { identity_file: identityFile.trim() } : {}),
+    }
+
+    await onSave(host)
+  }
+
+  const error = validationError ?? saveError
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add SSH host"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1100,
+      }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        style={{
+          backgroundColor: '#252526',
+          border: '1px solid #444',
+          borderRadius: '6px',
+          padding: '20px 24px',
+          width: '360px',
+          fontFamily: TERMINAL_FONT_FAMILY,
+          color: '#d4d4d4',
+        }}
+      >
+        <div style={{ fontSize: '14px', fontWeight: 600, marginBottom: '16px', color: '#e0e0e0' }}>
+          Add SSH Host
+        </div>
+
+        <div style={fieldStyle}>
+          <label htmlFor="ssh-host-name" style={labelStyle}>Alias</label>
+          <input
+            id="ssh-host-name"
+            type="text"
+            value={name}
+            onChange={(e) => { setName(e.target.value); setValidationError(null) }}
+            placeholder="prod-web"
+            style={inputStyle}
+            aria-label="Name"
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label htmlFor="ssh-host-hostname" style={labelStyle}>Hostname</label>
+          <input
+            id="ssh-host-hostname"
+            type="text"
+            value={hostname}
+            onChange={(e) => { setHostname(e.target.value); setValidationError(null) }}
+            placeholder="prod.example.com"
+            style={inputStyle}
+            aria-label="Hostname"
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label htmlFor="ssh-host-user" style={labelStyle}>User</label>
+          <input
+            id="ssh-host-user"
+            type="text"
+            value={user}
+            onChange={(e) => { setUser(e.target.value); setValidationError(null) }}
+            placeholder="ubuntu"
+            style={inputStyle}
+            aria-label="User"
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label htmlFor="ssh-host-port" style={labelStyle}>Port (optional)</label>
+          <input
+            id="ssh-host-port"
+            type="number"
+            value={port}
+            onChange={(e) => { setPort(e.target.value); setValidationError(null) }}
+            placeholder="22"
+            style={inputStyle}
+            aria-label="Port"
+          />
+        </div>
+
+        <div style={fieldStyle}>
+          <label htmlFor="ssh-host-identity-file" style={labelStyle}>Identity File (optional)</label>
+          <input
+            id="ssh-host-identity-file"
+            type="text"
+            value={identityFile}
+            onChange={(e) => setIdentityFile(e.target.value)}
+            placeholder="~/.ssh/id_rsa"
+            style={inputStyle}
+            aria-label="Identity File"
+          />
+        </div>
+
+        {error && (
+          <div style={{ fontSize: '12px', color: '#f44747', marginBottom: '12px' }}>
+            {error}
+          </div>
+        )}
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button
+            onClick={onClose}
+            disabled={isSaving}
+            style={{
+              padding: '5px 14px',
+              backgroundColor: 'transparent',
+              color: '#888',
+              border: '1px solid #555',
+              borderRadius: '3px',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: '13px',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            style={{
+              padding: '5px 14px',
+              backgroundColor: '#0e639c',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '3px',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: '13px',
+              cursor: 'pointer',
+              opacity: isSaving ? 0.6 : 1,
+            }}
+          >
+            {isSaving ? 'Saving…' : 'Add'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/PaneSettingsDialog.tsx
+++ b/frontend/src/components/PaneSettingsDialog.tsx
@@ -10,6 +10,7 @@ interface PaneSettingsDialogProps {
   isSaving: boolean
   onSave: (updated: PaneConfig) => Promise<void>
   onClose: () => void
+  onAddSSHHost: () => void
 }
 
 const PANE_TYPES: Array<{ value: PaneConfig['type']; label: string }> = [
@@ -51,6 +52,7 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   isSaving,
   onSave,
   onClose,
+  onAddSSHHost,
 }) => {
   const [type, setType] = useState<PaneConfig['type']>('local')
   const [shell, setShell] = useState('')
@@ -166,22 +168,37 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
         {needsConnection && (
           <div style={fieldStyle}>
             <label style={labelStyle}>Connection</label>
-            {sshConnectionNames.length === 0 ? (
-              <div style={{ fontSize: '12px', color: '#666', fontStyle: 'italic' }}>
-                No SSH connections configured in config.yaml
-              </div>
-            ) : (
+            <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
               <select
                 value={connection}
                 onChange={(e) => { setConnection(e.target.value); setValidationError(null) }}
-                style={inputStyle}
+                style={{ ...inputStyle, flex: 1 }}
               >
                 <option value="">— select connection —</option>
                 {sshConnectionNames.map((name) => (
                   <option key={name} value={name}>{name}</option>
                 ))}
               </select>
-            )}
+              <button
+                onClick={onAddSSHHost}
+                style={{
+                  padding: '5px 10px',
+                  backgroundColor: 'transparent',
+                  color: '#888',
+                  border: '1px solid #555',
+                  borderRadius: '3px',
+                  fontFamily: TERMINAL_FONT_FAMILY,
+                  fontSize: '13px',
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                + Add
+              </button>
+            </div>
+            <div style={{ fontSize: '11px', color: '#555', marginTop: '4px' }}>
+              Edit connections in ~/.ssh/config
+            </div>
           </div>
         )}
 
@@ -245,7 +262,7 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
           </button>
           <button
             onClick={handleSave}
-            disabled={isSaving || (needsConnection && sshConnectionNames.length === 0)}
+            disabled={isSaving || (needsConnection && !connection)}
             style={{
               padding: '5px 14px',
               backgroundColor: '#0e639c',

--- a/frontend/src/hooks/usePaneSettings.test.ts
+++ b/frontend/src/hooks/usePaneSettings.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePaneSettings } from './usePaneSettings'
-import type { LayoutNode, PaneConfig } from '../schemas'
+import type { LayoutNode, PaneConfig, SSHConfigHost } from '../schemas'
 
 const mockLayout: LayoutNode = {
   direction: 'horizontal',
@@ -148,5 +148,70 @@ describe('usePaneSettings', () => {
 
     // Dialog should still close even if restart fails
     expect(result.current.isOpen).toBe(false)
+  })
+
+  describe('addSSHConfigHost', () => {
+    const mockHost: SSHConfigHost = {
+      name: 'new-host',
+      hostname: 'new.example.com',
+      user: 'ubuntu',
+    }
+
+    it('posts to /api/ssh-config/hosts and refreshes ssh connection names', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) }) // initial GET ssh-connections
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })            // POST ssh-config/hosts
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: ['new-host'] }) }) // GET ssh-connections refresh
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+      await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
+
+      await act(async () => {
+        const name = await result.current.addSSHConfigHost(mockHost)
+        expect(name).toBe('new-host')
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/ssh-config/hosts',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      await waitFor(() => expect(result.current.sshConnectionNames).toEqual(['new-host']))
+    })
+
+    it('throws on POST failure', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ error: 'host already exists' }),
+        })
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+      await expect(
+        act(async () => {
+          await result.current.addSSHConfigHost(mockHost)
+        }),
+      ).rejects.toThrow('host already exists')
+    })
+
+    it('returns host name on success', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: ['new-host'] }) })
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+
+      let returnedName = ''
+      await act(async () => {
+        returnedName = await result.current.addSSHConfigHost(mockHost)
+      })
+      expect(returnedName).toBe('new-host')
+    })
   })
 })

--- a/frontend/src/hooks/usePaneSettings.ts
+++ b/frontend/src/hooks/usePaneSettings.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { SSHConnectionsResponseSchema } from '../schemas'
-import type { LayoutNode, PaneConfig } from '../schemas'
+import type { LayoutNode, PaneConfig, SSHConfigHost } from '../schemas'
 import { replacePaneInTree } from '../utils/layoutTree'
 
 export function usePaneSettings(
@@ -63,5 +63,21 @@ export function usePaneSettings(
     [layout, onLayoutChange],
   )
 
-  return { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings }
+  const addSSHConfigHost = useCallback(async (host: SSHConfigHost): Promise<string> => {
+    const r = await fetch('/api/ssh-config/hosts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(host),
+    })
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}))
+      throw new Error((body as { error?: string }).error ?? `HTTP ${r.status}`)
+    }
+    // Refresh the ssh connection names list
+    const data = await fetch('/api/ssh-connections').then((res) => res.json())
+    setSshConnectionNames(SSHConnectionsResponseSchema.parse(data).names)
+    return host.name
+  }, [])
+
+  return { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost }
 }

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -6,6 +6,8 @@ import {
   LayoutChildSchema,
   SessionInfoSchema,
   WSControlMessageSchema,
+  SSHConfigHostSchema,
+  SSHConfigHostsResponseSchema,
 } from './index'
 
 describe('DisplayConfigSchema', () => {
@@ -157,6 +159,100 @@ describe('WSControlMessageSchema', () => {
 
   it('rejects unknown type', () => {
     const result = WSControlMessageSchema.safeParse({ type: 'unknown' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SSHConfigHostSchema', () => {
+  it('accepts valid host with all fields', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+      port: 22,
+      identity_file: '~/.ssh/id_rsa',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts valid host without optional fields', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing name', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty name', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: '',
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing hostname', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      user: 'ubuntu',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing user', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      hostname: 'myhost.example.com',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects port above 65535', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+      port: 70000,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects negative port', () => {
+    const result = SSHConfigHostSchema.safeParse({
+      name: 'myhost',
+      hostname: 'myhost.example.com',
+      user: 'ubuntu',
+      port: -1,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('SSHConfigHostsResponseSchema', () => {
+  it('accepts valid response with hosts', () => {
+    const result = SSHConfigHostsResponseSchema.safeParse({
+      hosts: [{ name: 'myhost', hostname: 'myhost.example.com', user: 'ubuntu' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts empty hosts array', () => {
+    const result = SSHConfigHostsResponseSchema.safeParse({ hosts: [] })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing hosts field', () => {
+    const result = SSHConfigHostsResponseSchema.safeParse({})
     expect(result.success).toBe(false)
   })
 })

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -80,3 +80,19 @@ export const SSHConnectionsResponseSchema = z.object({
 })
 
 export type SSHConnectionsResponse = z.infer<typeof SSHConnectionsResponseSchema>
+
+export const SSHConfigHostSchema = z.object({
+  name: z.string().min(1),
+  hostname: z.string().min(1),
+  user: z.string().min(1),
+  port: z.number().int().min(0).max(65535).optional(),
+  identity_file: z.string().optional(),
+})
+
+export type SSHConfigHost = z.infer<typeof SSHConfigHostSchema>
+
+export const SSHConfigHostsResponseSchema = z.object({
+  hosts: z.array(SSHConfigHostSchema),
+})
+
+export type SSHConfigHostsResponse = z.infer<typeof SSHConfigHostsResponseSchema>

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"regexp"
 	"sort"
 	"sync/atomic"
 
@@ -10,13 +11,15 @@ import (
 
 	"panemux/internal/config"
 	"panemux/internal/session"
+	"panemux/internal/sshconfig"
 )
 
 // Handler provides REST API endpoints.
 type Handler struct {
-	cfg      *config.Config
-	manager  *session.Manager
-	editMode atomic.Bool
+	cfg           *config.Config
+	manager       *session.Manager
+	editMode      atomic.Bool
+	sshConfigPath string
 }
 
 type editModeResponse struct {
@@ -27,9 +30,31 @@ type sshConnectionsResponse struct {
 	Names []string `json:"names"`
 }
 
+type sshConfigHostsResponse struct {
+	Hosts []sshConfigHostInfo `json:"hosts"`
+}
+
+type sshConfigHostInfo struct {
+	Name         string `json:"name"`
+	Hostname     string `json:"hostname"`
+	User         string `json:"user"`
+	Port         int    `json:"port,omitempty"`
+	IdentityFile string `json:"identity_file,omitempty"`
+}
+
+type sshConfigHostRequest struct {
+	Name         string `json:"name"`
+	Hostname     string `json:"hostname"`
+	User         string `json:"user"`
+	Port         int    `json:"port,omitempty"`
+	IdentityFile string `json:"identity_file,omitempty"`
+}
+
+var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
+
 // NewHandler creates a new API handler.
 func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
-	return &Handler{cfg: cfg, manager: manager}
+	return &Handler{cfg: cfg, manager: manager, sshConfigPath: sshconfig.DefaultPath()}
 }
 
 // GetLayout returns the current layout configuration.
@@ -195,14 +220,115 @@ type sessionInfo struct {
 	State string `json:"state"`
 }
 
-// GetSSHConnections returns the sorted names of configured SSH connections.
+// GetSSHConnections returns the sorted names of configured SSH connections,
+// merging both yaml ssh_connections and ~/.ssh/config hosts (yaml takes precedence on conflict).
 func (h *Handler) GetSSHConnections(w http.ResponseWriter, r *http.Request) {
-	names := make([]string, 0, len(h.cfg.SSHConnections))
+	seen := make(map[string]struct{})
+	names := make([]string, 0)
+
+	// First add yaml-configured connections
 	for k := range h.cfg.SSHConnections {
+		seen[k] = struct{}{}
 		names = append(names, k)
 	}
+
+	// Then add SSH config hosts not already in the yaml map
+	hosts, _ := sshconfig.ParseHosts(h.sshConfigPath)
+	for _, host := range hosts {
+		if _, exists := seen[host.Name]; !exists {
+			names = append(names, host.Name)
+		}
+	}
+
 	sort.Strings(names)
 	writeJSON(w, sshConnectionsResponse{Names: names})
+}
+
+// GetSSHConfigHosts returns all hosts from ~/.ssh/config with full details.
+func (h *Handler) GetSSHConfigHosts(w http.ResponseWriter, r *http.Request) {
+	hosts, err := sshconfig.ParseHosts(h.sshConfigPath)
+	if err != nil {
+		http.Error(w, "failed to read ssh config", http.StatusInternalServerError)
+		return
+	}
+
+	infos := make([]sshConfigHostInfo, 0, len(hosts))
+	for _, host := range hosts {
+		infos = append(infos, sshConfigHostInfo{
+			Name:         host.Name,
+			Hostname:     host.Hostname,
+			User:         host.User,
+			Port:         host.Port,
+			IdentityFile: host.IdentityFile,
+		})
+	}
+	writeJSON(w, sshConfigHostsResponse{Hosts: infos})
+}
+
+// PostSSHConfigHost adds a new host to ~/.ssh/config.
+func (h *Handler) PostSSHConfigHost(w http.ResponseWriter, r *http.Request) {
+	var req sshConfigHostRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate
+	if req.Name == "" {
+		writeValidationError(w, "name is required")
+		return
+	}
+	if !validHostName.MatchString(req.Name) {
+		writeValidationError(w, "name must contain only alphanumeric characters, hyphens, underscores, or dots")
+		return
+	}
+	if req.Hostname == "" {
+		writeValidationError(w, "hostname is required")
+		return
+	}
+	if req.User == "" {
+		writeValidationError(w, "user is required")
+		return
+	}
+	if req.Port < 0 || req.Port > 65535 {
+		writeValidationError(w, "port must be between 0 and 65535")
+		return
+	}
+
+	// Check for duplicate
+	hosts, err := sshconfig.ParseHosts(h.sshConfigPath)
+	if err != nil {
+		http.Error(w, "failed to read ssh config", http.StatusInternalServerError)
+		return
+	}
+	for _, host := range hosts {
+		if host.Name == req.Name {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "host already exists"})
+			return
+		}
+	}
+
+	// Append the new host
+	if err := sshconfig.AppendHost(h.sshConfigPath, sshconfig.Host{
+		Name:         req.Name,
+		Hostname:     req.Hostname,
+		User:         req.User,
+		Port:         req.Port,
+		IdentityFile: req.IdentityFile,
+	}); err != nil {
+		http.Error(w, "failed to write ssh config", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func writeValidationError(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnprocessableEntity)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -40,6 +40,12 @@ func (m *mockSession) Close() error                { return nil }
 
 func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 	h := NewHandler(cfg, mgr)
+	// Use a temp empty SSH config to avoid real ~/.ssh/config leaking into tests
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	return setupRouterWithHandler(h)
+}
+
+func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r := chi.NewRouter()
 	r.Get("/api/layout", h.GetLayout)
 	r.Put("/api/layout", h.PutLayout)
@@ -51,6 +57,8 @@ func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 	r.Get("/api/edit-mode", h.GetEditMode)
 	r.Put("/api/edit-mode", h.PutEditMode)
 	r.Get("/api/ssh-connections", h.GetSSHConnections)
+	r.Get("/api/ssh-config/hosts", h.GetSSHConfigHosts)
+	r.Post("/api/ssh-config/hosts", h.PostSSHConfigHost)
 	return r
 }
 
@@ -502,4 +510,224 @@ func TestGetSSHConnections_NilMap(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.NotNil(t, resp.Names)
 	assert.Empty(t, resp.Names)
+}
+
+// writeTempSSHConfigForAPI writes a minimal SSH config file with given content and returns its path.
+func writeTempSSHConfigForAPI(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
+	return f
+}
+
+func TestGetSSHConnections_MergesSSHConfigHosts(t *testing.T) {
+	sshConfigPath := writeTempSSHConfigForAPI(t, "Host ssh-host\n    HostName ssh.example.com\n    User alice\n")
+
+	cfg := defaultTestConfig()
+	cfg.SSHConnections = map[string]config.SSHConnection{
+		"yaml-conn": {Host: "yaml.example.com", Port: 22, User: "bob"},
+	}
+
+	h := NewHandler(cfg, session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-connections", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConnectionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.ElementsMatch(t, []string{"yaml-conn", "ssh-host"}, resp.Names)
+	// Must be sorted
+	assert.Equal(t, []string{"ssh-host", "yaml-conn"}, resp.Names)
+}
+
+func TestGetSSHConnections_SSHConfigTakesPrecedenceOnConflict(t *testing.T) {
+	// When both yaml and ssh config have same name, yaml takes precedence (name appears once)
+	sshConfigPath := writeTempSSHConfigForAPI(t, "Host shared\n    HostName ssh.example.com\n    User alice\n")
+
+	cfg := defaultTestConfig()
+	cfg.SSHConnections = map[string]config.SSHConnection{
+		"shared": {Host: "yaml.example.com", Port: 22, User: "bob"},
+	}
+
+	h := NewHandler(cfg, session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-connections", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConnectionsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	// Deduplication: "shared" should appear only once
+	assert.Equal(t, []string{"shared"}, resp.Names)
+}
+
+func TestGetSSHConfigHosts_ReturnsHosts(t *testing.T) {
+	sshConfigPath := writeTempSSHConfigForAPI(t, "Host myhost\n    HostName myhost.example.com\n    User ubuntu\n    Port 2222\n")
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-config/hosts", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConfigHostsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Hosts, 1)
+	assert.Equal(t, "myhost", resp.Hosts[0].Name)
+	assert.Equal(t, "myhost.example.com", resp.Hosts[0].Hostname)
+	assert.Equal(t, "ubuntu", resp.Hosts[0].User)
+	assert.Equal(t, 2222, resp.Hosts[0].Port)
+}
+
+func TestGetSSHConfigHosts_Empty(t *testing.T) {
+	sshConfigPath := writeTempSSHConfigForAPI(t, "")
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/ssh-config/hosts", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp sshConfigHostsResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Hosts)
+}
+
+func TestPostSSHConfigHost_ValidHost_201(t *testing.T) {
+	dir := t.TempDir()
+	sshConfigPath := filepath.Join(dir, "config")
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{
+		Name:     "new-host",
+		Hostname: "new.example.com",
+		User:     "deploy",
+		Port:     22,
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	// Verify it was written to the file
+	data, err := os.ReadFile(sshConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Host new-host")
+}
+
+func TestPostSSHConfigHost_MissingName_422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Hostname: "host.example.com", User: "ubuntu"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostSSHConfigHost_InvalidNameChars_422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Name: "bad name!", Hostname: "h.example.com", User: "u"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostSSHConfigHost_MissingHostname_422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", User: "ubuntu"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostSSHConfigHost_MissingUser_422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", Hostname: "myhost.example.com"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostSSHConfigHost_PortOutOfRange_422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", Hostname: "myhost.example.com", User: "ubuntu", Port: 70000})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostSSHConfigHost_DuplicateName_409(t *testing.T) {
+	sshConfigPath := writeTempSSHConfigForAPI(t, "Host existing\n    HostName existing.example.com\n    User ubuntu\n")
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = sshConfigPath
+	r := setupRouterWithHandler(h)
+
+	body, _ := json.Marshal(sshConfigHostRequest{Name: "existing", Hostname: "new.example.com", User: "ubuntu"})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestPostSSHConfigHost_InvalidBody_400(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewBufferString("not json"))
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,8 +60,9 @@ type Config struct {
 	Display        DisplayConfig            `yaml:"display,omitempty" json:"display"`
 
 	// internal: raw yaml node for comment-preserving writes
-	rawNode  *yaml.Node
-	filePath string
+	rawNode       *yaml.Node
+	filePath      string
+	sshConfigPath string // overridable for tests; empty = use sshconfig.DefaultPath()
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,9 +73,26 @@ func TestValidate_SSHPaneConnectionNotDefined_Error(t *testing.T) {
 	cfg := validConfig()
 	cfg.Layout.Children[0].Pane.Type = "ssh"
 	cfg.Layout.Children[0].Pane.Connection = "nonexistent"
+	// Point at an empty temp dir so ~/.ssh/config is not read
+	cfg.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	err := cfg.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection")
+}
+
+// TestValidate_SSHPaneInSSHConfig_NoError verifies that a pane whose connection
+// name is defined in ~/.ssh/config (not in yaml ssh_connections) passes validation.
+// This is the positive counterpart of TestValidate_SSHPaneConnectionNotDefined_Error.
+func TestValidate_SSHPaneInSSHConfig_NoError(t *testing.T) {
+	sshCfg := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, os.WriteFile(sshCfg, []byte("Host myserver\n    HostName 192.168.1.1\n    User deploy\n"), 0600))
+
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.Type = "ssh"
+	cfg.Layout.Children[0].Pane.Connection = "myserver"
+	cfg.sshConfigPath = sshCfg
+
+	assert.NoError(t, cfg.Validate())
 }
 
 func TestValidate_ServerPortOutOfRange_Error(t *testing.T) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -27,7 +27,11 @@ func (c *Config) Validate() error {
 	// Also accept hosts from ~/.ssh/config as valid connections.
 	// This allows panes to reference ssh config host aliases without
 	// duplicating connection details in ssh_connections.
-	if hosts, err := sshconfig.ParseHosts(sshconfig.DefaultPath()); err == nil {
+	sshCfgPath := c.sshConfigPath
+	if sshCfgPath == "" {
+		sshCfgPath = sshconfig.DefaultPath()
+	}
+	if hosts, err := sshconfig.ParseHosts(sshCfgPath); err == nil {
 		for _, h := range hosts {
 			if _, exists := sshConns[h.Name]; !exists {
 				sshConns[h.Name] = SSHConnection{Host: h.Hostname}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"panemux/internal/sshconfig"
 )
 
 var tmuxSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
@@ -21,6 +23,16 @@ func (c *Config) Validate() error {
 	sshConns := c.SSHConnections
 	if sshConns == nil {
 		sshConns = make(map[string]SSHConnection)
+	}
+	// Also accept hosts from ~/.ssh/config as valid connections.
+	// This allows panes to reference ssh config host aliases without
+	// duplicating connection details in ssh_connections.
+	if hosts, err := sshconfig.ParseHosts(sshconfig.DefaultPath()); err == nil {
+		for _, h := range hosts {
+			if _, exists := sshConns[h.Name]; !exists {
+				sshConns[h.Name] = SSHConnection{Host: h.Hostname}
+			}
+		}
 	}
 	errs = append(errs, validateLayoutNode(c.Layout, sshConns)...)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,6 +46,8 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Get("/edit-mode", apiHandler.GetEditMode)
 		r.Put("/edit-mode", apiHandler.PutEditMode)
 		r.Get("/ssh-connections", apiHandler.GetSSHConnections)
+		r.Get("/ssh-config/hosts", apiHandler.GetSSHConfigHosts)
+		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
 	})
 
 	// WebSocket

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -28,6 +28,7 @@ func createSession(pane *config.PaneConfig, sshConns map[string]config.SSHConnec
 		if err != nil {
 			return nil, err
 		}
+		cfg.Cwd = pane.Cwd
 		return NewSSH(pane.ID, pane.Title, cfg)
 
 	case TypeTmux:
@@ -38,6 +39,7 @@ func createSession(pane *config.PaneConfig, sshConns map[string]config.SSHConnec
 		if err != nil {
 			return nil, err
 		}
+		cfg.Cwd = pane.Cwd
 		return NewTmuxSSH(pane.ID, pane.Title, pane.TmuxSession, cfg)
 
 	default:

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -4,46 +4,78 @@ import (
 	"fmt"
 
 	"panemux/internal/config"
+	"panemux/internal/sshconfig"
 )
 
 // CreateFromConfig creates a Session from a PaneConfig and SSH connections map.
+// For SSH types, if the connection is not found in sshConns, it falls back to ~/.ssh/config.
 func CreateFromConfig(pane *config.PaneConfig, sshConns map[string]config.SSHConnection) (Session, error) {
+	return createSession(pane, sshConns, sshconfig.DefaultPath())
+}
+
+// createSession is the internal, testable version of CreateFromConfig that accepts
+// an explicit SSH config path instead of always using the default.
+func createSession(pane *config.PaneConfig, sshConns map[string]config.SSHConnection, sshConfigPath string) (Session, error) {
 	switch Type(pane.Type) {
 	case TypeLocal:
 		return NewLocal(pane.ID, pane.Shell, pane.Cwd, pane.Title)
 
 	case TypeSSH:
-		conn, ok := sshConns[pane.Connection]
-		if !ok {
-			return nil, fmt.Errorf("ssh connection %q not found", pane.Connection)
+		cfg, err := resolveSSHConfig(pane.Connection, sshConns, sshConfigPath)
+		if err != nil {
+			return nil, err
 		}
-		return NewSSH(pane.ID, pane.Title, SSHConfig{
-			Host:           conn.Host,
-			Port:           conn.Port,
-			User:           conn.User,
-			KeyFile:        conn.KeyFile,
-			Password:       conn.Password,
-			KnownHostsFile: conn.KnownHostsFile,
-		})
+		return NewSSH(pane.ID, pane.Title, cfg)
 
 	case TypeTmux:
 		return NewTmuxLocal(pane.ID, pane.Title, pane.TmuxSession)
 
 	case TypeSSHTmux:
-		conn, ok := sshConns[pane.Connection]
-		if !ok {
-			return nil, fmt.Errorf("ssh connection %q not found", pane.Connection)
+		cfg, err := resolveSSHConfig(pane.Connection, sshConns, sshConfigPath)
+		if err != nil {
+			return nil, err
 		}
-		return NewTmuxSSH(pane.ID, pane.Title, pane.TmuxSession, SSHConfig{
+		return NewTmuxSSH(pane.ID, pane.Title, pane.TmuxSession, cfg)
+
+	default:
+		return nil, fmt.Errorf("unknown session type: %s", pane.Type)
+	}
+}
+
+// resolveSSHConfig looks up the SSH connection by name, first in the sshConns map,
+// then falling back to the SSH config file at sshConfigPath.
+func resolveSSHConfig(name string, sshConns map[string]config.SSHConnection, sshConfigPath string) (SSHConfig, error) {
+	if conn, ok := sshConns[name]; ok {
+		return SSHConfig{
 			Host:           conn.Host,
 			Port:           conn.Port,
 			User:           conn.User,
 			KeyFile:        conn.KeyFile,
 			Password:       conn.Password,
 			KnownHostsFile: conn.KnownHostsFile,
-		})
-
-	default:
-		return nil, fmt.Errorf("unknown session type: %s", pane.Type)
+		}, nil
 	}
+
+	// Fall back to ~/.ssh/config
+	hosts, err := sshconfig.ParseHosts(sshConfigPath)
+	if err != nil {
+		return SSHConfig{}, fmt.Errorf("ssh connection %q not found", name)
+	}
+
+	for _, h := range hosts {
+		if h.Name == name {
+			port := h.Port
+			if port == 0 {
+				port = 22
+			}
+			return SSHConfig{
+				Host:    h.Hostname,
+				Port:    port,
+				User:    h.User,
+				KeyFile: h.IdentityFile,
+			}, nil
+		}
+	}
+
+	return SSHConfig{}, fmt.Errorf("ssh connection %q not found", name)
 }

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -2,6 +2,9 @@ package session
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"panemux/internal/config"
 	"panemux/internal/sshconfig"
@@ -68,11 +71,16 @@ func resolveSSHConfig(name string, sshConns map[string]config.SSHConnection, ssh
 			if port == 0 {
 				port = 22
 			}
+			keyFile := h.IdentityFile
+			if strings.HasPrefix(keyFile, "~/") {
+				home, _ := os.UserHomeDir()
+				keyFile = filepath.Join(home, keyFile[2:])
+			}
 			return SSHConfig{
 				Host:    h.Hostname,
 				Port:    port,
 				User:    h.User,
-				KeyFile: h.IdentityFile,
+				KeyFile: keyFile,
 			}, nil
 		}
 	}

--- a/internal/session/factory_test.go
+++ b/internal/session/factory_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,4 +45,91 @@ func TestCreateFromConfig_SSHMissing(t *testing.T) {
 	_, err := CreateFromConfig(pane, map[string]config.SSHConnection{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+// writeTempSSHConfig writes a minimal SSH config file with a Host block and returns the path.
+func writeTempSSHConfig(t *testing.T, name, hostname, user string, port int) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+	content := "Host " + name + "\n"
+	content += "    HostName " + hostname + "\n"
+	content += "    User " + user + "\n"
+	if port != 0 {
+		content += "    Port " + itoa(port) + "\n"
+	}
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
+	return f
+}
+
+func itoa(i int) string {
+	return string(rune('0'+i%10)) // simple, only used for port ≤9 in tests
+}
+
+func TestCreateSession_SSHFallbackToSSHConfig(t *testing.T) {
+	// pane.Connection "ssh-alias" not in sshConns map → should be found in ~/.ssh/config
+	sshConfigPath := writeTempSSHConfig(t, "ssh-alias", "ssh.example.com", "alice", 0)
+
+	pane := &config.PaneConfig{
+		ID:         "test-ssh-fallback",
+		Type:       "ssh",
+		Connection: "ssh-alias",
+	}
+
+	// This should not fail — the SSH connection is resolved from ssh config
+	// (it will fail to connect, but that's a network issue, not a config one)
+	// We only test that the error is NOT "not found"
+	_, err := createSession(pane, map[string]config.SSHConnection{}, sshConfigPath)
+	// The error (if any) should be a connection error, not "not found"
+	if err != nil {
+		assert.NotContains(t, err.Error(), "not found")
+	}
+}
+
+func TestCreateSession_SSHFallback_NotInSSHConfig_Errors(t *testing.T) {
+	sshConfigPath := writeTempSSHConfig(t, "other-host", "other.example.com", "bob", 0)
+
+	pane := &config.PaneConfig{
+		ID:         "test-ssh-missing",
+		Type:       "ssh",
+		Connection: "does-not-exist",
+	}
+	_, err := createSession(pane, map[string]config.SSHConnection{}, sshConfigPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestCreateSession_SSHTmuxFallbackToSSHConfig(t *testing.T) {
+	sshConfigPath := writeTempSSHConfig(t, "tmux-host", "tmux.example.com", "carol", 0)
+
+	pane := &config.PaneConfig{
+		ID:          "test-ssh-tmux-fallback",
+		Type:        "ssh_tmux",
+		Connection:  "tmux-host",
+		TmuxSession: "main",
+	}
+	_, err := createSession(pane, map[string]config.SSHConnection{}, sshConfigPath)
+	// Expect connection error, not "not found"
+	if err != nil {
+		assert.NotContains(t, err.Error(), "not found")
+	}
+}
+
+func TestCreateSession_SSHConfigPort_UsedWhenSet(t *testing.T) {
+	// Port 2 in test — won't actually connect, but let's verify it's read from config
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+	content := "Host myhost\n    HostName myhost.example.com\n    User myuser\n    Port 2222\n"
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
+
+	pane := &config.PaneConfig{
+		ID:         "test-port",
+		Type:       "ssh",
+		Connection: "myhost",
+	}
+	_, err := createSession(pane, map[string]config.SSHConnection{}, f)
+	// We only care that "not found" is NOT returned
+	if err != nil {
+		assert.NotContains(t, err.Error(), "not found")
+	}
 }

--- a/internal/session/factory_test.go
+++ b/internal/session/factory_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,7 +64,61 @@ func writeTempSSHConfig(t *testing.T, name, hostname, user string, port int) str
 }
 
 func itoa(i int) string {
-	return string(rune('0'+i%10)) // simple, only used for port ≤9 in tests
+	return fmt.Sprintf("%d", i)
+}
+
+// TestResolveSSHConfig_FromSSHConfigMap verifies that resolveSSHConfig returns
+// the correct values when the connection is found in the yaml sshConns map.
+func TestResolveSSHConfig_FromSSHConfigMap(t *testing.T) {
+	conns := map[string]config.SSHConnection{
+		"prod": {Host: "prod.example.com", Port: 2222, User: "deploy", KeyFile: "/home/user/.ssh/id_rsa"},
+	}
+	cfg, err := resolveSSHConfig("prod", conns, filepath.Join(t.TempDir(), "no-config"))
+	require.NoError(t, err)
+	assert.Equal(t, "prod.example.com", cfg.Host)
+	assert.Equal(t, 2222, cfg.Port)
+	assert.Equal(t, "deploy", cfg.User)
+	assert.Equal(t, "/home/user/.ssh/id_rsa", cfg.KeyFile)
+}
+
+// TestResolveSSHConfig_FallbackToSSHConfig verifies the ~/.ssh/config fallback path:
+// host is resolved, port defaults to 22, and IdentityFile with ~/ is expanded.
+func TestResolveSSHConfig_FallbackToSSHConfig(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	require.NoError(t, os.MkdirAll(sshDir, 0700))
+
+	sshCfgPath := filepath.Join(sshDir, "config")
+	content := "Host myserver\n    HostName 10.0.0.1\n    User admin\n    IdentityFile ~/.ssh/id_ed25519\n"
+	require.NoError(t, os.WriteFile(sshCfgPath, []byte(content), 0600))
+
+	// Temporarily override HOME so ~/ expansion uses our temp dir
+	t.Setenv("HOME", home)
+
+	cfg, err := resolveSSHConfig("myserver", nil, sshCfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.1", cfg.Host)
+	assert.Equal(t, 22, cfg.Port) // default when not set
+	assert.Equal(t, "admin", cfg.User)
+	// IdentityFile should have ~/ expanded to home
+	assert.Equal(t, filepath.Join(home, ".ssh", "id_ed25519"), cfg.KeyFile)
+}
+
+// TestResolveSSHConfig_PortFromSSHConfig verifies that an explicit Port in the
+// ssh config file is used as-is.
+func TestResolveSSHConfig_PortFromSSHConfig(t *testing.T) {
+	sshCfgPath := writeTempSSHConfig(t, "myhost", "myhost.example.com", "myuser", 2222)
+	cfg, err := resolveSSHConfig("myhost", nil, sshCfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, 2222, cfg.Port)
+}
+
+// TestResolveSSHConfig_NotFound verifies that a missing connection returns an error.
+func TestResolveSSHConfig_NotFound(t *testing.T) {
+	sshCfgPath := writeTempSSHConfig(t, "other", "other.example.com", "user", 0)
+	_, err := resolveSSHConfig("does-not-exist", nil, sshCfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestCreateSession_SSHFallbackToSSHConfig(t *testing.T) {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -164,6 +164,23 @@ func buildAuthMethods(cfg SSHConfig) ([]ssh.AuthMethod, error) {
 		methods = append(methods, ssh.Password(cfg.Password))
 	}
 
+	// If no explicit auth method, try common default key files (mirrors OpenSSH behaviour).
+	if len(methods) == 0 {
+		home, _ := os.UserHomeDir()
+		for _, name := range []string{"id_ed25519", "id_rsa", "id_ecdsa"} {
+			keyData, err := os.ReadFile(filepath.Join(home, ".ssh", name))
+			if err != nil {
+				continue
+			}
+			signer, err := ssh.ParsePrivateKey(keyData)
+			if err != nil {
+				continue
+			}
+			methods = append(methods, ssh.PublicKeys(signer))
+			break
+		}
+	}
+
 	if len(methods) == 0 {
 		return nil, fmt.Errorf("no auth methods configured for SSH connection")
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -6,12 +6,20 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
 )
+
+// validRemotePath is the CodeQL-recommended regex guard for shell arguments.
+// It matches absolute paths that contain no shell metacharacters, making the
+// value safe to embed in a remote shell command via shellQuotePath.
+// Allowed: any character except shell metacharacters (;|&$`'"<>(){}[]!\)
+// and control characters (newlines, null bytes, etc.).
+var validRemotePath = regexp.MustCompile(`^(/[^;|&$` + "`" + `'"<>()\[\]{}!\\\x00-\x1f\x7f]*)+$`)
 
 // SSHSession manages an SSH connection with a PTY.
 type SSHSession struct {
@@ -110,11 +118,17 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	sess.Stdout = pw
 	sess.Stderr = pw
 
-	// Start the shell. If a working directory is configured, use sess.Start()
-	// with an explicit cd so the shell opens in the requested directory.
+	// Start the shell. If a working directory is configured, validate it with
+	// the regex guard (CodeQL go/command-injection recommended pattern for
+	// arguments) before embedding it in the remote shell command.
 	// sess.Shell() and sess.Start() are mutually exclusive in the SSH protocol.
 	var startErr error
 	if cfg.Cwd != "" {
+		if !validRemotePath.MatchString(cfg.Cwd) {
+			sess.Close()
+			client.Close()
+			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
+		}
 		startErr = sess.Start(fmt.Sprintf("cd %s && exec $SHELL", shellQuotePath(cfg.Cwd)))
 	} else {
 		startErr = sess.Shell()

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"golang.org/x/crypto/ssh"
@@ -34,6 +35,13 @@ type SSHConfig struct {
 	KeyFile        string
 	Password       string
 	KnownHostsFile string
+	Cwd            string // initial working directory on the remote host
+}
+
+// shellQuotePath wraps path in single quotes and escapes any single quotes
+// within the path, making it safe to embed in a POSIX shell command.
+func shellQuotePath(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
 // NewSSH creates and starts a new SSH terminal session.
@@ -102,10 +110,19 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	sess.Stdout = pw
 	sess.Stderr = pw
 
-	if err := sess.Shell(); err != nil {
+	// Start the shell. If a working directory is configured, use sess.Start()
+	// with an explicit cd so the shell opens in the requested directory.
+	// sess.Shell() and sess.Start() are mutually exclusive in the SSH protocol.
+	var startErr error
+	if cfg.Cwd != "" {
+		startErr = sess.Start(fmt.Sprintf("cd %s && exec $SHELL", shellQuotePath(cfg.Cwd)))
+	} else {
+		startErr = sess.Shell()
+	}
+	if startErr != nil {
 		sess.Close()
 		client.Close()
-		return nil, fmt.Errorf("start shell: %w", err)
+		return nil, fmt.Errorf("start shell: %w", startErr)
 	}
 
 	s := &SSHSession{

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -68,6 +68,23 @@ func TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound(t *testing.T) {
 	assert.Len(t, methods, 1)
 }
 
+func TestShellQuotePath_Simple(t *testing.T) {
+	assert.Equal(t, "'/home/user/projects'", shellQuotePath("/home/user/projects"))
+}
+
+func TestShellQuotePath_WithSpaces(t *testing.T) {
+	assert.Equal(t, "'/home/user/my project'", shellQuotePath("/home/user/my project"))
+}
+
+func TestShellQuotePath_WithSingleQuote(t *testing.T) {
+	// /home/user/it's → '/home/user/it'\''s'
+	assert.Equal(t, `'/home/user/it'\''s'`, shellQuotePath("/home/user/it's"))
+}
+
+func TestShellQuotePath_Empty(t *testing.T) {
+	assert.Equal(t, "''", shellQuotePath(""))
+}
+
 func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {
 	_, err := buildHostKeyCallback("/nonexistent/path/known_hosts")
 	require.Error(t, err)

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -1,13 +1,72 @@
 package session
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
 )
+
+// generateTestKeyFile creates a real ed25519 private key file at the given path
+// and returns the path. Used by tests that need a valid SSH key without
+// requiring a real SSH server.
+func generateTestKeyFile(t *testing.T, path string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	block, err := gossh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(block), 0600))
+}
+
+// TestBuildAuthMethods_WithKeyFile verifies that a valid key file produces an auth method.
+func TestBuildAuthMethods_WithKeyFile(t *testing.T) {
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	generateTestKeyFile(t, keyPath)
+
+	cfg := SSHConfig{KeyFile: keyPath}
+	methods, err := buildAuthMethods(cfg)
+	require.NoError(t, err)
+	assert.Len(t, methods, 1)
+}
+
+// TestBuildAuthMethods_NoKeyNoPassword_NoDefaultKeys_Error verifies that when
+// neither KeyFile nor Password is set and no default keys exist, an error is returned.
+// This is the case that caused the 500 on Restart Session when ~/.ssh/config
+// entries don't specify IdentityFile.
+func TestBuildAuthMethods_NoKeyNoPassword_NoDefaultKeys_Error(t *testing.T) {
+	// Override HOME to a temp dir with no .ssh keys
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := SSHConfig{}
+	_, err := buildAuthMethods(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no auth methods")
+}
+
+// TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound verifies that when no
+// explicit KeyFile is set but a default key exists at ~/.ssh/id_ed25519,
+// it is used automatically (mirrors OpenSSH behaviour).
+// This tests the fix for the case where ~/.ssh/config entries omit IdentityFile.
+func TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound(t *testing.T) {
+	home := t.TempDir()
+	sshDir := filepath.Join(home, ".ssh")
+	require.NoError(t, os.MkdirAll(sshDir, 0700))
+
+	generateTestKeyFile(t, filepath.Join(sshDir, "id_ed25519"))
+	t.Setenv("HOME", home)
+
+	cfg := SSHConfig{}
+	methods, err := buildAuthMethods(cfg)
+	require.NoError(t, err)
+	assert.Len(t, methods, 1)
+}
 
 func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {
 	_, err := buildHostKeyCallback("/nonexistent/path/known_hosts")

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -68,6 +68,39 @@ func TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound(t *testing.T) {
 	assert.Len(t, methods, 1)
 }
 
+// TestValidRemotePath_* cover the regex guard that prevents command injection
+// via the working directory field (CodeQL go/command-injection pattern).
+
+func TestValidRemotePath_AbsoluteOK(t *testing.T) {
+	for _, p := range []string{
+		"/home/user/projects",
+		"/tmp",
+		"/var/log/my app",     // space is allowed
+		"/データ/プロジェクト", // unicode allowed
+		"/home/user_name/file-name.txt",
+	} {
+		assert.True(t, validRemotePath.MatchString(p), "expected %q to be valid", p)
+	}
+}
+
+func TestValidRemotePath_Rejected(t *testing.T) {
+	for _, p := range []string{
+		"relative/path",             // not absolute
+		"",                          // empty
+		"/tmp/$(evil)",              // command substitution $()
+		"/tmp/`evil`",               // backtick substitution
+		"/tmp/'; rm -rf /; echo '",  // single-quote injection
+		"/tmp/\"; rm -rf /; echo \"", // double-quote injection
+		"/tmp/a;b",                  // semicolon
+		"/tmp/a|b",                  // pipe
+		"/tmp/a&b",                  // background
+		"/tmp/a\x00b",               // null byte
+		"/tmp/a\nb",                 // newline
+	} {
+		assert.False(t, validRemotePath.MatchString(p), "expected %q to be rejected", p)
+	}
+}
+
 func TestShellQuotePath_Simple(t *testing.T) {
 	assert.Equal(t, "'/home/user/projects'", shellQuotePath("/home/user/projects"))
 }

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -103,6 +103,13 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	// (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
 	tmuxCmd := fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)
 	if cfg.Cwd != "" {
+		// Validate cwd with the regex guard before embedding in the shell command
+		// (CodeQL go/command-injection recommended pattern for arguments).
+		if !validRemotePath.MatchString(cfg.Cwd) {
+			sess.Close()
+			client.Close()
+			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
+		}
 		tmuxCmd += fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd))
 	}
 	if err := sess.Start(tmuxCmd); err != nil {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -98,8 +98,14 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	sess.Stderr = pw
 
 	// Attach to existing tmux session or create it if absent.
+	// -c sets the working directory for newly created sessions; it has no
+	// effect when attaching to an existing session.
 	// (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
-	if err := sess.Start(fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)); err != nil {
+	tmuxCmd := fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)
+	if cfg.Cwd != "" {
+		tmuxCmd += fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd))
+	}
+	if err := sess.Start(tmuxCmd); err != nil {
 		sess.Close()
 		client.Close()
 		return nil, fmt.Errorf("starting tmux attach: %w", err)

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -1,0 +1,150 @@
+package sshconfig
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Host represents a single Host block parsed from an SSH config file.
+type Host struct {
+	Name         string // Host alias (e.g. "prod-web")
+	Hostname     string // HostName directive (defaults to Name if not set)
+	User         string
+	Port         int    // 0 = not set (caller uses default 22)
+	IdentityFile string
+}
+
+// DefaultPath returns the default SSH config path (~/.ssh/config).
+func DefaultPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".ssh", "config")
+	}
+	return filepath.Join(home, ".ssh", "config")
+}
+
+// ParseHosts parses non-wildcard Host blocks from the given SSH config file.
+// If the file does not exist, it returns an empty list and no error.
+func ParseHosts(path string) ([]Host, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []Host{}, nil
+		}
+		return nil, fmt.Errorf("open ssh config: %w", err)
+	}
+	defer f.Close()
+
+	var hosts []Host
+	var current *Host
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+
+		if key == "host" {
+			// Save previous host if non-wildcard
+			if current != nil {
+				if current.Hostname == "" {
+					current.Hostname = current.Name
+				}
+				hosts = append(hosts, *current)
+			}
+			// Start new host block, skip wildcards
+			if strings.ContainsAny(val, "*?") {
+				current = nil
+			} else {
+				current = &Host{Name: val}
+			}
+			continue
+		}
+
+		if current == nil {
+			continue
+		}
+
+		switch key {
+		case "hostname":
+			current.Hostname = val
+		case "user":
+			current.User = val
+		case "port":
+			p, err := strconv.Atoi(val)
+			if err == nil {
+				current.Port = p
+			}
+		case "identityfile":
+			current.IdentityFile = val
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan ssh config: %w", err)
+	}
+
+	// Save last block
+	if current != nil {
+		if current.Hostname == "" {
+			current.Hostname = current.Name
+		}
+		hosts = append(hosts, *current)
+	}
+
+	return hosts, nil
+}
+
+// AppendHost appends a new Host block to the SSH config file at path.
+// The file is created if it does not exist.
+func AppendHost(path string, h Host) error {
+	// Ensure the directory exists
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create ssh config dir: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open ssh config for append: %w", err)
+	}
+	defer f.Close()
+
+	var sb strings.Builder
+	sb.WriteString("\nHost ")
+	sb.WriteString(h.Name)
+	sb.WriteString("\n")
+	sb.WriteString("    HostName ")
+	sb.WriteString(h.Hostname)
+	sb.WriteString("\n")
+	sb.WriteString("    User ")
+	sb.WriteString(h.User)
+	sb.WriteString("\n")
+	if h.Port != 0 {
+		sb.WriteString(fmt.Sprintf("    Port %d\n", h.Port))
+	}
+	if h.IdentityFile != "" {
+		sb.WriteString("    IdentityFile ")
+		sb.WriteString(h.IdentityFile)
+		sb.WriteString("\n")
+	}
+
+	_, err = f.WriteString(sb.String())
+	if err != nil {
+		return fmt.Errorf("write ssh config: %w", err)
+	}
+	return nil
+}

--- a/internal/sshconfig/parse_test.go
+++ b/internal/sshconfig/parse_test.go
@@ -1,0 +1,191 @@
+package sshconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultPath_EndsWithSSHConfig(t *testing.T) {
+	p := DefaultPath()
+	assert.True(t, strings.HasSuffix(p, filepath.Join(".ssh", "config")),
+		"expected path to end with .ssh/config, got %s", p)
+}
+
+func TestParseHosts_MultipleBlocks(t *testing.T) {
+	content := `Host prod-web
+    HostName prod.example.com
+    User admin
+    Port 2222
+    IdentityFile ~/.ssh/prod_rsa
+
+Host dev
+    HostName dev.example.com
+    User developer
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 2)
+
+	assert.Equal(t, "prod-web", hosts[0].Name)
+	assert.Equal(t, "prod.example.com", hosts[0].Hostname)
+	assert.Equal(t, "admin", hosts[0].User)
+	assert.Equal(t, 2222, hosts[0].Port)
+	assert.Equal(t, "~/.ssh/prod_rsa", hosts[0].IdentityFile)
+
+	assert.Equal(t, "dev", hosts[1].Name)
+	assert.Equal(t, "dev.example.com", hosts[1].Hostname)
+	assert.Equal(t, "developer", hosts[1].User)
+	assert.Equal(t, 0, hosts[1].Port)
+	assert.Equal(t, "", hosts[1].IdentityFile)
+}
+
+func TestParseHosts_WildcardExcluded(t *testing.T) {
+	content := `Host *
+    ServerAliveInterval 60
+
+Host myserver
+    HostName myserver.example.com
+    User ubuntu
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "myserver", hosts[0].Name)
+}
+
+func TestParseHosts_MissingHostname_UsesName(t *testing.T) {
+	content := `Host myalias
+    User ubuntu
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "myalias", hosts[0].Hostname)
+}
+
+func TestParseHosts_FileNotFound_ReturnsEmpty(t *testing.T) {
+	hosts, err := ParseHosts("/nonexistent/path/ssh/config")
+	assert.NoError(t, err)
+	assert.Empty(t, hosts)
+}
+
+func TestParseHosts_EmptyFile(t *testing.T) {
+	f := writeTempSSHConfig(t, "")
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	assert.Empty(t, hosts)
+}
+
+func TestParseHosts_CaseInsensitiveKeys(t *testing.T) {
+	content := `Host myserver
+    hostname myserver.example.com
+    user ubuntu
+    port 22
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "myserver.example.com", hosts[0].Hostname)
+	assert.Equal(t, "ubuntu", hosts[0].User)
+	assert.Equal(t, 22, hosts[0].Port)
+}
+
+func TestAppendHost_WritesCorrectBlock(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+
+	h := Host{
+		Name:         "staging",
+		Hostname:     "staging.example.com",
+		User:         "deploy",
+		Port:         2222,
+		IdentityFile: "~/.ssh/staging_rsa",
+	}
+	err := AppendHost(f, h)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(f)
+	require.NoError(t, err)
+	s := string(data)
+	assert.Contains(t, s, "Host staging\n")
+	assert.Contains(t, s, "    HostName staging.example.com\n")
+	assert.Contains(t, s, "    User deploy\n")
+	assert.Contains(t, s, "    Port 2222\n")
+	assert.Contains(t, s, "    IdentityFile ~/.ssh/staging_rsa\n")
+}
+
+func TestAppendHost_NoPortOrIdentityFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+
+	h := Host{
+		Name:     "simple",
+		Hostname: "simple.example.com",
+		User:     "ubuntu",
+	}
+	err := AppendHost(f, h)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(f)
+	require.NoError(t, err)
+	s := string(data)
+	assert.Contains(t, s, "Host simple\n")
+	assert.Contains(t, s, "    HostName simple.example.com\n")
+	assert.Contains(t, s, "    User ubuntu\n")
+	assert.NotContains(t, s, "Port")
+	assert.NotContains(t, s, "IdentityFile")
+}
+
+func TestAppendHost_AppendsToExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+
+	// Write initial content
+	err := os.WriteFile(f, []byte("Host existing\n    User old\n"), 0600)
+	require.NoError(t, err)
+
+	h := Host{Name: "new", Hostname: "new.example.com", User: "newuser"}
+	err = AppendHost(f, h)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(f)
+	require.NoError(t, err)
+	s := string(data)
+	// Both blocks should exist
+	assert.Contains(t, s, "Host existing")
+	assert.Contains(t, s, "Host new")
+}
+
+func TestParseHosts_AfterAppend(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+
+	h := Host{Name: "myhost", Hostname: "myhost.example.com", User: "myuser", Port: 22}
+	require.NoError(t, AppendHost(f, h))
+
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "myhost", hosts[0].Name)
+	assert.Equal(t, "myhost.example.com", hosts[0].Hostname)
+	assert.Equal(t, "myuser", hosts[0].User)
+	assert.Equal(t, 22, hosts[0].Port)
+}
+
+// writeTempSSHConfig creates a temp file with the given content and returns the path.
+func writeTempSSHConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	f := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
+	return f
+}


### PR DESCRIPTION
## Summary

- Read non-wildcard hosts from `~/.ssh/config` as SSH connection sources; panes can reference them directly in `connection` without duplicating entries under `ssh_connections`
- Add REST endpoints (`GET /api/ssh-connections`, `GET /api/ssh-config/hosts`, `POST /api/ssh-config/hosts`) for the UI to enumerate and create SSH connection entries
- Fix auth fallback to try default key files (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`) when no `key_file` or `password` is set
- Apply `cwd` to SSH and SSH+tmux sessions; guard the path with `validRemotePath` + `shellQuotePath` to prevent command injection (CodeQL `go/command-injection`)
- Document SSH connections, authentication order, SSH pane fields, REST endpoints, and remote path security design in `docs/`

## Test plan

- [x] `go test ./... -v -race` — all tests pass
- [x] `make coverage-go` — ≥ 80% coverage
- [x] `go vet ./...` — no errors
- [x] SSH connection using `ssh_connections` YAML entry works
- [x] SSH connection using `~/.ssh/config` host alias works
- [x] Auth fallback tries default key files when none configured
- [x] `cwd` changes working directory on remote SSH session
- [x] Invalid `cwd` (metacharacters) is rejected with an error
- [x] `GET /api/ssh-connections` returns merged, deduplicated list
- [x] `POST /api/ssh-config/hosts` appends new host to `~/.ssh/config`
- [x] `POST /api/ssh-config/hosts` returns 409 for duplicate host name