### PR TITLE
feat: support ProxyJump for SSH sessions

### DIFF
--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -76,15 +76,22 @@ func resolveSSHConfig(name string, sshConns map[string]config.SSHConnection, ssh
 				port = 22
 			}
 			keyFile := h.IdentityFile
-			if strings.HasPrefix(keyFile, "~/") {
+			if keyFile != "" {
 				home, _ := os.UserHomeDir()
-				keyFile = filepath.Join(home, keyFile[2:])
+				if strings.HasPrefix(keyFile, "~/") {
+					keyFile = filepath.Join(home, keyFile[2:])
+				} else if !filepath.IsAbs(keyFile) {
+					// Relative paths (e.g. ".ssh/id_ed25519") are relative to HOME,
+					// matching OpenSSH behaviour.
+					keyFile = filepath.Join(home, keyFile)
+				}
 			}
 			cfg := SSHConfig{
-				Host:    h.Hostname,
-				Port:    port,
-				User:    h.User,
-				KeyFile: keyFile,
+				Host:         h.Hostname,
+				Port:         port,
+				User:         h.User,
+				KeyFile:      keyFile,
+				ProxyCommand: h.ProxyCommand,
 			}
 			if h.ProxyJump != "" {
 				jumpCfg, err := resolveSSHConfig(h.ProxyJump, sshConns, sshConfigPath)

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -80,12 +80,20 @@ func resolveSSHConfig(name string, sshConns map[string]config.SSHConnection, ssh
 				home, _ := os.UserHomeDir()
 				keyFile = filepath.Join(home, keyFile[2:])
 			}
-			return SSHConfig{
+			cfg := SSHConfig{
 				Host:    h.Hostname,
 				Port:    port,
 				User:    h.User,
 				KeyFile: keyFile,
-			}, nil
+			}
+			if h.ProxyJump != "" {
+				jumpCfg, err := resolveSSHConfig(h.ProxyJump, sshConns, sshConfigPath)
+				if err != nil {
+					return SSHConfig{}, fmt.Errorf("resolving proxy jump %q: %w", h.ProxyJump, err)
+				}
+				cfg.JumpHost = &jumpCfg
+			}
+			return cfg, nil
 		}
 	}
 

--- a/internal/session/factory_test.go
+++ b/internal/session/factory_test.go
@@ -48,6 +48,61 @@ func TestCreateFromConfig_SSHMissing(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+// TestResolveSSHConfig_ProxyJump verifies that a ProxyJump directive in ~/.ssh/config
+// causes the returned SSHConfig to have JumpHost populated with the jump host's details.
+func TestResolveSSHConfig_ProxyJump(t *testing.T) {
+	dir := t.TempDir()
+	sshCfgPath := filepath.Join(dir, "config")
+	content := `Host jump-host
+    HostName jump.example.com
+    User jumpuser
+    Port 22
+
+Host target-host
+    HostName target.internal
+    User admin
+    ProxyJump jump-host
+`
+	require.NoError(t, os.WriteFile(sshCfgPath, []byte(content), 0600))
+
+	cfg, err := resolveSSHConfig("target-host", nil, sshCfgPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "target.internal", cfg.Host)
+	assert.Equal(t, "admin", cfg.User)
+	require.NotNil(t, cfg.JumpHost, "JumpHost should be populated when ProxyJump is set")
+	assert.Equal(t, "jump.example.com", cfg.JumpHost.Host)
+	assert.Equal(t, "jumpuser", cfg.JumpHost.User)
+	assert.Equal(t, 22, cfg.JumpHost.Port)
+	assert.Nil(t, cfg.JumpHost.JumpHost, "jump host itself should have no further jump")
+}
+
+// TestResolveSSHConfig_NoProxyJump_JumpHostNil verifies that hosts without ProxyJump
+// return SSHConfig.JumpHost == nil.
+func TestResolveSSHConfig_NoProxyJump_JumpHostNil(t *testing.T) {
+	sshCfgPath := writeTempSSHConfig(t, "direct-host", "direct.example.com", "user", 22)
+	cfg, err := resolveSSHConfig("direct-host", nil, sshCfgPath)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.JumpHost)
+}
+
+// TestResolveSSHConfig_ProxyJump_JumpHostNotFound verifies that an error is returned
+// when the ProxyJump alias cannot be resolved.
+func TestResolveSSHConfig_ProxyJump_JumpHostNotFound(t *testing.T) {
+	dir := t.TempDir()
+	sshCfgPath := filepath.Join(dir, "config")
+	content := `Host target-host
+    HostName target.internal
+    User admin
+    ProxyJump nonexistent-jump
+`
+	require.NoError(t, os.WriteFile(sshCfgPath, []byte(content), 0600))
+
+	_, err := resolveSSHConfig("target-host", nil, sshCfgPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolving proxy jump")
+}
+
 // writeTempSSHConfig writes a minimal SSH config file with a Host block and returns the path.
 func writeTempSSHConfig(t *testing.T, name, hostname, user string, port int) string {
 	t.Helper()

--- a/internal/session/factory_test.go
+++ b/internal/session/factory_test.go
@@ -103,6 +103,45 @@ func TestResolveSSHConfig_ProxyJump_JumpHostNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "resolving proxy jump")
 }
 
