### PR TITLE
fix: resolve test failures and act() warnings

### DIFF
--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -66,12 +66,15 @@ describe('useLayout', () => {
         ok: true,
         json: () => Promise.resolve(validLayout),
       } as Response)
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve(validLayout) } as Response)
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
     window.fetch = fetchMock
 
     const { result } = renderHook(() => useLayout())
     // Wait for initial fetches (layout + display) without fake timers
-    await waitFor(() => expect(result.current.layout).not.toBeNull())
+    await waitFor(() => {
+      expect(result.current.layout).not.toBeNull()
+      expect(result.current.displayConfig).not.toBeNull()
+    })
 
     // Count calls so far (layout + display = 2)
     const callsAfterInit = fetchMock.mock.calls.length
@@ -80,9 +83,11 @@ describe('useLayout', () => {
     vi.useFakeTimers()
     try {
       const updated: LayoutNode = { ...validLayout, direction: 'vertical' }
-      result.current.updateSizes(updated)
-      result.current.updateSizes(updated)
-      result.current.updateSizes(updated)
+      act(() => {
+        result.current.updateSizes(updated)
+        result.current.updateSizes(updated)
+        result.current.updateSizes(updated)
+      })
 
       // Debounce not yet fired
       expect(fetchMock).toHaveBeenCalledTimes(callsAfterInit)

--- a/frontend/src/hooks/usePaneSettings.test.ts
+++ b/frontend/src/hooks/usePaneSettings.test.ts
@@ -42,17 +42,19 @@ describe('usePaneSettings', () => {
     await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
   })
 
-  it('openSettings sets isOpen true with the given pane', () => {
+  it('openSettings sets isOpen true with the given pane', async () => {
     vi.stubGlobal('fetch', makeFetchOk({ names: [] }))
     const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
     act(() => result.current.openSettings(mockPane))
     expect(result.current.isOpen).toBe(true)
     expect(result.current.currentPane).toEqual(mockPane)
   })
 
-  it('closeSettings sets isOpen false', () => {
+  it('closeSettings sets isOpen false', async () => {
     vi.stubGlobal('fetch', makeFetchOk({ names: [] }))
     const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+    await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
     act(() => result.current.openSettings(mockPane))
     act(() => result.current.closeSettings())
     expect(result.current.isOpen).toBe(false)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -20,6 +20,7 @@ type Handler struct {
 	manager       *session.Manager
 	editMode      atomic.Bool
 	sshConfigPath string
+	createSession func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
 }
 
 type editModeResponse struct {
@@ -54,7 +55,9 @@ var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
 func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
-	return &Handler{cfg: cfg, manager: manager, sshConfigPath: sshconfig.DefaultPath()}
+	h := &Handler{cfg: cfg, manager: manager, sshConfigPath: sshconfig.DefaultPath()}
+	h.createSession = session.CreateFromConfig
+	return h
 }
 
 // GetLayout returns the current layout configuration.
@@ -128,7 +131,7 @@ func (h *Handler) PostSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess, err := session.CreateFromConfig(&pane, h.cfg.SSHConnections)
+	sess, err := h.createSession(&pane, h.cfg.SSHConnections)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -177,7 +180,7 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 
 	h.manager.Remove(id) //nolint:errcheck -- ok if already gone
 
-	sess, err := session.CreateFromConfig(found, h.cfg.SSHConnections)
+	sess, err := h.createSession(found, h.cfg.SSHConnections)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -174,7 +174,12 @@ func TestDeleteSession_NotFound_404(t *testing.T) {
 }
 
 func TestPostSession_ValidLocal_201(t *testing.T) {
-	r := setupRouter(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		return newMockSession(pane.ID), nil
+	}
+	r := setupRouterWithHandler(h)
 	body, _ := json.Marshal(config.PaneConfig{ID: "new-pane", Type: "local"})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions", bytes.NewReader(body))
@@ -221,7 +226,12 @@ func TestRestartSession_Found_200(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main")) // pre-existing (exited) session
-	r := setupRouter(cfg, mgr)
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		return newMockSession(pane.ID), nil
+	}
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)


### PR DESCRIPTION
## Summary

- **Go**: Add injectable `createSession` field to `Handler` so `TestPostSession_ValidLocal_201` and `TestRestartSession_Found_200` can use a mock session instead of spawning a real PTY (which fails with "operation not permitted" in sandboxed environments). Production behaviour is unchanged — `NewHandler` defaults to `session.CreateFromConfig`.
- **Frontend**: Fix two `usePaneSettings` tests that were synchronous but triggered an async `useEffect` fetch on mount; make them `async` and `await` the initial SSH connection fetch before calling `act()`.
- **Frontend**: Fix `useLayout` debounce test — use `validDisplay` as catch-all mock so `displayConfig` becomes non-null, wait for both `layout` and `displayConfig` before enabling fake timers, and wrap `updateSizes` calls in `act()`.

## Test plan

- [x] `go test ./internal/api/... -v -run "TestPostSession_ValidLocal_201|TestRestartSession_Found_200"` — both pass
- [x] `go test ./internal/api/... -v` — all 38 API tests pass
- [x] `cd frontend && npm test -- --run` — 142 tests pass, 0 act() warnings