### PR TITLE
feat: add golangci-lint v2 to lint pipeline and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Set up golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
+        with:
+          version: v2.11.4
+          install-mode: binary
+          args: --version
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: standard
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    staticcheck:
+      checks: ["all"]
+  exclusions:
+    rules:
+      # Session package manages OS processes and SSH connections; Close/Wait/Kill
+      # errors in teardown paths are not actionable.
+      - path: internal/session/
+        linters:
+          - errcheck
+      # Test cleanup (defer conn.Close(), SetReadDeadline, ReadMessage) does not
+      # require error handling — test failures surface through assertions.
+      - path: _test\.go
+        linters:
+          - errcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,8 @@ Example: `Config.sshConfigPath` (empty = use `sshconfig.DefaultPath()`, non-empt
 - Test commands: `make test-go` / `make test-frontend` / `make test`
 - Coverage commands: `make coverage-go` / `make coverage-frontend`
 - Lint commands: `make lint-go` / `make lint-frontend` / `make lint`
+- **Go lint includes `gofmt`, `go vet`, and `golangci-lint run ./...`** (v2, config in `.golangci.yml`). The lint binary auto-installs via `make install-deps` / `make install-deps-ci`.
+- **Run `make lint-go` (or `make lint`) after every Go code change, before committing.** CI gates PRs on the same command.
 
 ### Documentation updates
 - When a behavior, operational assumption, browser requirement, rendering constraint, or user-visible rule becomes confirmed, update the relevant files in `docs/` in the same change.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 .PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci \
         test test-go test-frontend \
         fmt fmt-go fmt-check-go \
-        lint lint-go lint-frontend \
+        lint lint-go lint-go-deps lint-frontend \
         coverage coverage-go coverage-frontend \
         check release-snapshot package
 
+GOLANGCI_LINT_VERSION := v2.11.4
+
 # ── Dependencies ──────────────────────────────────────────────────────────────
 
-install-deps:
+install-deps: lint-go-deps
 	cd frontend && npm install
 	go mod download
 
-install-deps-ci:
+install-deps-ci: lint-go-deps
 	cd frontend && npm ci
 	go mod download
 
@@ -75,8 +77,13 @@ fmt-check-go:
 
 lint: lint-go lint-frontend
 
-lint-go: fmt-check-go
+lint-go-deps:
+	@command -v golangci-lint >/dev/null 2>&1 || \
+	  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+lint-go: fmt-check-go lint-go-deps
 	go vet ./...
+	golangci-lint run ./...
 
 lint-frontend:
 	cd frontend && npx tsc --noEmit

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,3 +1,4 @@
+// Package api provides HTTP REST API handlers for panemux.
 package api
 
 import (
@@ -90,7 +91,7 @@ func (h *Handler) PutLayout(w http.ResponseWriter, r *http.Request) {
 	if err := config.ValidateLayout(layout); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -134,7 +135,7 @@ func (h *Handler) PostSession(w http.ResponseWriter, r *http.Request) {
 	if err := config.ValidatePane(&pane); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 
@@ -152,7 +153,7 @@ func (h *Handler) PostSession(w http.ResponseWriter, r *http.Request) {
 	h.manager.Add(sess)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(sessionInfo{
+	_ = json.NewEncoder(w).Encode(sessionInfo{
 		ID:    sess.ID(),
 		Type:  string(sess.Type()),
 		Title: sess.Title(),
@@ -190,7 +191,7 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.manager.Remove(id) //nolint:errcheck -- ok if already gone
+	h.manager.Remove(id) //nolint:errcheck // ok if already gone
 
 	sess, err := h.createSession(found, h.cfg.SSHConnections)
 	if err != nil {
@@ -320,7 +321,7 @@ func (h *Handler) PostSSHConfigHost(w http.ResponseWriter, r *http.Request) {
 		if host.Name == req.Name {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{"error": "host already exists"})
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "host already exists"})
 			return
 		}
 	}
@@ -404,7 +405,7 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Launch VSCode asynchronously — we do not wait for it to exit.
-	cmd := exec.Command(codePath, args...) //nolint:gosec -- codePath is from trusted lookup, not user input
+	cmd := exec.Command(codePath, args...) //nolint:gosec // codePath is from trusted lookup
 	if err := cmd.Start(); err != nil {
 		http.Error(w, fmt.Sprintf("failed to launch VSCode: %v", err), http.StatusInternalServerError)
 		return
@@ -499,7 +500,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Determine the git repo top-level directory.
-	toplevelOut, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output() //nolint:gosec -- gitPath from trusted lookup, cwd from OS
+	toplevelOut, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output() //nolint:gosec // gitPath is from trusted lookup
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
@@ -507,7 +508,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	repo := filepath.Base(strings.TrimSpace(string(toplevelOut)))
 
 	// Get the current branch name.
-	branchOut, err := exec.Command(gitPath, "-C", cwd, "branch", "--show-current").Output() //nolint:gosec -- gitPath from trusted lookup, cwd from OS
+	branchOut, err := exec.Command(gitPath, "-C", cwd, "branch", "--show-current").Output() //nolint:gosec // gitPath is from trusted lookup
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: true, Repo: repo})
 		return
@@ -528,10 +529,10 @@ func (h *Handler) findGit() (string, error) {
 func writeValidationError(w http.ResponseWriter, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnprocessableEntity)
-	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(v)
+	_ = json.NewEncoder(w).Encode(v)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config loads and manages panemux YAML configuration.
 package config
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,4 @@
+// Package server wires together the chi router, API handlers, and embedded frontend.
 package server
 
 import (

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -1,3 +1,4 @@
+// Package session manages terminal sessions (local PTY, SSH, tmux).
 package session
 
 import (

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -37,7 +37,6 @@ type SSHSession struct {
 	client  *ssh.Client
 	session *ssh.Session
 	stdin   io.WriteCloser
-	stdout  io.Reader
 	// combined reader for stdout+stderr
 	reader         io.Reader
 	connectionName string
@@ -209,7 +208,7 @@ func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 	cmd := substituteProxyCommand(proxyCmd, host, port)
 	// Pass to /bin/sh -c so the command is interpreted by a shell, matching
 	// OpenSSH behaviour. /bin/sh is a hardcoded trusted binary.
-	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec -- cmd is from trusted ~/.ssh/config
+	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec // cmd is from trusted ~/.ssh/config
 	c.Stderr = os.Stderr
 
 	stdin, err := c.StdinPipe()

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -57,7 +57,7 @@ func NewTmuxLocal(id, title, tmuxSession string) (*TmuxLocalSession, error) {
 	// inject an error message when tmux exited with a non-zero status so that
 	// the WebSocket reader always delivers the exit reason to the browser.
 	go func() {
-		io.Copy(pw, ptmx) //nolint:errcheck -- EIO is expected when slave closes
+		io.Copy(pw, ptmx) //nolint:errcheck // EIO is expected when slave closes
 		exitErr := cmd.Wait()
 		s.mu.Lock()
 		s.state = StateExited
@@ -67,7 +67,7 @@ func NewTmuxLocal(id, title, tmuxSession string) (*TmuxLocalSession, error) {
 				"\r\n\x1b[31m[panemux] tmux session %q exited: %v\x1b[0m\r\n",
 				tmuxSession, exitErr,
 			)
-			pw.Write([]byte(msg)) //nolint:errcheck -- pw may be closed if Close() was called first
+			pw.Write([]byte(msg)) //nolint:errcheck // pw may be closed if Close() was called first
 		}
 		pw.Close()
 	}()

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -1,3 +1,4 @@
+// Package sshconfig parses SSH config files and provides host enumeration.
 package sshconfig
 
 import (
@@ -39,7 +40,7 @@ func ParseHosts(path string) ([]Host, error) {
 		}
 		return nil, fmt.Errorf("open ssh config: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	var hosts []Host
 	var current *Host
@@ -127,7 +128,7 @@ func AppendHost(path string, h Host) error {
 	if err != nil {
 		return fmt.Errorf("open ssh config for append: %w", err)
 	}
-	defer f.Close()
+	defer f.Close() //nolint:errcheck
 
 	var sb strings.Builder
 	sb.WriteString("\nHost ")
@@ -140,7 +141,7 @@ func AppendHost(path string, h Host) error {
 	sb.WriteString(h.User)
 	sb.WriteString("\n")
 	if h.Port != 0 {
-		sb.WriteString(fmt.Sprintf("    Port %d\n", h.Port))
+		fmt.Fprintf(&sb, "    Port %d\n", h.Port)
 	}
 	if h.IdentityFile != "" {
 		sb.WriteString("    IdentityFile ")

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -1,3 +1,4 @@
+// Package ws provides the WebSocket handler that bridges terminal sessions to the browser.
 package ws
 
 import (
@@ -55,7 +56,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("ws upgrade error for session %s: %v", sessionID, err)
 		return
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 
 	// Send initial connected status
 	h.sendStatus(conn, "connected")
@@ -133,5 +134,5 @@ func (h *Handler) handleControl(conn *websocket.Conn, sess session.Session, msg 
 func (h *Handler) sendStatus(conn *websocket.Conn, state string) {
 	msg := ControlMessage{Type: "status", State: state}
 	data, _ := json.Marshal(msg)
-	conn.WriteMessage(websocket.TextMessage, data)
+	_ = conn.WriteMessage(websocket.TextMessage, data)
 }

--- a/main.go
+++ b/main.go
@@ -89,7 +89,9 @@ func main() {
 		log.Println("Shutting down...")
 		ctx, cancel := context.WithTimeout(context.Background(), 5000000000) // 5s
 		defer cancel()
-		srv.Shutdown(ctx)
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("Shutdown error: %v", err)
+		}
 		manager.CloseAll()
 	}
 }


### PR DESCRIPTION
## Summary

- Add **`.golangci.yml`** (v2 format) with standard linters: `errcheck`, `govet`, `ineffassign`, `staticcheck`, `unused`. Exclusion rules for `internal/session/` teardown code and `_test.go` files where `errcheck` is not actionable.
- Extend **`Makefile`**: `GOLANGCI_LINT_VERSION=v2.11.4`, new `lint-go-deps` target that auto-installs the binary, `lint-go` now runs `golangci-lint run ./...` after `go vet`, `install-deps` / `install-deps-ci` depend on `lint-go-deps`.
- Add **`golangci/golangci-lint-action@1e7e51e`** (v9.2.0, SHA-pinned per project rules) to `ci.yml` for cached binary install; existing `make lint` step invokes the linter.
- Update **`CLAUDE.md`** Quality gate section: document that Go lint includes golangci-lint and must be run after every Go code change.
- Fix all pre-existing violations: package doc comments (6 packages), `errcheck` on `json.Encoder.Encode` / `conn.WriteMessage` / `srv.Shutdown`, unused `SSHSession.stdout` field, staticcheck QF1012, `nolint` format (`--` → `//`).

## Test plan

- [x] `golangci-lint --version` outputs `v2.11.4`
- [x] `make lint-go` passes (gofmt + go vet + golangci-lint, 0 issues)
- [x] `make test-go` passes (all tests green, no regressions)
- [x] `make check` passes (full quality gate: build-frontend + lint + test + coverage)
- [x] CI workflow `ci.yml` includes `Set up golangci-lint` step (SHA-pinned) and `Lint` step runs `make lint`