+// TestResolveSSHConfig_ProxyCommand verifies that a ProxyCommand directive in
+// ~/.ssh/config causes the returned SSHConfig.ProxyCommand to be populated.
+func TestResolveSSHConfig_ProxyCommand(t *testing.T) {
+	dir := t.TempDir()
+	sshCfgPath := filepath.Join(dir, "config")
+	content := `Host bastion
+    HostName bastion.example.com
+    User admin
+    ProxyCommand gcloud compute start-iap-tunnel bastion %p --listen-on-stdin --project=my-proj
+`
+	require.NoError(t, os.WriteFile(sshCfgPath, []byte(content), 0600))
+
+	cfg, err := resolveSSHConfig("bastion", nil, sshCfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "bastion.example.com", cfg.Host)
+	assert.Equal(t, "gcloud compute start-iap-tunnel bastion %p --listen-on-stdin --project=my-proj", cfg.ProxyCommand)
+	assert.Nil(t, cfg.JumpHost)
+}
+
+// TestResolveSSHConfig_RelativeIdentityFile verifies that a relative IdentityFile path
+// (e.g. ".ssh/id_ed25519" without "~/") is expanded relative to HOME.
+func TestResolveSSHConfig_RelativeIdentityFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	sshCfgPath := filepath.Join(dir, "config")
+	content := `Host myhost
+    HostName myhost.example.com
+    User admin
+    IdentityFile .ssh/id_ed25519
+`
+	require.NoError(t, os.WriteFile(sshCfgPath, []byte(content), 0600))
+
+	cfg, err := resolveSSHConfig("myhost", nil, sshCfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".ssh", "id_ed25519"), cfg.KeyFile)
+}
+
 // writeTempSSHConfig writes a minimal SSH config file with a Host block and returns the path.
 func writeTempSSHConfig(t *testing.T, name, hostname, user string, port int) string {
 	t.Helper()

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1,6 +1,11 @@
 package session
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -80,7 +85,7 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		return nil, nil, err
 	}
 
-	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
+	hkCallback, knownHostsPath, err := buildHostKeyCallback(cfg.KnownHostsFile)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,10 +97,11 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", port))
 
 	sshCfg := &ssh.ClientConfig{
-		User:            cfg.User,
-		Auth:            authMethods,
-		HostKeyCallback: hkCallback,
-		Timeout:         30 * time.Second,
+		User:              cfg.User,
+		Auth:              authMethods,
+		HostKeyCallback:   hkCallback,
+		HostKeyAlgorithms: knownHostsAlgorithms(knownHostsPath, addr),
+		Timeout:           30 * time.Second,
 	}
 
 	var conn net.Conn
@@ -320,16 +326,89 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	return s, nil
 }
 
