### PR TITLE
ci: fix goreleaser for draft releases using delayed-tag workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ on:
       - 'frontend/**'
       - 'Makefile'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/**'
+      - '.goreleaser.yaml'
       - 'docs/**'
       - 'README.md'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: release
@@ -34,12 +33,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Create local tag for GoReleaser
-        run: |
-          TAG="${{ needs.release-please.outputs.tag_name }}"
-          SHA="${{ needs.release-please.outputs.sha }}"
-          git rev-parse "$TAG" 2>/dev/null || git tag "$TAG" "$SHA"
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
@@ -60,7 +53,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           version: latest
-          args: release --clean
+          args: release --clean --current-tag=${{ needs.release-please.outputs.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: release
@@ -33,6 +34,12 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Create local tag for GoReleaser
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          SHA="${{ needs.release-please.outputs.sha }}"
+          git rev-parse "$TAG" 2>/dev/null || git tag "$TAG" "$SHA"
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
@@ -53,7 +60,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           version: latest
-          args: release --clean --current-tag=${{ needs.release-please.outputs.tag_name }}
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: release
@@ -31,6 +33,13 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create local tag for GoReleaser
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          SHA="${{ needs.release-please.outputs.sha }}"
+          git rev-parse "$TAG" 2>/dev/null || git tag "$TAG" "$SHA"
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      sha: ${{ steps.release.outputs.sha }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: release
@@ -38,7 +37,7 @@ jobs:
       - name: Create local tag for GoReleaser
         run: |
           TAG="${{ needs.release-please.outputs.tag_name }}"
-          SHA="${{ needs.release-please.outputs.sha }}"
+          SHA="${{ github.sha }}"
           git rev-parse "$TAG" 2>/dev/null || git tag "$TAG" "$SHA"
 
       - name: Set up Go
@@ -59,7 +58,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,6 @@ changelog:
 
 release:
   use_existing_draft: true
-  target_commitish: "{{ .Commit }}"
   mode: keep-existing
   github:
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,8 @@ changelog:
 
 release:
   replace_existing_draft: true
+  use_existing_draft: true
+  target_commitish: "{{ .Commit }}"
   mode: keep-existing
   github:
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,7 +51,6 @@ changelog:
       - "^test:"
 
 release:
-  replace_existing_draft: true
   use_existing_draft: true
   target_commitish: "{{ .Commit }}"
   mode: keep-existing


### PR DESCRIPTION
## Summary

- `release-please` creates GitHub draft releases (`draft: true`) but does **not** push a git tag; GoReleaser needs a tag for version detection and failed with `git tag v0.4.0 was not made against commit ...`
- Add `use_existing_draft: true` + `target_commitish: "{{ .Commit }}"` to `.goreleaser.yaml` so GoReleaser finds the existing draft release and works without a pre-pushed tag
- Pass `tag_name`/`sha` from the `release-please` job to the `goreleaser` job, then create the local tag before running GoReleaser
- Add `fetch-tags: true` to the checkout step for robustness

Also closed the invalid PR #34 (chore(main): release 0.6.0) which was generated before the v0.5.0 tag existed and contained incorrect changelog entries.

## Test plan

- [x] PR #34 closed
- [x] `.goreleaser.yaml` has `use_existing_draft: true` and `target_commitish`
- [x] Workflow passes `tag_name`/`sha` as job outputs
- [x] `Create local tag for GoReleaser` step added before GoReleaser runs
- [x] `fetch-tags: true` added to checkout
- [ ] Merge this PR → confirm release-please runs without creating a new release PR (ci: prefix)
- [ ] On next feature/fix merge: verify release-please creates a correct v0.6.0 PR, merging it triggers goreleaser successfully