### PR TITLE
docs: document SSH connections, auth, API endpoints, and remote path security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ on:
       - 'frontend/**'
       - 'Makefile'
       - '.github/workflows/ci.yml'
+      - 'docs/**'
+      - 'README.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 - **Four pane types** — `local` (shell), `ssh` (remote), `tmux` (local session attach), `ssh_tmux` (SSH → tmux)
 - **Recursive split layout** — nest horizontal and vertical splits to any depth
 - **Drag-to-resize** — drag dividers in the browser to adjust pane sizes
-- **Edit mode** — lock/unlock toggle controls whether layout changes are saved to disk; edits are always applied in-memory
+- **Drag-to-reorder** — in edit mode, drag any pane by its body to swap positions
+- **Edit mode** — enables layout reordering and persists changes to disk; terminal input is blocked while active so keystrokes can't reach the shell accidentally
+- **`~/.ssh/config` integration** — reference any host alias from `~/.ssh/config` directly as a `connection` without duplicating entries in YAML
 - **Session resilience** — tmux sessions are auto-created when absent; exited panes show a Restart button to reconnect without reloading
 - **xterm.js rendering** — full-featured terminal emulation with Unicode and colour support
 - **Single binary** — Go backend embeds the compiled frontend; no separate web server needed
@@ -75,7 +77,7 @@ server:
   port: 8080
   host: "127.0.0.1"
 
-# Named SSH connections referenced by layout panes
+# Named SSH connections (optional — hosts from ~/.ssh/config are also usable directly)
 ssh_connections:
   prod-web:
     host: "192.168.1.10"
@@ -116,13 +118,28 @@ layout:
 | Type | Description |
 |------|-------------|
 | `local` | Local shell process (`shell`, `cwd` optional) |
-| `ssh` | SSH connection defined in `ssh_connections` |
+| `ssh` | SSH connection — name from `ssh_connections` or a `~/.ssh/config` host alias |
 | `tmux` | Attach to a local tmux session (`tmux_session`); created automatically if absent |
 | `ssh_tmux` | SSH to a host, then attach to a tmux session; created automatically if absent |
 