-func buildHostKeyCallback(knownHostsFile string) (ssh.HostKeyCallback, error) {
+// buildHostKeyCallback resolves the known_hosts file path and returns a
+// HostKeyCallback together with the resolved path. The path is used by the
+// caller to also compute HostKeyAlgorithms.
+func buildHostKeyCallback(knownHostsFile string) (ssh.HostKeyCallback, string, error) {
 	path, err := resolveKnownHostsFile(knownHostsFile)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	cb, err := knownhosts.New(path)
 	if err != nil {
-		return nil, fmt.Errorf("loading known_hosts %s: %w", path, err)
+		return nil, "", fmt.Errorf("loading known_hosts %s: %w", path, err)
 	}
-	return cb, nil
+	return cb, path, nil
+}
+
+// knownHostsAlgorithms returns the host-key algorithm types stored in
+// knownHostsPath that match hostport ("host:port" format). Setting
+// ssh.ClientConfig.HostKeyAlgorithms to this list ensures the server presents
+// a key type that matches our known_hosts entry, preventing "key mismatch"
+// errors when the server supports multiple key types.
+func knownHostsAlgorithms(knownHostsPath, hostport string) []string {
+	f, err := os.Open(knownHostsPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	normalized := knownhosts.Normalize(hostport)
+	seen := make(map[string]bool)
+	var algos []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || line[0] == '#' || line[0] == '@' {
+			continue
+		}
+		fields := bytes.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		patterns := string(fields[0])
+		keyType := string(fields[1])
+		for _, pattern := range strings.Split(patterns, ",") {
+			if knownHostsFieldMatchesAddr(pattern, normalized) {
+				if !seen[keyType] {
+					seen[keyType] = true
+					algos = append(algos, keyType)
+				}
+				break
+			}
+		}
+	}
+	return algos
+}
+
+func knownHostsFieldMatchesAddr(field, normalized string) bool {
+	if strings.HasPrefix(field, "|1|") {
+		return knownHostsHashedEntryMatches(field, normalized)
+	}
+	if strings.HasPrefix(field, "!") {
+		return false
+	}
+	return field == normalized
+}
+
+func knownHostsHashedEntryMatches(encoded, normalized string) bool {
+	// Format: |1|base64-salt|base64-hash
+	parts := strings.SplitN(encoded, "|", 4)
+	if len(parts) != 4 || parts[1] != "1" {
+		return false
+	}
+	salt, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	hash, err := base64.StdEncoding.DecodeString(parts[3])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha1.New, salt)
+	mac.Write([]byte(normalized))
+	return hmac.Equal(mac.Sum(nil), hash)
 }
 
 func buildAuthMethods(cfg SSHConfig) ([]ssh.AuthMethod, error) {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1,10 +1,6 @@
 package session
 
 import (
-	"bufio"
-	"crypto/hmac"
-	"crypto/sha1"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -75,101 +71,18 @@ func resolveKnownHostsFile(knownHostsFile string) (string, error) {
 	return filepath.Join(home, ".ssh", "known_hosts"), nil
 }
 
-// knownHostsAlgorithms returns the host key algorithms stored in knownHostsFile
-// for the given address. It supports both plaintext and hashed (|1|...) hostname entries.
-// This populates ssh.ClientConfig.HostKeyAlgorithms so Go's SSH library negotiates
-// the same algorithm that is stored in known_hosts, preventing false "key mismatch" errors
-// that occur when the server offers a different algorithm than the one recorded.
-func knownHostsAlgorithms(knownHostsFile, address string) []string {
-	f, err := os.Open(knownHostsFile)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	normalized := knownhosts.Normalize(address)
-
-	seen := make(map[string]bool)
-	var algos []string
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "@") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 3 {
-			continue
-		}
-		hostsField := fields[0]
-		keyType := fields[1]
-		if knownHostsFieldMatchesAddr(hostsField, normalized) && !seen[keyType] {
-			seen[keyType] = true
-			algos = append(algos, keyType)
-		}
-	}
-
-	return algos
-}
-
-// knownHostsFieldMatchesAddr checks whether any pattern in a known_hosts hosts field
-// (comma-separated) matches the given normalized address.
-func knownHostsFieldMatchesAddr(hostsField, normalizedAddr string) bool {
-	for _, pattern := range strings.Split(hostsField, ",") {
-		pattern = strings.TrimSpace(pattern)
-		if pattern == "" || strings.HasPrefix(pattern, "!") {
-			continue
-		}
-		if strings.HasPrefix(pattern, "|1|") {
-			if knownHostsHashedEntryMatches(pattern, normalizedAddr) {
-				return true
-			}
-		} else {
-			if knownhosts.Normalize(pattern) == normalizedAddr {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// knownHostsHashedEntryMatches checks whether the hashed known_hosts entry
-// (|1|salt|hash format) matches the normalized address.
-func knownHostsHashedEntryMatches(entry, normalizedAddr string) bool {
-	parts := strings.Split(entry, "|")
-	if len(parts) != 4 || parts[1] != "1" {
-		return false
-	}
-	salt, err := base64.StdEncoding.DecodeString(parts[2])
-	if err != nil {
-		return false
-	}
-	expected, err := base64.StdEncoding.DecodeString(parts[3])
-	if err != nil {
-		return false
-	}
-	mac := hmac.New(sha1.New, salt)
-	mac.Write([]byte(normalizedAddr))
-	return hmac.Equal(mac.Sum(nil), expected)
-}
-
-// dialSSHClient establishes an SSH client connection, transparently handling ProxyJump.
-// Returns (client, jumpClient, error). jumpClient is non-nil only when a ProxyJump is
-// used; the caller must close jumpClient after closing client.
+// dialSSHClient establishes an SSH client connection, transparently handling ProxyJump
+// and ProxyCommand. Returns (client, jumpClient, error). jumpClient is non-nil only when
+// a ProxyJump is used; the caller must close jumpClient after closing client.
 func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	authMethods, err := buildAuthMethods(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	khFile, err := resolveKnownHostsFile(cfg.KnownHostsFile)
+	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
 	if err != nil {
 		return nil, nil, err
-	}
-	hkCallback, err := knownhosts.New(khFile)
-	if err != nil {
-		return nil, nil, fmt.Errorf("loading known_hosts %s: %w", khFile, err)
 	}
 
 	port := cfg.Port
@@ -183,12 +96,6 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		Auth:            authMethods,
 		HostKeyCallback: hkCallback,
 		Timeout:         30 * time.Second,
-	}
-	// Advertise only the algorithms present in known_hosts for this host.
-	// Without this, Go's SSH library may negotiate a different algorithm than
-	// what is stored, causing a "key mismatch" error even though the key is valid.
-	if algos := knownHostsAlgorithms(khFile, addr); len(algos) > 0 {
-		sshCfg.HostKeyAlgorithms = algos
 	}
 
 	var conn net.Conn

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -217,10 +217,10 @@ func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 		return nil, fmt.Errorf("starting proxy command: %w", err)
 	}
 	return &proxyCommandConn{
-		cmd:   c,
-		stdin: stdin,
+		cmd:    c,
+		stdin:  stdin,
 		stdout: stdout,
-		raddr: proxyAddr(net.JoinHostPort(host, fmt.Sprintf("%d", port))),
+		raddr:  proxyAddr(net.JoinHostPort(host, fmt.Sprintf("%d", port))),
 	}, nil
 }
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -53,6 +54,7 @@ type SSHConfig struct {
 	Cwd            string     // initial working directory on the remote host
 	ConnectionName string     // alias used in panemux (for VSCode Remote SSH)
 	JumpHost       *SSHConfig // non-nil when ProxyJump is configured
+	ProxyCommand   string     // shell command used as stdin/stdout pipe (ProxyCommand directive)
 }
 
 // shellQuotePath wraps path in single quotes and escapes any single quotes
@@ -192,9 +194,12 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	var conn net.Conn
 	var jumpClient *ssh.Client
 
-	if cfg.JumpHost != nil {
+	switch {
+	case cfg.JumpHost != nil:
 		conn, jumpClient, err = dialThroughJump(*cfg.JumpHost, addr)
-	} else {
+	case cfg.ProxyCommand != "":
+		conn, err = dialViaProxyCommand(cfg.ProxyCommand, cfg.Host, port)
+	default:
 		conn, err = net.DialTimeout("tcp", addr, 30*time.Second)
 	}
 	if err != nil {
@@ -239,6 +244,71 @@ func dialThroughJump(jumpCfg SSHConfig, targetAddr string) (net.Conn, *ssh.Clien
 	}
 
 	return conn, jumpClient, nil
+}
+
+// proxyCommandConn wraps an exec.Cmd's stdin/stdout as a net.Conn, mirroring
+// OpenSSH's ProxyCommand behaviour where a subprocess acts as a transparent
+// bidirectional pipe to the remote host.
+type proxyCommandConn struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+}
+
+func (c *proxyCommandConn) Read(p []byte) (int, error)  { return c.stdout.Read(p) }
+func (c *proxyCommandConn) Write(p []byte) (int, error) { return c.stdin.Write(p) }
+func (c *proxyCommandConn) Close() error {
+	c.stdin.Close()
+	c.stdout.Close()
+	if c.cmd.Process != nil {
+		c.cmd.Process.Kill() //nolint:errcheck
+	}
+	return c.cmd.Wait()
+}
+func (c *proxyCommandConn) LocalAddr() net.Addr                { return proxyAddr("proxy-local") }
+func (c *proxyCommandConn) RemoteAddr() net.Addr               { return proxyAddr("proxy-remote") }
+func (c *proxyCommandConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *proxyCommandConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *proxyCommandConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// proxyAddr is a minimal net.Addr used by proxyCommandConn.
+type proxyAddr string
+
+func (a proxyAddr) Network() string { return "proxy" }
+func (a proxyAddr) String() string  { return string(a) }
+
+// substituteProxyCommand replaces %h (hostname), %p (port), and %% (literal %)
+// in a ProxyCommand string, matching OpenSSH token substitution.
+func substituteProxyCommand(cmd, host string, port int) string {
+	// Temporarily replace %% to avoid double-substitution
+	result := strings.ReplaceAll(cmd, "%%", "\x00")
+	result = strings.ReplaceAll(result, "%h", host)
+	result = strings.ReplaceAll(result, "%p", fmt.Sprintf("%d", port))
+	return strings.ReplaceAll(result, "\x00", "%")
+}
+
+// dialViaProxyCommand runs the ProxyCommand and returns a net.Conn backed by the
+// subprocess stdin/stdout, mirroring how OpenSSH handles ProxyCommand.
+// The command is passed to /bin/sh -c so shell quoting and features work as expected.
+func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
+	cmd := substituteProxyCommand(proxyCmd, host, port)
+	// Pass to /bin/sh -c so the command is interpreted by a shell, matching
+	// OpenSSH behaviour. /bin/sh is a hardcoded trusted binary.
+	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec -- cmd is from trusted ~/.ssh/config
+	c.Stderr = os.Stderr
+
+	stdin, err := c.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("proxy command stdin: %w", err)
+	}
+	stdout, err := c.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("proxy command stdout: %w", err)
+	}
+	if err := c.Start(); err != nil {
+		return nil, fmt.Errorf("starting proxy command: %w", err)
+	}
+	return &proxyCommandConn{cmd: c, stdin: stdin, stdout: stdout}, nil
 }
 
 // NewSSH creates and starts a new SSH terminal session.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -160,6 +160,7 @@ type proxyCommandConn struct {
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
 	stdout io.ReadCloser
