### PR TITLE
feat: show git repository info in pane header

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -106,8 +106,12 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       />
       <span style={{ color, fontWeight: 600 }}>{label}</span>
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
-      {gitInfo?.is_git && gitInfo.branch && (
-        <span style={{ color: '#6e8a6e', fontSize: '11px' }}>⎇ {gitInfo.branch}</span>
+      {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch) && (
+        <span style={{ color: '#6e8a6e', fontSize: '11px' }}>
+          {gitInfo.repo && <span>{gitInfo.repo}</span>}
+          {gitInfo.repo && gitInfo.branch && <span style={{ color: '#4a6a4a' }}>{' '}⎇{' '}</span>}
+          {gitInfo.branch && <span>{gitInfo.branch}</span>}
+        </span>
       )}
       {!connected && <span style={{ color: '#555' }}>reconnecting…</span>}
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '4px' }}>

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
+import { GitInfo } from '../schemas'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
 interface PaneHeaderProps {
@@ -8,6 +9,7 @@ interface PaneHeaderProps {
   displayConfig: DisplayConfig
   isMaximized: boolean
   editMode: boolean
+  gitInfo?: GitInfo
   onSplit: (direction: 'horizontal' | 'vertical') => void
   onClose: () => void
   onMaximize: () => void
@@ -51,6 +53,7 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
   displayConfig,
   isMaximized,
   editMode,
+  gitInfo,
   onSplit,
   onClose,
   onMaximize,
@@ -103,6 +106,9 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       />
       <span style={{ color, fontWeight: 600 }}>{label}</span>
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
+      {gitInfo?.is_git && gitInfo.branch && (
+        <span style={{ color: '#6e8a6e', fontSize: '11px' }}>⎇ {gitInfo.branch}</span>
+      )}
       {!connected && <span style={{ color: '#555' }}>reconnecting…</span>}
       <div style={{ marginLeft: 'auto', display: 'flex', gap: '4px' }}>
         {editMode && (

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
 import { useTerminal } from '../hooks/useTerminal'
+import { useGitInfo } from '../hooks/useGitInfo'
 import { PaneHeader } from './PaneHeader'
 import { PaneStatusBar } from './PaneStatusBar'
 import { LayoutActionsContext } from './SplitContainer'
@@ -35,6 +36,8 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
     container: containerEl,
     editMode,
   })
+
+  const gitInfo = useGitInfo(pane.id)
 
   // Observe resize events for this pane
   useEffect(() => {
@@ -116,6 +119,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
         displayConfig={displayConfig}
         isMaximized={ctx?.maximizedPaneId === pane.id}
         editMode={editMode}
+        gitInfo={gitInfo}
         onSplit={(direction) => ctx?.onSplit(pane.id, direction)}
         onClose={() => ctx?.onClose(pane.id)}
         onMaximize={() => ctx?.onMaximize(ctx.maximizedPaneId === pane.id ? null : pane.id)}

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { useGitInfo } from './useGitInfo'
+
+describe('useGitInfo', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns isGit false initially before fetch resolves', () => {
+    window.fetch = vi.fn().mockReturnValue(new Promise(() => {})) // never resolves
+    const { result } = renderHook(() => useGitInfo('pane1'))
+    expect(result.current.is_git).toBe(false)
+    expect(result.current.branch).toBeUndefined()
+    expect(result.current.repo).toBeUndefined()
+  })
+
+  it('returns isGit false on non-git response', async () => {
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    const { result } = renderHook(() => useGitInfo('pane1'))
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
+    await act(async () => {})
+    expect(result.current.is_git).toBe(false)
+  })
+
+  it('returns branch and repo when in a git repo', async () => {
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: true, branch: 'main', repo: 'myrepo' }),
+    } as Response)
+
+    const { result } = renderHook(() => useGitInfo('pane1'))
+    await waitFor(() => expect(result.current.is_git).toBe(true))
+    expect(result.current.branch).toBe('main')
+    expect(result.current.repo).toBe('myrepo')
+  })
+
+  it('calls /api/sessions/{id}/git-info with the correct session id', async () => {
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    renderHook(() => useGitInfo('my-session-id'))
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
+    expect(window.fetch).toHaveBeenCalledWith('/api/sessions/my-session-id/git-info')
+  })
+
+  it('registers a 5-second polling interval', () => {
+    const intervalSpy = vi.spyOn(window, 'setInterval')
+    window.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+
+    renderHook(() => useGitInfo('pane1'))
+
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
+  })
+
+  it('silently ignores fetch errors — state stays at default', async () => {
+    let resolveFetch!: () => void
+    const fetchPromise = new Promise<Response>((_, reject) => {
+      resolveFetch = () => reject(new Error('network error'))
+    })
+    window.fetch = vi.fn().mockReturnValue(fetchPromise)
+
+    const { result } = renderHook(() => useGitInfo('pane1'))
+
+    await act(async () => {
+      resolveFetch()
+      await fetchPromise.catch(() => {})
+    })
+
+    expect(result.current.is_git).toBe(false)
+  })
+
+  it('silently ignores non-ok responses — state stays at default', async () => {
+    let resolveFetch!: (r: Response) => void
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })
+    window.fetch = vi.fn().mockReturnValue(fetchPromise)
+
+    const { result } = renderHook(() => useGitInfo('pane1'))
+
+    await act(async () => {
+      resolveFetch({ ok: false, status: 404 } as Response)
+      await fetchPromise
+    })
+
+    expect(result.current.is_git).toBe(false)
+  })
+})