+### SSH connections
+
+Connections can be defined in two ways:
+
+**In the YAML config** under `ssh_connections` — supports `host`, `user`, `port`, `key_file`, `password`, and `known_hosts_file`.
+
+**Via `~/.ssh/config`** — any non-wildcard `Host` entry is automatically available as a `connection` name. `HostName`, `User`, `Port`, and `IdentityFile` are read from the file. This lets you reuse your existing SSH config without duplicating it in YAML.
+
+When the same name appears in both, `ssh_connections` takes precedence.
+
+Authentication is attempted in order: configured `key_file` → configured `password` → default key files (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`).
+
 ### Edit mode
 
-By default, layout changes (drag-resize, close) are applied in-memory only. Click the lock icon in the bottom-right corner to enable **edit mode**, which persists changes back to the config file. Disable edit mode to explore layouts without touching the file.
+Click the lock icon in the bottom-right corner to toggle **edit mode**.
+
+- **ON** — layout changes are persisted to the config file; terminal input is blocked and a visual overlay shows which panes are locked; drag any pane by its body (not just the header) to reorder it
+- **OFF** — terminal is fully interactive; drag-resize and close are applied in-memory only
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,14 @@ For the same reason, `os.Getenv("SHELL")` is not used as a default shell. Enviro
 
 `validTmuxSessionName` in `internal/session/tmux_ssh.go` uses a strict regex (`^[a-zA-Z0-9_.-]+$`) validated at construction time, and arguments are passed as discrete `exec.Command` args (not via `sh -c`), so no shell interpolation occurs.
 
+**Remote path arguments (SSH working directory)**
+
+When an SSH or SSH+tmux pane has `cwd` set, the path is passed as part of a remote shell command (`cd <cwd> && exec $SHELL`). User-supplied paths that flow into `sess.Start()` must be validated with `validRemotePath` (defined in `internal/session/ssh.go`) before use.
+
+`validRemotePath` is a regex guard (`^(/[^;|&$\`'"<>()\[\]{}!\\\x00-\x1f\x7f]*)+$`) that accepts only absolute Unix paths and rejects shell metacharacters and control characters. This is the CodeQL-recommended sanitization pattern for shell arguments.
+
+After validation, the path is wrapped with `shellQuotePath`, which single-quotes the value and escapes any interior single quotes. This ensures paths containing spaces or unusual (but allowed) characters are safe to embed in a shell string.
+
 **General rule**
 
 When adding new session types or new `exec.Command` calls: the value passed as the command (first argument) must come from a hardcoded literal or from a trusted system source (file, registry) with no data-flow path to user input. Arguments after the command may be user-supplied if they cannot be interpreted as commands by the target binary.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -33,6 +33,71 @@ Path behavior:
 
 - `~/` in SSH key paths and pane working directories is expanded at load time
 
+## SSH Connections
+
+### Defining connections in `ssh_connections`
+
+Each entry under `ssh_connections` in the YAML config has the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `host` | yes | Hostname or IP address |
+| `user` | yes | Remote username |
+| `port` | no (default 22) | SSH port |
+| `key_file` | no | Path to private key; `~/` is expanded at load time |
+| `password` | no | Password for password-based authentication |
+| `known_hosts_file` | no (default `~/.ssh/known_hosts`) | Path to known\_hosts file for host-key verification |
+
+Example:
+
+```yaml
+ssh_connections:
+  prod-web:
+    host: 192.168.1.10
+    user: deploy
+    key_file: ~/.ssh/id_ed25519
+  bastion:
+    host: bastion.example.com
+    user: ops
+    key_file: ~/.ssh/id_ed25519
+    known_hosts_file: ~/.ssh/known_hosts
+```
+
+### Using `~/.ssh/config` hosts
+
+Panes can reference host aliases from `~/.ssh/config` directly in the `connection` field without duplicating them under `ssh_connections`. The following fields are read from each non-wildcard `Host` block:
+
+- `HostName` — hostname or IP (defaults to the alias name if omitted)
+- `User` — remote username
+- `Port` — port number (defaults to 22 if omitted)
+- `IdentityFile` — path to private key; `~/` is expanded at session creation time
+
+Wildcard entries (`Host *`, `Host *.example.com`) are skipped.
+
+`ssh_connections` takes precedence over `~/.ssh/config` when the same name appears in both.
+
+### Authentication
+
+When establishing an SSH connection, the following auth methods are attempted in order:
+
+1. Key file specified in `key_file` (if present)
+2. Password specified in `password` (if present)
+3. Default key files in order: `~/.ssh/id_ed25519`, `~/.ssh/id_rsa`, `~/.ssh/id_ecdsa`
+
+Host-key verification uses `known_hosts_file` if configured, or `~/.ssh/known_hosts` by default. If the known\_hosts file does not exist, the connection is refused (the app does not silently accept unknown hosts).
+
+### SSH pane fields
+
+| Field | Types | Required | Description |
+|---|---|---|---|
+| `connection` | `ssh`, `ssh_tmux` | yes | Name from `ssh_connections` or `~/.ssh/config` |
+| `cwd` | `ssh`, `ssh_tmux` | no | Remote working directory; executes `cd {cwd} && exec $SHELL` |
+| `tmux_session` | `ssh_tmux` | yes | Remote tmux session name to attach or create |
+
+`tmux_session` must match `^[a-zA-Z0-9_.-]+$`.
+
+`cwd` is validated against `validRemotePath` before use: absolute paths only, no shell metacharacters (`;|&$` + "`" + `'"<>(){}[]!`), no control characters. See *Security Design* in `architecture.md`.
+
 Persistence behavior:
 
 - `PUT /api/layout` updates in-memory layout always
@@ -71,6 +136,53 @@ Current product use: the frontend uses this endpoint when the user splits a pane
 ### `DELETE /api/sessions/{id}`
 
 Closes the session, removes its pane from the layout, collapses redundant parent splits, normalizes sibling sizes, and returns `204`.
+
+### `GET /api/ssh-connections`
+
+Returns a sorted list of all known SSH connection names — the union of names defined in `ssh_connections` (YAML) and non-wildcard hosts from `~/.ssh/config`. Names present in both sources are deduplicated, with the YAML entry taking precedence.
+
+Response:
+
+```json
+{ "names": ["bastion", "prod-web"] }
+```
+
+### `GET /api/ssh-config/hosts`
+
+Returns all non-wildcard hosts from `~/.ssh/config` with full field details.
+
+- `500`: unable to read `~/.ssh/config`
+- `200`: list of host records
+
+Response:
+
+```json
+{
+  "hosts": [
+    { "name": "bastion", "hostname": "bastion.example.com", "user": "ops", "port": 22, "identity_file": "~/.ssh/id_ed25519" }
+  ]
+}
+```
+
+Fields `port` and `identity_file` are omitted when not set in `~/.ssh/config`.
+
+### `POST /api/ssh-config/hosts`
+
+Appends a new `Host` block to `~/.ssh/config`.
+
+Request body:
+
+```json
+{ "name": "my-server", "hostname": "192.168.1.5", "user": "deploy", "port": 22, "identity_file": "~/.ssh/id_ed25519" }
+```
+
+- `400`: invalid JSON
+- `409`: a host with the same name already exists in `~/.ssh/config`
+- `422`: validation error (name, hostname, or user missing; name contains invalid characters; port out of range)
+- `500`: unable to read or write `~/.ssh/config`
+- `201`: host appended
+
+`name` must match `^[a-zA-Z0-9_.\-]+$`. `port` defaults to 0 (omitted from the written block) when not specified. `identity_file` is optional.
 
 ### `GET /api/display`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -256,6 +256,26 @@ User types in xterm.js
 - Dragging split dividers updates layout percentages in memory.
 - Layout persistence is debounced by 500 ms before `PUT /api/layout`.
 
+### Edit mode and pane reordering
+
+Edit mode is toggled by the fixed button in the bottom-right corner. When edit mode is ON:
+
+- The entire pane body becomes a drag surface; the user can drag any pane onto any other pane to swap their positions in the layout tree.
+- Terminal keyboard input is blocked — `onData` and `onBinary` handlers do not forward bytes to the session while edit mode is active.
+- A semi-transparent overlay covers each terminal area and intercepts pointer events, preventing the terminal from gaining focus.
+- Layout changes (including drag-resize) are persisted to the config file via `PUT /api/layout`.
+
+When edit mode is OFF, terminal input is fully restored and layout changes are applied in-memory only.
+
+Drag-and-drop pane reordering:
+
+1. User starts dragging a pane — `dragstart` fires on the outer pane div; `dragSourcePaneId` is set in context.
+2. User hovers over a target pane — `dragover` fires; the target receives a visual drop indicator.
+3. User releases — `drop` fires; the two panes' `PaneConfig` objects are swapped in the layout tree, and `PUT /api/layout` is called immediately (no debounce).
+4. `dragSourcePaneId` is cleared in context; both panes return to normal edit-mode appearance.
+
+When a pane moves to a different parent node during a swap (cross-row reorder), the component is remounted by React. xterm.js terminal instances survive remounting via a module-level `TerminalEntry` map keyed by session ID; the existing canvas is reattached to the new container with `appendChild` rather than `replaceChildren`, preserving React-managed sibling nodes (overlays) in the container.
+
 ### Split and close semantics
 
 - Splitting a pane creates a new local pane, creates a backend session through `POST /api/sessions`, then rewrites the layout tree so the original and new panes each receive `50%` under a new split node.


### PR DESCRIPTION
## Summary

- Add SSH Connections section to `behavior.md` covering `ssh_connections` fields, `~/.ssh/config` integration, authentication order, and SSH pane fields with validation rules
- Add SSH REST API endpoints to `behavior.md`: `GET /api/ssh-connections`, `GET /api/ssh-config/hosts`, `POST /api/ssh-config/hosts` with request/response formats and error codes
- Add remote path security design to `architecture.md`: `validRemotePath` regex guard and `shellQuotePath` single-quote wrapping for `cwd` arguments in SSH sessions

## Test plan

- [x] `docs/behavior.md` — SSH Connections section covers all fields, examples, auth order, and pane validation rules
- [x] `docs/behavior.md` — SSH REST API endpoints documented with status codes and response shapes
- [x] `docs/architecture.md` — Security Design section covers `validRemotePath` and `shellQuotePath` with rationale