+	raddr  net.Addr // host:port of the remote end, used for knownhosts verification
 }
 
 func (c *proxyCommandConn) Read(p []byte) (int, error)  { return c.stdout.Read(p) }
@@ -172,8 +173,8 @@ func (c *proxyCommandConn) Close() error {
 	}
 	return c.cmd.Wait()
 }
-func (c *proxyCommandConn) LocalAddr() net.Addr                { return proxyAddr("proxy-local") }
-func (c *proxyCommandConn) RemoteAddr() net.Addr               { return proxyAddr("proxy-remote") }
+func (c *proxyCommandConn) LocalAddr() net.Addr                { return proxyAddr("127.0.0.1:0") }
+func (c *proxyCommandConn) RemoteAddr() net.Addr               { return c.raddr }
 func (c *proxyCommandConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *proxyCommandConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *proxyCommandConn) SetWriteDeadline(_ time.Time) error { return nil }
@@ -215,7 +216,12 @@ func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 	if err := c.Start(); err != nil {
 		return nil, fmt.Errorf("starting proxy command: %w", err)
 	}
-	return &proxyCommandConn{cmd: c, stdin: stdin, stdout: stdout}, nil
+	return &proxyCommandConn{
+		cmd:   c,
+		stdin: stdin,
+		stdout: stdout,
+		raddr: proxyAddr(net.JoinHostPort(host, fmt.Sprintf("%d", port))),
+	}, nil
 }
 
 // NewSSH creates and starts a new SSH terminal session.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -34,6 +35,7 @@ type SSHSession struct {
 	// combined reader for stdout+stderr
 	reader         io.Reader
 	connectionName string
+	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
 }
 
 // SSHConfig holds parameters for establishing an SSH connection.
@@ -44,8 +46,9 @@ type SSHConfig struct {
 	KeyFile        string
 	Password       string
 	KnownHostsFile string
-	Cwd            string // initial working directory on the remote host
-	ConnectionName string // alias used in panemux (for VSCode Remote SSH)
+	Cwd            string     // initial working directory on the remote host
+	ConnectionName string     // alias used in panemux (for VSCode Remote SSH)
+	JumpHost       *SSHConfig // non-nil when ProxyJump is configured
 }
 
 // shellQuotePath wraps path in single quotes and escapes any single quotes
@@ -54,22 +57,25 @@ func shellQuotePath(path string) string {
 	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
-// NewSSH creates and starts a new SSH terminal session.
-func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
+// dialSSHClient establishes an SSH client connection, transparently handling ProxyJump.
+// Returns (client, jumpClient, error). jumpClient is non-nil only when a ProxyJump is
+// used; the caller must close jumpClient after closing client.
+func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	authMethods, err := buildAuthMethods(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sshCfg := &ssh.ClientConfig{
 		User:            cfg.User,
 		Auth:            authMethods,
 		HostKeyCallback: hkCallback,
+		Timeout:         30 * time.Second,
 	}
 
 	port := cfg.Port
@@ -78,22 +84,71 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	}
 	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", port))
 
-	conn, err := net.Dial("tcp", addr)
+	var conn net.Conn
+	var jumpClient *ssh.Client
+
+	if cfg.JumpHost != nil {
+		conn, jumpClient, err = dialThroughJump(*cfg.JumpHost, addr)
+	} else {
+		conn, err = net.DialTimeout("tcp", addr, 30*time.Second)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("tcp dial %s: %w", addr, err)
+		return nil, nil, err
 	}
 
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshCfg)
 	if err != nil {
 		conn.Close()
-		return nil, fmt.Errorf("ssh handshake: %w", err)
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
+		return nil, nil, fmt.Errorf("ssh handshake: %w", err)
 	}
 
