### PR TITLE
feat: show status bar by default

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -11,7 +11,7 @@ server:
 # Global defaults for all panes. Individual panes can override these values.
 display:
   show_header: true      # show pane header with title and controls (default: true)
-  show_status_bar: false # show terminal dimensions bar at the bottom (default: false)
+  show_status_bar: true  # show terminal dimensions bar at the bottom (default: true)
 
 # ── SSH connections ────────────────────────────────────────────────────────────
 # Define named SSH connections here; reference them in panes with `connection:`.
@@ -71,7 +71,7 @@ layout:
         title: "Dev Shell"      # optional; shown in the pane header
         # Per-pane display overrides (uncomment to override global display settings):
         # show_header: false
-        show_status_bar: true   # show dimensions bar for this pane only
+        show_status_bar: false  # hide dimensions bar for this pane only
 
     # ── right half: vertical split ──────────────────────────────────────────
     - size: 50

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { TERMINAL_FONT_FAMILY } from './utils/fonts'
 import { findPaneById } from './utils/layoutTree'
 import type { SSHConfigHost } from './schemas'
 
-const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
+const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
 
 export const App: React.FC = () => {
   const { layout, displayConfig, error, updateSizes, splitPane, closePane, swapPanes } = useLayout()

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -5,7 +5,7 @@ import { PaneHeader } from './PaneHeader'
 import { PaneStatusBar } from './PaneStatusBar'
 import { LayoutActionsContext } from './SplitContainer'
 
-const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: false }
+const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
 
 interface TerminalPaneProps {
   pane: PaneConfig

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -8,7 +8,7 @@ const validLayout: LayoutNode = {
   children: [{ size: 100, pane: { id: 'main', type: 'local' } }],
 }
 
-const validDisplay = { show_header: true, show_status_bar: false }
+const validDisplay = { show_header: true, show_status_bar: true }
 
 describe('useLayout', () => {
   afterEach(() => {
@@ -34,7 +34,7 @@ describe('useLayout', () => {
     const { result } = renderHook(() => useLayout())
     await waitFor(() => expect(result.current.displayConfig).not.toBeNull())
     expect(result.current.displayConfig?.show_header).toBe(true)
-    expect(result.current.displayConfig?.show_status_bar).toBe(false)
+    expect(result.current.displayConfig?.show_status_bar).toBe(true)
   })
 
   it('sets error on fetch failure', async () => {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -405,7 +405,7 @@ func TestDeleteSession_EditModeOn_Saves(t *testing.T) {
 
 func TestGetDisplay_ReturnsJSON(t *testing.T) {
 	cfg := defaultTestConfig()
-	cfg.Display = config.DisplayConfig{ShowHeader: true, ShowStatusBar: false}
+	cfg.Display = config.DisplayConfig{ShowHeader: true, ShowStatusBar: true}
 	r := setupRouter(cfg, session.NewManager())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/display", nil)
@@ -415,7 +415,7 @@ func TestGetDisplay_ReturnsJSON(t *testing.T) {
 	var display config.DisplayConfig
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&display))
 	assert.True(t, display.ShowHeader)
-	assert.False(t, display.ShowStatusBar)
+	assert.True(t, display.ShowStatusBar)
 }
 
 func TestPutLayout_ExpandsTildeCwd(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,7 +100,7 @@ func Default() *Config {
 		},
 		Display: DisplayConfig{
 			ShowHeader:    true,
-			ShowStatusBar: false,
+			ShowStatusBar: true,
 		},
 		Layout: LayoutNode{
 			Direction: "horizontal",


### PR DESCRIPTION
## Summary
- Change `show_status_bar` default from `false` to `true` so the terminal dimensions bar is visible out of the box
- Updated backend `Default()` config, frontend fallback constants, tests, and `config.example.yaml`

## Test plan
- [x] `go test ./internal/config/... ./internal/api/...` passes
- [x] `make test-frontend` passes (147 tests)