### PR TITLE
build: add go fmt to development process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,14 @@ make dev-frontend   # Vite dev server on :5173
 make dev-backend    # backend must be running separately
 ```
 
+**Format**:
+```sh
+make fmt        # apply go fmt -s to all Go files
+```
+
 **Checks**:
 ```sh
-make lint
+make lint       # includes go fmt check; fails if any Go file is unformatted
 make test
 make check
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci \
         test test-go test-frontend \
+        fmt fmt-go fmt-check-go \
         lint lint-go lint-frontend \
         coverage coverage-go coverage-frontend \
         check release-snapshot package
@@ -55,11 +56,26 @@ coverage-go:
 coverage-frontend:
 	cd frontend && npm run coverage
 
+# ── Format ────────────────────────────────────────────────────────────────────
+
+fmt: fmt-go
+
+fmt-go:
+	gofmt -s -w .
+
+fmt-check-go:
+	@files=$$(gofmt -s -l .); \
+	if [ -n "$$files" ]; then \
+	  echo "Unformatted Go files (run 'make fmt'):"; \
+	  echo "$$files"; \
+	  exit 1; \
+	fi
+
 # ── Lint ──────────────────────────────────────────────────────────────────────
 
 lint: lint-go lint-frontend
 
-lint-go:
+lint-go: fmt-check-go
 	go vet ./...
 
 lint-frontend:

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -754,12 +754,12 @@ func (m *mockCWDSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
 // mockSSHCWDSession is a mockSession that implements both CWDGetter and SSHConnNamer.
 type mockSSHCWDSession struct {
 	mockSession
-	cwd        string
-	connName   string
+	cwd      string
+	connName string
 }
 
 func (m *mockSSHCWDSession) GetCWD() (string, error) { return m.cwd, nil }
-func (m *mockSSHCWDSession) ConnectionName() string   { return m.connName }
+func (m *mockSSHCWDSession) ConnectionName() string  { return m.connName }
 
 func setupRouterWithVSCode(h *Handler) *chi.Mux {
 	r := setupRouterWithHandler(h)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -29,11 +29,11 @@ type mockSession struct {
 func newMockSession(id string) *mockSession {
 	return &mockSession{id: id, typ: session.TypeLocal, title: id, state: session.StateConnected}
 }
-func (m *mockSession) ID() string              { return m.id }
-func (m *mockSession) Type() session.Type      { return m.typ }
-func (m *mockSession) Title() string           { return m.title }
-func (m *mockSession) State() session.State    { return m.state }
-func (m *mockSession) Read(p []byte) (int, error) { return 0, io.EOF }
+func (m *mockSession) ID() string                  { return m.id }
+func (m *mockSession) Type() session.Type          { return m.typ }
+func (m *mockSession) Title() string               { return m.title }
+func (m *mockSession) State() session.State        { return m.state }
+func (m *mockSession) Read(p []byte) (int, error)  { return 0, io.EOF }
 func (m *mockSession) Write(p []byte) (int, error) { return len(p), nil }
 func (m *mockSession) Resize(c, r uint16) error    { return nil }
 func (m *mockSession) Close() error                { return nil }

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -23,14 +23,14 @@ var validRemotePath = regexp.MustCompile(`^(/[^;|&$` + "`" + `'"<>()\[\]{}!\\\x0
 
 // SSHSession manages an SSH connection with a PTY.
 type SSHSession struct {
-	mu             sync.RWMutex
-	id             string
-	title          string
-	state          State
-	client         *ssh.Client
-	session        *ssh.Session
-	stdin          io.WriteCloser
-	stdout         io.Reader
+	mu      sync.RWMutex
+	id      string
+	title   string
+	state   State
+	client  *ssh.Client
+	session *ssh.Session
+	stdin   io.WriteCloser
+	stdout  io.Reader
 	// combined reader for stdout+stderr
 	reader         io.Reader
 	connectionName string

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -75,8 +75,8 @@ func TestValidRemotePath_AbsoluteOK(t *testing.T) {
 	for _, p := range []string{
 		"/home/user/projects",
 		"/tmp",
-		"/var/log/my app",     // space is allowed
-		"/データ/プロジェクト", // unicode allowed
+		"/var/log/my app", // space is allowed
+		"/データ/プロジェクト",     // unicode allowed
 		"/home/user_name/file-name.txt",
 	} {
 		assert.True(t, validRemotePath.MatchString(p), "expected %q to be valid", p)
@@ -85,17 +85,17 @@ func TestValidRemotePath_AbsoluteOK(t *testing.T) {
 
 func TestValidRemotePath_Rejected(t *testing.T) {
 	for _, p := range []string{
-		"relative/path",             // not absolute
-		"",                          // empty
-		"/tmp/$(evil)",              // command substitution $()
-		"/tmp/`evil`",               // backtick substitution
-		"/tmp/'; rm -rf /; echo '",  // single-quote injection
+		"relative/path",              // not absolute
+		"",                           // empty
+		"/tmp/$(evil)",               // command substitution $()
+		"/tmp/`evil`",                // backtick substitution
+		"/tmp/'; rm -rf /; echo '",   // single-quote injection
 		"/tmp/\"; rm -rf /; echo \"", // double-quote injection
-		"/tmp/a;b",                  // semicolon
-		"/tmp/a|b",                  // pipe
-		"/tmp/a&b",                  // background
-		"/tmp/a\x00b",               // null byte
-		"/tmp/a\nb",                 // newline
+		"/tmp/a;b",                   // semicolon
+		"/tmp/a|b",                   // pipe
+		"/tmp/a&b",                   // background
+		"/tmp/a\x00b",                // null byte
+		"/tmp/a\nb",                  // newline
 	} {
 		assert.False(t, validRemotePath.MatchString(p), "expected %q to be rejected", p)
 	}

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -14,7 +14,7 @@ type Host struct {
 	Name         string // Host alias (e.g. "prod-web")
 	Hostname     string // HostName directive (defaults to Name if not set)
 	User         string
-	Port         int    // 0 = not set (caller uses default 22)
+	Port         int // 0 = not set (caller uses default 22)
 	IdentityFile string
 }
 


### PR DESCRIPTION
## Summary

- Add `make fmt` / `make fmt-go` targets that run `gofmt -s -w .` to apply formatting
- Add `make fmt-check-go` target that fails if any Go file is unformatted
- Integrate `fmt-check-go` into `lint-go` so `make lint` and `make check` enforce formatting in CI
- Apply `gofmt -s` to 3 files that were already out of format (`internal/api/handler_test.go`, `internal/session/ssh_test.go`, `internal/sshconfig/parse.go`)
- Document `make fmt` in CLAUDE.md

## Test plan

- [x] `make fmt-check-go` passes after `make fmt` is run
- [x] `make fmt-go` applies formatting correctly (idempotent — running twice produces no diff)
- [x] `make lint-go` runs `fmt-check-go` before `go vet`
- [x] Introducing an unformatted file causes `make fmt-check-go` to fail with a clear message