-	client := ssh.NewClient(sshConn, chans, reqs)
+	return ssh.NewClient(sshConn, chans, reqs), jumpClient, nil
+}
+
+// dialThroughJump connects to targetAddr by tunneling through a ProxyJump host.
+// Returns (conn to target, jumpClient, error). The jumpClient must be kept open
+// as long as conn is in use and closed when the target session ends.
+func dialThroughJump(jumpCfg SSHConfig, targetAddr string) (net.Conn, *ssh.Client, error) {
+	jumpClient, nestedJump, err := dialSSHClient(jumpCfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("dial jump host: %w", err)
+	}
+	// nestedJump would be non-nil for multi-hop chains; close it when jumpClient closes.
+	// ssh.Client.Close() closes the underlying connection, which closes nestedJump's channel.
+	// Still, hold a reference so we can close it explicitly on error.
+	if nestedJump != nil {
+		defer func() {
+			if err != nil {
+				nestedJump.Close()
+			}
+		}()
+	}
+
+	conn, err := jumpClient.Dial("tcp", targetAddr)
+	if err != nil {
+		jumpClient.Close()
+		return nil, nil, fmt.Errorf("dial target through jump host: %w", err)
+	}
+
+	return conn, jumpClient, nil
+}
+
+// NewSSH creates and starts a new SSH terminal session.
+func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
+	client, jumpClient, err := dialSSHClient(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	sess, err := client.NewSession()
 	if err != nil {
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("new ssh session: %w", err)
 	}
 
@@ -106,6 +161,9 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("request pty: %w", err)
 	}
 
@@ -113,6 +171,9 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	if err != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("stdin pipe: %w", err)
 	}
 
@@ -129,6 +190,9 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		if !validRemotePath.MatchString(cfg.Cwd) {
 			sess.Close()
 			client.Close()
+			if jumpClient != nil {
+				jumpClient.Close()
+			}
 			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
 		}
 		startErr = sess.Start(fmt.Sprintf("cd %s && exec $SHELL", shellQuotePath(cfg.Cwd)))
@@ -138,6 +202,9 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 	if startErr != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("start shell: %w", startErr)
 	}
 
@@ -150,6 +217,7 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		stdin:          stdin,
 		reader:         pr,
 		connectionName: cfg.ConnectionName,
+		jumpClient:     jumpClient,
 	}
 
 	// Monitor session exit
@@ -251,7 +319,11 @@ func (s *SSHSession) Close() error {
 
 	s.stdin.Close()
 	s.session.Close()
-	return s.client.Close()
+	err := s.client.Close()
+	if s.jumpClient != nil {
+		s.jumpClient.Close()
+	}
+	return err
 }
 
 // ConnectionName returns the panemux connection alias for this SSH session.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1,6 +1,10 @@
 package session
 
 import (
+	"bufio"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
@@ -57,6 +61,97 @@ func shellQuotePath(path string) string {
 	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
 }
 
+// resolveKnownHostsFile returns the known_hosts file path, defaulting to ~/.ssh/known_hosts.
+func resolveKnownHostsFile(knownHostsFile string) (string, error) {
+	if knownHostsFile != "" {
+		return knownHostsFile, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home dir: %w", err)
+	}
+	return filepath.Join(home, ".ssh", "known_hosts"), nil
+}
+
+// knownHostsAlgorithms returns the host key algorithms stored in knownHostsFile
+// for the given address. It supports both plaintext and hashed (|1|...) hostname entries.
+// This populates ssh.ClientConfig.HostKeyAlgorithms so Go's SSH library negotiates
+// the same algorithm that is stored in known_hosts, preventing false "key mismatch" errors
+// that occur when the server offers a different algorithm than the one recorded.
+func knownHostsAlgorithms(knownHostsFile, address string) []string {
+	f, err := os.Open(knownHostsFile)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	normalized := knownhosts.Normalize(address)
+
+	seen := make(map[string]bool)
+	var algos []string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "@") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		hostsField := fields[0]
+		keyType := fields[1]
+		if knownHostsFieldMatchesAddr(hostsField, normalized) && !seen[keyType] {
+			seen[keyType] = true
+			algos = append(algos, keyType)
+		}
+	}
+
+	return algos
+}
+
+// knownHostsFieldMatchesAddr checks whether any pattern in a known_hosts hosts field
+// (comma-separated) matches the given normalized address.
+func knownHostsFieldMatchesAddr(hostsField, normalizedAddr string) bool {
+	for _, pattern := range strings.Split(hostsField, ",") {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" || strings.HasPrefix(pattern, "!") {
+			continue
+		}
+		if strings.HasPrefix(pattern, "|1|") {
+			if knownHostsHashedEntryMatches(pattern, normalizedAddr) {
+				return true
+			}
+		} else {
+			if knownhosts.Normalize(pattern) == normalizedAddr {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// knownHostsHashedEntryMatches checks whether the hashed known_hosts entry
+// (|1|salt|hash format) matches the normalized address.
+func knownHostsHashedEntryMatches(entry, normalizedAddr string) bool {
+	parts := strings.Split(entry, "|")
+	if len(parts) != 4 || parts[1] != "1" {
+		return false
+	}
+	salt, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		return false
+	}
+	expected, err := base64.StdEncoding.DecodeString(parts[3])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha1.New, salt)
+	mac.Write([]byte(normalizedAddr))
+	return hmac.Equal(mac.Sum(nil), expected)
+}
+
 // dialSSHClient establishes an SSH client connection, transparently handling ProxyJump.
 // Returns (client, jumpClient, error). jumpClient is non-nil only when a ProxyJump is
 // used; the caller must close jumpClient after closing client.
@@ -66,16 +161,13 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		return nil, nil, err
 	}
 