--- a/frontend/src/hooks/useGitInfo.ts
+++ b/frontend/src/hooks/useGitInfo.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect, useCallback } from 'react'
+import { GitInfo, GitInfoSchema } from '../schemas'
+
+export function useGitInfo(sessionId: string): GitInfo {
+  const [gitInfo, setGitInfo] = useState<GitInfo>({ is_git: false })
+
+  const fetchGitInfo = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/git-info`)
+      if (!res.ok) return
+      const data = GitInfoSchema.parse(await res.json())
+      setGitInfo(data)
+    } catch {
+      // ignore errors silently — git info is best-effort
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    fetchGitInfo()
+    const interval = setInterval(fetchGitInfo, 5000)
+    return () => clearInterval(interval)
+  }, [fetchGitInfo])
+
+  return gitInfo
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -69,6 +69,14 @@ export const WSControlMessageSchema = z.discriminatedUnion('type', [
 
 export type WSControlMessage = z.infer<typeof WSControlMessageSchema>
 
+export const GitInfoSchema = z.object({
+  is_git: z.boolean(),
+  branch: z.string().optional(),
+  repo: z.string().optional(),
+})
+
+export type GitInfo = z.infer<typeof GitInfoSchema>
+
 export const EditModeResponseSchema = z.object({
   editMode: z.boolean(),
 })

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"sync/atomic"
 
 	"github.com/go-chi/chi/v5"
@@ -25,6 +27,7 @@ type Handler struct {
 	editMode       atomic.Bool
 	sshConfigPath  string
 	codeBinaryPath string // empty = auto-detect; overridden in tests
+	gitBinaryPath  string // empty = auto-detect; overridden in tests
 	createSession  func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
 }
 
@@ -424,6 +427,66 @@ func (h *Handler) findVSCode() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("code binary not found")
+}
+
+type gitInfoResponse struct {
+	IsGit  bool   `json:"is_git"`
+	Branch string `json:"branch,omitempty"`
+	Repo   string `json:"repo,omitempty"`
+}
+
+// GetGitInfo returns git repository information for the session's current working directory.
+func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	sess, ok := h.manager.Get(id)
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+
+	cwdGetter, ok := sess.(session.CWDGetter)
+	if !ok {
+		writeJSON(w, gitInfoResponse{IsGit: false})
+		return
+	}
+
+	cwd, err := cwdGetter.GetCWD()
+	if err != nil {
+		writeJSON(w, gitInfoResponse{IsGit: false})
+		return
+	}
+
+	gitPath, err := h.findGit()
+	if err != nil {
+		writeJSON(w, gitInfoResponse{IsGit: false})
+		return
+	}
+
+	// Determine the git repo top-level directory.
+	toplevelOut, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output() //nolint:gosec -- gitPath from trusted lookup, cwd from OS
+	if err != nil {
+		writeJSON(w, gitInfoResponse{IsGit: false})
+		return
+	}
+	repo := filepath.Base(strings.TrimSpace(string(toplevelOut)))
+
+	// Get the current branch name.
+	branchOut, err := exec.Command(gitPath, "-C", cwd, "branch", "--show-current").Output() //nolint:gosec -- gitPath from trusted lookup, cwd from OS
+	if err != nil {
+		writeJSON(w, gitInfoResponse{IsGit: true, Repo: repo})
+		return
+	}
+	branch := strings.TrimSpace(string(branchOut))
+
+	writeJSON(w, gitInfoResponse{IsGit: true, Branch: branch, Repo: repo})
+}
+
+// findGit returns the path to the git binary.
+func (h *Handler) findGit() (string, error) {
+	if h.gitBinaryPath != "" {
+		return h.gitBinaryPath, nil
+	}
+	return exec.LookPath("git")
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -53,6 +54,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Post("/api/sessions", h.PostSession)
 	r.Delete("/api/sessions/{id}", h.DeleteSession)
 	r.Post("/api/sessions/{id}/restart", h.RestartSession)
+	r.Get("/api/sessions/{id}/git-info", h.GetGitInfo)
 	r.Get("/api/display", h.GetDisplay)
 	r.Get("/api/edit-mode", h.GetEditMode)
 	r.Put("/api/edit-mode", h.PutEditMode)
@@ -910,4 +912,143 @@ func TestPostOpenVSCode_SSHTmux_200(t *testing.T) {
 	var resp openVSCodeResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "/home/user/remote", resp.Cwd)
+}
+
+// initTempGitRepo creates a temporary directory with an initialised git repo
+// on a branch named "main" and returns the directory path.
+func initTempGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "init", "-b", "main", dir},
+		{"git", "-C", dir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "config", "commit.gpgsign", "false"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec -- trusted test args
+		require.NoError(t, err, "git init step failed: %s", string(out))
+	}
+	return dir
+}
+
+func setupRouterWithGitInfo(h *Handler) *chi.Mux {
+	r := setupRouterWithHandler(h)
+	r.Get("/api/sessions/{id}/git-info", h.GetGitInfo)
+	return r
+}
+
+func TestGetGitInfo_NotFound_404(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/missing/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestGetGitInfo_NoCWDGetter_IsGitFalse(t *testing.T) {
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("s1"))
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/s1/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.IsGit)
+}
+
+func TestGetGitInfo_NotAGitRepo_IsGitFalse(t *testing.T) {
+	dir := t.TempDir() // plain directory, no git
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "local1", typ: session.TypeLocal},
+		cwd:         dir,
+	})
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local1/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.IsGit)
+}
+
+func TestGetGitInfo_IsGitRepo_ReturnsBranchAndRepo(t *testing.T) {
+	dir := initTempGitRepo(t)
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "local2", typ: session.TypeLocal},
+		cwd:         dir,
+	})
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local2/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "main", resp.Branch)
+	assert.NotEmpty(t, resp.Repo)
+}
+
+func TestGetGitInfo_SubdirOfGitRepo_ReturnsBranchAndRepo(t *testing.T) {
+	dir := initTempGitRepo(t)
+	subdir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(subdir, 0755))
+
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "sub1", typ: session.TypeLocal},
+		cwd:         subdir,
+	})
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/sub1/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "main", resp.Branch)
+}
+
+func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
+	dir := initTempGitRepo(t)
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "local3", typ: session.TypeLocal},
+		cwd:         dir,
+	})
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.gitBinaryPath = "/nonexistent/git" // simulate git not found
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local3/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.IsGit)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Delete("/sessions/{id}", apiHandler.DeleteSession)
 		r.Post("/sessions/{id}/restart", apiHandler.RestartSession)
 		r.Post("/sessions/{id}/open-vscode", apiHandler.PostOpenVSCode)
+		r.Get("/sessions/{id}/git-info", apiHandler.GetGitInfo)
 		r.Get("/display", apiHandler.GetDisplay)
 		r.Get("/edit-mode", apiHandler.GetEditMode)
 		r.Put("/edit-mode", apiHandler.PutEditMode)


### PR DESCRIPTION
## Summary

- Add `GET /api/sessions/{id}/git-info` endpoint that detects git branch and repo name from the session's current working directory
- Add `GitInfoSchema` / `useGitInfo` hook (polls every 5s) on the frontend
- Display `reponame ⎇ branch` in the pane header when the cwd is inside a git repository

## Test plan

- [x] Backend: `TestGetGitInfo_*` tests cover session-not-found (404), no CWDGetter, non-git directory, git repo root, subdirectory of repo, and git binary not found
- [x] Frontend: `useGitInfo` tests cover initial state, git/non-git responses, correct URL, polling interval registration, and silent error handling
- [x] Go coverage: 84.7% (≥ 80%)
- [x] Frontend coverage: 95.76% (`useGitInfo.ts` 100%)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Go fmt check passes

https://claude.ai/code/session_01MBn3Qy3YQ2ijmQ2bmmvQ7s