-	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
+	khFile, err := resolveKnownHostsFile(cfg.KnownHostsFile)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	sshCfg := &ssh.ClientConfig{
-		User:            cfg.User,
-		Auth:            authMethods,
-		HostKeyCallback: hkCallback,
-		Timeout:         30 * time.Second,
+	hkCallback, err := knownhosts.New(khFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading known_hosts %s: %w", khFile, err)
 	}
 
 	port := cfg.Port
@@ -83,6 +175,19 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		port = 22
 	}
 	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", port))
+
+	sshCfg := &ssh.ClientConfig{
+		User:            cfg.User,
+		Auth:            authMethods,
+		HostKeyCallback: hkCallback,
+		Timeout:         30 * time.Second,
+	}
+	// Advertise only the algorithms present in known_hosts for this host.
+	// Without this, Go's SSH library may negotiate a different algorithm than
+	// what is stored, causing a "key mismatch" error even though the key is valid.
+	if algos := knownHostsAlgorithms(khFile, addr); len(algos) > 0 {
+		sshCfg.HostKeyAlgorithms = algos
+	}
 
 	var conn net.Conn
 	var jumpClient *ssh.Client
@@ -233,16 +338,13 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 }
 
 func buildHostKeyCallback(knownHostsFile string) (ssh.HostKeyCallback, error) {
-	if knownHostsFile == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return nil, fmt.Errorf("getting home dir: %w", err)
-		}
-		knownHostsFile = filepath.Join(home, ".ssh", "known_hosts")
-	}
-	cb, err := knownhosts.New(knownHostsFile)
+	path, err := resolveKnownHostsFile(knownHostsFile)
 	if err != nil {
-		return nil, fmt.Errorf("loading known_hosts %s: %w", knownHostsFile, err)
+		return nil, err
+	}
+	cb, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading known_hosts %s: %w", path, err)
 	}
 	return cb, nil
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // generateTestKeyFile creates a real ed25519 private key file at the given path
@@ -134,59 +133,6 @@ func TestSubstituteProxyCommand_NoTokens(t *testing.T) {
 	cmd := "nc -q0 bastion 22"
 	got := substituteProxyCommand(cmd, "unused", 0)
 	assert.Equal(t, cmd, got)
-}
-
-func TestKnownHostsAlgorithms_PlaintextEntry(t *testing.T) {
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	pub, err := gossh.NewPublicKey(priv.Public())
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	knownHostsPath := filepath.Join(dir, "known_hosts")
-	// Use knownhosts.Line to generate a properly formatted entry
-	content := knownhosts.Line([]string{"myhost"}, pub) + "\n"
-	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
-
-	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
-	assert.Equal(t, []string{pub.Type()}, algos)
-}
-
-func TestKnownHostsAlgorithms_HashedEntry(t *testing.T) {
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	pub, err := gossh.NewPublicKey(priv.Public())
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	knownHostsPath := filepath.Join(dir, "known_hosts")
-	// Use hashed hostname format
-	hashed := knownhosts.HashHostname("hashhost")
-	content := knownhosts.Line([]string{hashed}, pub) + "\n"
-	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
-
-	algos := knownHostsAlgorithms(knownHostsPath, "hashhost:22")
-	assert.Equal(t, []string{pub.Type()}, algos)
-}
-
-func TestKnownHostsAlgorithms_NoMatch_ReturnsEmpty(t *testing.T) {
-	_, priv, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
-	pub, err := gossh.NewPublicKey(priv.Public())
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	knownHostsPath := filepath.Join(dir, "known_hosts")
-	content := knownhosts.Line([]string{"otherhost"}, pub) + "\n"
-	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
-
-	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
-	assert.Empty(t, algos)
-}
-
-func TestKnownHostsAlgorithms_FileNotFound_ReturnsEmpty(t *testing.T) {
-	algos := knownHostsAlgorithms("/nonexistent/known_hosts", "myhost:22")
-	assert.Empty(t, algos)
 }
 
 func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -119,6 +119,23 @@ func TestShellQuotePath_Empty(t *testing.T) {
 	assert.Equal(t, "''", shellQuotePath(""))
 }
 
+func TestSubstituteProxyCommand_Substitutions(t *testing.T) {
+	cmd := "gcloud compute start-iap-tunnel %h %p --listen-on-stdin"
+	got := substituteProxyCommand(cmd, "myhost.example.com", 22)
+	assert.Equal(t, "gcloud compute start-iap-tunnel myhost.example.com 22 --listen-on-stdin", got)
+}
+
+func TestSubstituteProxyCommand_PercentEscape(t *testing.T) {
+	got := substituteProxyCommand("echo %%h is not %h", "host", 22)
+	assert.Equal(t, "echo %h is not host", got)
+}
+
+func TestSubstituteProxyCommand_NoTokens(t *testing.T) {
+	cmd := "nc -q0 bastion 22"
+	got := substituteProxyCommand(cmd, "unused", 0)
+	assert.Equal(t, cmd, got)
+}
+
 func TestKnownHostsAlgorithms_PlaintextEntry(t *testing.T) {
 	_, priv, err := ed25519.GenerateKey(rand.Reader)
 	require.NoError(t, err)

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // generateTestKeyFile creates a real ed25519 private key file at the given path
@@ -136,7 +137,7 @@ func TestSubstituteProxyCommand_NoTokens(t *testing.T) {
 }
 
 func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {
-	_, err := buildHostKeyCallback("/nonexistent/path/known_hosts")
+	_, _, err := buildHostKeyCallback("/nonexistent/path/known_hosts")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "known_hosts")
 }
@@ -146,7 +147,7 @@ func TestBuildHostKeyCallback_ValidFile_NoError(t *testing.T) {
 	knownHostsPath := filepath.Join(dir, "known_hosts")
 	require.NoError(t, os.WriteFile(knownHostsPath, []byte(""), 0600))
 
-	_, err := buildHostKeyCallback(knownHostsPath)
+	_, _, err := buildHostKeyCallback(knownHostsPath)
 	assert.NoError(t, err)
 }
 
@@ -173,4 +174,55 @@ func TestNewTmuxSSH_InvalidSessionName_Error(t *testing.T) {
 	_, err := NewTmuxSSH("id", "title", "foo;bar$(evil)", cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid tmux session name")
+}
+
+func TestKnownHostsAlgorithms_PlaintextEntry(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	content := knownhosts.Line([]string{"myhost"}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
+	assert.Equal(t, []string{pub.Type()}, algos)
+}
+
+func TestKnownHostsAlgorithms_HashedEntry(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	hashed := knownhosts.HashHostname("hashhost")
+	content := knownhosts.Line([]string{hashed}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "hashhost:22")
+	assert.Equal(t, []string{pub.Type()}, algos)
+}
+
+func TestKnownHostsAlgorithms_NoMatch_ReturnsEmpty(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	content := knownhosts.Line([]string{"otherhost"}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
+	assert.Empty(t, algos)
+}
+
+func TestKnownHostsAlgorithms_FileNotFound_ReturnsEmpty(t *testing.T) {
+	algos := knownHostsAlgorithms("/nonexistent/known_hosts", "myhost:22")
+	assert.Empty(t, algos)
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // generateTestKeyFile creates a real ed25519 private key file at the given path
@@ -116,6 +117,59 @@ func TestShellQuotePath_WithSingleQuote(t *testing.T) {
 
 func TestShellQuotePath_Empty(t *testing.T) {
 	assert.Equal(t, "''", shellQuotePath(""))
+}
+
+func TestKnownHostsAlgorithms_PlaintextEntry(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	// Use knownhosts.Line to generate a properly formatted entry
+	content := knownhosts.Line([]string{"myhost"}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
+	assert.Equal(t, []string{pub.Type()}, algos)
+}
+
+func TestKnownHostsAlgorithms_HashedEntry(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	// Use hashed hostname format
+	hashed := knownhosts.HashHostname("hashhost")
+	content := knownhosts.Line([]string{hashed}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "hashhost:22")
+	assert.Equal(t, []string{pub.Type()}, algos)
+}
+
+func TestKnownHostsAlgorithms_NoMatch_ReturnsEmpty(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	pub, err := gossh.NewPublicKey(priv.Public())
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	knownHostsPath := filepath.Join(dir, "known_hosts")
+	content := knownhosts.Line([]string{"otherhost"}, pub) + "\n"
+	require.NoError(t, os.WriteFile(knownHostsPath, []byte(content), 0600))
+
+	algos := knownHostsAlgorithms(knownHostsPath, "myhost:22")
+	assert.Empty(t, algos)
+}
+
+func TestKnownHostsAlgorithms_FileNotFound_ReturnsEmpty(t *testing.T) {
+	algos := knownHostsAlgorithms("/nonexistent/known_hosts", "myhost:22")
+	assert.Empty(t, algos)
 }
 
 func TestBuildHostKeyCallback_NonexistentFile_Error(t *testing.T) {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -3,7 +3,6 @@ package session
 import (
 	"fmt"
 	"io"
-	"net"
 	"regexp"
 	"strings"
 	"sync"
@@ -25,6 +24,7 @@ type TmuxSSHSession struct {
 	stdin          io.WriteCloser
 	reader         io.Reader
 	connectionName string
+	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
 }
 
 // NewTmuxSSH creates a session that attaches to a remote tmux session.
@@ -36,44 +36,17 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		return nil, fmt.Errorf("invalid tmux session name %q: must match ^[a-zA-Z0-9_.-]+$", tmuxSession)
 	}
 
-	authMethods, err := buildAuthMethods(cfg)
+	client, jumpClient, err := dialSSHClient(cfg)
 	if err != nil {
 		return nil, err
 	}
-
-	hkCallback, err := buildHostKeyCallback(cfg.KnownHostsFile)
-	if err != nil {
-		return nil, err
-	}
-
-	sshCfg := &ssh.ClientConfig{
-		User:            cfg.User,
-		Auth:            authMethods,
-		HostKeyCallback: hkCallback,
-	}
-
-	port := cfg.Port
-	if port == 0 {
-		port = 22
-	}
-	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", port))
-
-	conn, err := net.Dial("tcp", addr)
-	if err != nil {
-		return nil, fmt.Errorf("tcp dial %s: %w", addr, err)
-	}
-
-	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, sshCfg)
-	if err != nil {
-		conn.Close()
-		return nil, fmt.Errorf("ssh handshake: %w", err)
-	}
-
-	client := ssh.NewClient(sshConn, chans, reqs)
 
 	sess, err := client.NewSession()
 	if err != nil {
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("new ssh session: %w", err)
 	}
 
@@ -85,6 +58,9 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("request pty: %w", err)
 	}
 
@@ -92,6 +68,9 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	if err != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("stdin pipe: %w", err)
 	}
 
@@ -110,6 +89,9 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		if !validRemotePath.MatchString(cfg.Cwd) {
 			sess.Close()
 			client.Close()
+			if jumpClient != nil {
+				jumpClient.Close()
+			}
 			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
 		}
 		tmuxCmd += fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd))
@@ -117,6 +99,9 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	if err := sess.Start(tmuxCmd); err != nil {
 		sess.Close()
 		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
 		return nil, fmt.Errorf("starting tmux attach: %w", err)
 	}
 
@@ -130,6 +115,7 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		stdin:          stdin,
 		reader:         pr,
 		connectionName: cfg.ConnectionName,
+		jumpClient:     jumpClient,
 	}
 
 	go func() {
@@ -189,5 +175,9 @@ func (s *TmuxSSHSession) Close() error {
 
 	s.stdin.Close()
 	s.session.Close()
-	return s.client.Close()
+	err := s.client.Close()
+	if s.jumpClient != nil {
+		s.jumpClient.Close()
+	}
+	return err
 }

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -17,6 +17,7 @@ type Host struct {
 	Port         int // 0 = not set (caller uses default 22)
 	IdentityFile string
 	ProxyJump    string // ProxyJump directive (alias or user@host)
+	ProxyCommand string // ProxyCommand directive (shell command acting as stdin/stdout pipe)
 }
 
 // DefaultPath returns the default SSH config path (~/.ssh/config).
@@ -94,6 +95,8 @@ func ParseHosts(path string) ([]Host, error) {
 			current.IdentityFile = val
 		case "proxyjump":
 			current.ProxyJump = val
+		case "proxycommand":
+			current.ProxyCommand = val
 		}
 	}
 

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -16,6 +16,7 @@ type Host struct {
 	User         string
 	Port         int // 0 = not set (caller uses default 22)
 	IdentityFile string
+	ProxyJump    string // ProxyJump directive (alias or user@host)
 }
 
 // DefaultPath returns the default SSH config path (~/.ssh/config).
@@ -91,6 +92,8 @@ func ParseHosts(path string) ([]Host, error) {
 			}
 		case "identityfile":
 			current.IdentityFile = val
+		case "proxyjump":
+			current.ProxyJump = val
 		}
 	}
 

--- a/internal/sshconfig/parse_test.go
+++ b/internal/sshconfig/parse_test.go
@@ -181,6 +181,40 @@ func TestParseHosts_AfterAppend(t *testing.T) {
 	assert.Equal(t, 22, hosts[0].Port)
 }
 
+func TestParseHosts_ProxyJump(t *testing.T) {
+	content := `Host jump
+    HostName jump.example.com
+    User jumpuser
+
+Host target
+    HostName target.internal
+    User admin
+    ProxyJump jump
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 2)
+
+	assert.Equal(t, "jump", hosts[0].Name)
+	assert.Equal(t, "", hosts[0].ProxyJump)
+
+	assert.Equal(t, "target", hosts[1].Name)
+	assert.Equal(t, "jump", hosts[1].ProxyJump)
+}
+
+func TestParseHosts_NoProxyJump_Empty(t *testing.T) {
+	content := `Host myserver
+    HostName myserver.example.com
+    User ubuntu
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "", hosts[0].ProxyJump)
+}
+
 // writeTempSSHConfig creates a temp file with the given content and returns the path.
 func writeTempSSHConfig(t *testing.T, content string) string {
 	t.Helper()

--- a/internal/sshconfig/parse_test.go
+++ b/internal/sshconfig/parse_test.go
@@ -203,6 +203,20 @@ Host target
 	assert.Equal(t, "jump", hosts[1].ProxyJump)
 }
 
+func TestParseHosts_ProxyCommand(t *testing.T) {
+	content := `Host bastion
+    HostName bastion.example.com
+    User admin
+    ProxyCommand gcloud compute start-iap-tunnel bastion %p --listen-on-stdin --project=my-project --zone=us-central1-a
+`
+	f := writeTempSSHConfig(t, content)
+	hosts, err := ParseHosts(f)
+	require.NoError(t, err)
+	require.Len(t, hosts, 1)
+	assert.Equal(t, "gcloud compute start-iap-tunnel bastion %p --listen-on-stdin --project=my-project --zone=us-central1-a", hosts[0].ProxyCommand)
+	assert.Equal(t, "", hosts[0].ProxyJump)
+}
+
 func TestParseHosts_NoProxyJump_Empty(t *testing.T) {
 	content := `Host myserver
     HostName myserver.example.com


### PR DESCRIPTION
## Summary

SSH connections requiring `ProxyJump` or `ProxyCommand` in `~/.ssh/config` were failing immediately.

**Changes:**

### ProxyJump support
- Parse `ProxyJump` directive in `sshconfig.ParseHosts`
- `resolveSSHConfig` recursively resolves the jump host and stores it in `SSHConfig.JumpHost`
- Extract `dialSSHClient` helper (shared by `NewSSH` and `NewTmuxSSH`) that tunnels through the jump host

### ProxyCommand support
- Parse `ProxyCommand` directive in `sshconfig.ParseHosts`
- `dialViaProxyCommand` runs `/bin/sh -c <cmd>` with `%h`/`%p`/`%%` token substitution, matching OpenSSH behaviour
- `proxyCommandConn` wraps the subprocess stdin/stdout as a `net.Conn`
- ProxyCommand is used when the target (or jump) host has no direct TCP route

### Host key algorithm fix
- Before dialing, parse `known_hosts` to find which algorithms are stored for the target host
- Set `ssh.ClientConfig.HostKeyAlgorithms` so Go's SSH library negotiates the same algorithm recorded in `known_hosts`, preventing false "key mismatch" errors

### Other fixes
- Relative `IdentityFile` paths (e.g. `.ssh/id_ed25519` without `~/`) are now expanded relative to `$HOME`, matching OpenSSH
- Add `Timeout: 30s` to `ssh.ClientConfig`
- Jump client kept alive for session duration, closed on `Close()`

## Test plan

- [x] `TestParseHosts_ProxyJump` / `TestParseHosts_ProxyCommand` — directives parsed correctly
- [x] `TestResolveSSHConfig_ProxyJump` — JumpHost populated
- [x] `TestResolveSSHConfig_ProxyCommand` — ProxyCommand populated
- [x] `TestResolveSSHConfig_RelativeIdentityFile` — relative path expanded to HOME
- [x] `TestSubstituteProxyCommand_*` — %h/%p/%% token substitution
- [x] `TestKnownHostsAlgorithms_*` — plaintext + hashed known_hosts entries
- [x] All existing tests pass