### PR TITLE
chore: add funlen and lll linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
-        with:
-          version: v2.11.4
-          install-mode: binary
-          args: --version
-
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,8 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - funlen
+    - lll
     - staticcheck
     - unused
   settings:

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -368,52 +368,71 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For local sessions, verify the directory still exists in the filesystem.
-	// A shell can remain in a directory after it has been deleted (the inode is
-	// kept alive by the open CWD reference), and passing a deleted path to
-	// `code` causes VSCode to open files in an unsaved/detached state.
-	switch sess.Type() {
-	case session.TypeLocal, session.TypeTmux:
-		if _, err := os.Stat(cwd); err != nil {
-			writeValidationError(w, fmt.Sprintf("working directory no longer exists: %s", cwd))
-			return
-		}
+	if !h.validateVSCodeCWD(w, sess, cwd) {
+		return
 	}
 
 	codePath, err := h.findVSCode()
 	if err != nil {
-		http.Error(w, "VSCode (code) not found: install VSCode and run 'Install code command in PATH'", http.StatusInternalServerError)
+		http.Error(
+			w,
+			"VSCode (code) not found: install VSCode and run 'Install code command in PATH'",
+			http.StatusInternalServerError,
+		)
 		return
 	}
 
-	var args []string
-	switch sess.Type() {
-	case session.TypeSSH, session.TypeSSHTmux:
-		namer, ok := sess.(session.SSHConnNamer)
-		if !ok {
-			writeValidationError(w, "SSH session missing connection name")
-			return
-		}
-		connName := namer.ConnectionName()
-		if !validHostName.MatchString(connName) {
-			writeValidationError(w, "SSH connection name contains invalid characters")
-			return
-		}
-		args = []string{"--remote", "ssh-remote+" + connName, cwd}
-	default:
-		args = []string{cwd}
+	args, ok := vscodeArgs(w, sess, cwd)
+	if !ok {
+		return
 	}
 
-	// Launch VSCode asynchronously — we do not wait for it to exit.
 	cmd := exec.Command(codePath, args...) //nolint:gosec // codePath is from trusted lookup
 	if err := cmd.Start(); err != nil {
 		http.Error(w, fmt.Sprintf("failed to launch VSCode: %v", err), http.StatusInternalServerError)
 		return
 	}
-	// Detach: let VSCode run independently.
 	go cmd.Wait() //nolint:errcheck
 
 	writeJSON(w, openVSCodeResponse{Cwd: cwd})
+}
+
+func (h *Handler) validateVSCodeCWD(
+	w http.ResponseWriter,
+	sess session.Session,
+	cwd string,
+) bool {
+	switch sess.Type() {
+	case session.TypeLocal, session.TypeTmux:
+		if _, err := os.Stat(cwd); err != nil {
+			writeValidationError(w, fmt.Sprintf("working directory no longer exists: %s", cwd))
+			return false
+		}
+	}
+	return true
+}
+
+func vscodeArgs(
+	w http.ResponseWriter,
+	sess session.Session,
+	cwd string,
+) ([]string, bool) {
+	switch sess.Type() {
+	case session.TypeSSH, session.TypeSSHTmux:
+		namer, ok := sess.(session.SSHConnNamer)
+		if !ok {
+			writeValidationError(w, "SSH session missing connection name")
+			return nil, false
+		}
+		connName := namer.ConnectionName()
+		if !validHostName.MatchString(connName) {
+			writeValidationError(w, "SSH connection name contains invalid characters")
+			return nil, false
+		}
+		return []string{"--remote", "ssh-remote+" + connName, cwd}, true
+	default:
+		return []string{cwd}, true
+	}
 }
 
 // findVSCode returns the path to the VSCode CLI binary.
@@ -499,16 +518,26 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Determine the git repo top-level directory.
-	toplevelOut, err := exec.Command(gitPath, "-C", cwd, "rev-parse", "--show-toplevel").Output() //nolint:gosec // gitPath is from trusted lookup
+	toplevelOut, err := exec.Command( //nolint:gosec // gitPath is from trusted lookup
+		gitPath,
+		"-C",
+		cwd,
+		"rev-parse",
+		"--show-toplevel",
+	).Output()
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
 	}
 	repo := filepath.Base(strings.TrimSpace(string(toplevelOut)))
 
-	// Get the current branch name.
-	branchOut, err := exec.Command(gitPath, "-C", cwd, "branch", "--show-current").Output() //nolint:gosec // gitPath is from trusted lookup
+	branchOut, err := exec.Command( //nolint:gosec // gitPath is from trusted lookup
+		gitPath,
+		"-C",
+		cwd,
+		"branch",
+		"--show-current",
+	).Output()
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: true, Repo: repo})
 		return

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -382,11 +382,13 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	args, ok := vscodeArgs(w, sess, cwd)
-	if !ok {
+	args, err := vscodeArgs(sess, cwd)
+	if err != nil {
+		writeValidationError(w, err.Error())
 		return
 	}
 
+	// Launch VSCode detached — we do not wait for it to exit.
 	cmd := exec.Command(codePath, args...) //nolint:gosec // codePath is from trusted lookup
 	if err := cmd.Start(); err != nil {
 		http.Error(w, fmt.Sprintf("failed to launch VSCode: %v", err), http.StatusInternalServerError)
@@ -397,6 +399,10 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, openVSCodeResponse{Cwd: cwd})
 }
 
+// validateVSCodeCWD checks that the CWD is still accessible for local/tmux sessions.
+// A shell can remain in a directory after it has been deleted (the inode is kept alive
+// by the open CWD reference); passing a deleted path to `code` causes VSCode to open
+// files in an unsaved/detached state.
 func (h *Handler) validateVSCodeCWD(
 	w http.ResponseWriter,
 	sess session.Session,
@@ -412,26 +418,20 @@ func (h *Handler) validateVSCodeCWD(
 	return true
 }
 
-func vscodeArgs(
-	w http.ResponseWriter,
-	sess session.Session,
-	cwd string,
-) ([]string, bool) {
+func vscodeArgs(sess session.Session, cwd string) ([]string, error) {
 	switch sess.Type() {
 	case session.TypeSSH, session.TypeSSHTmux:
 		namer, ok := sess.(session.SSHConnNamer)
 		if !ok {
-			writeValidationError(w, "SSH session missing connection name")
-			return nil, false
+			return nil, fmt.Errorf("SSH session missing connection name")
 		}
 		connName := namer.ConnectionName()
 		if !validHostName.MatchString(connName) {
-			writeValidationError(w, "SSH connection name contains invalid characters")
-			return nil, false
+			return nil, fmt.Errorf("SSH connection name contains invalid characters")
 		}
-		return []string{"--remote", "ssh-remote+" + connName, cwd}, true
+		return []string{"--remote", "ssh-remote+" + connName, cwd}, nil
 	default:
-		return []string{cwd}, true
+		return []string{cwd}, nil
 	}
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -584,7 +584,10 @@ func TestGetSSHConnections_SSHConfigTakesPrecedenceOnConflict(t *testing.T) {
 }
 
 func TestGetSSHConfigHosts_ReturnsHosts(t *testing.T) {
-	sshConfigPath := writeTempSSHConfigForAPI(t, "Host myhost\n    HostName myhost.example.com\n    User ubuntu\n    Port 2222\n")
+	sshConfigPath := writeTempSSHConfigForAPI(
+		t,
+		"Host myhost\n    HostName myhost.example.com\n    User ubuntu\n    Port 2222\n",
+	)
 
 	h := NewHandler(defaultTestConfig(), session.NewManager())
 	h.sshConfigPath = sshConfigPath
@@ -709,7 +712,12 @@ func TestPostSSHConfigHost_PortOutOfRange_422(t *testing.T) {
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
-	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", Hostname: "myhost.example.com", User: "ubuntu", Port: 70000})
+	body, _ := json.Marshal(sshConfigHostRequest{
+		Name:     "myhost",
+		Hostname: "myhost.example.com",
+		User:     "ubuntu",
+		Port:     70000,
+	})
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -100,7 +100,14 @@ func validateChildren(children []LayoutChild, sshConns map[string]SSHConnection)
 
 	for i, child := range children {
 		if child.Direction != "" && child.Direction != "horizontal" && child.Direction != "vertical" {
-			errs = append(errs, fmt.Sprintf("child[%d] invalid direction %q: must be horizontal or vertical", i, child.Direction))
+			errs = append(
+				errs,
+				fmt.Sprintf(
+					"child[%d] invalid direction %q: must be horizontal or vertical",
+					i,
+					child.Direction,
+				),
+			)
 		}
 		if child.Pane != nil {
 			errs = append(errs, validatePane(child.Pane, sshConns)...)
@@ -121,7 +128,14 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 	case "local", "ssh", "tmux", "ssh_tmux":
 		// valid
 	default:
-		errs = append(errs, fmt.Sprintf("pane %q has invalid type %q: must be local, ssh, tmux, or ssh_tmux", p.ID, p.Type))
+		errs = append(
+			errs,
+			fmt.Sprintf(
+				"pane %q has invalid type %q: must be local, ssh, tmux, or ssh_tmux",
+				p.ID,
+				p.Type,
+			),
+		)
 	}
 
 	if p.Type == "ssh" || p.Type == "ssh_tmux" {
@@ -142,7 +156,15 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 		if p.TmuxSession == "" {
 			errs = append(errs, fmt.Sprintf("pane %q: tmux_session must not be empty", p.ID))
 		} else if !tmuxSessionNameRe.MatchString(p.TmuxSession) {
-			errs = append(errs, fmt.Sprintf("pane %q: tmux_session %q contains invalid characters (allowed: a-z A-Z 0-9 - _ .)", p.ID, p.TmuxSession))
+			errs = append(
+				errs,
+				fmt.Sprintf(
+					"pane %q: tmux_session %q contains invalid characters "+
+						"(allowed: a-z A-Z 0-9 - _ .)",
+					p.ID,
+					p.TmuxSession,
+				),
+			)
 		}
 	}
 

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -19,7 +19,11 @@ func CreateFromConfig(pane *config.PaneConfig, sshConns map[string]config.SSHCon
 
 // createSession is the internal, testable version of CreateFromConfig that accepts
 // an explicit SSH config path instead of always using the default.
-func createSession(pane *config.PaneConfig, sshConns map[string]config.SSHConnection, sshConfigPath string) (Session, error) {
+func createSession(
+	pane *config.PaneConfig,
+	sshConns map[string]config.SSHConnection,
+	sshConfigPath string,
+) (Session, error) {
 	switch Type(pane.Type) {
 	case TypeLocal:
 		return NewLocal(pane.ID, pane.Shell, pane.Cwd, pane.Title)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -310,6 +310,10 @@ func startSSHShell(sess *ssh.Session, cfg SSHConfig) error {
 	return nil
 }
 
+// sshShellCommand returns the remote command to pass to sess.Start, or "" to use
+// sess.Shell. Paths are validated with the regex guard (CodeQL go/command-injection
+// recommended pattern) before being embedded in the shell command.
+// sess.Shell() and sess.Start() are mutually exclusive in the SSH protocol.
 func sshShellCommand(cfg SSHConfig) (string, error) {
 	if cfg.Shell != "" {
 		if err := validateRemotePath("shell", cfg.Shell); err != nil {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -28,6 +28,8 @@ import (
 // and control characters (newlines, null bytes, etc.).
 var validRemotePath = regexp.MustCompile(`^(/[^;|&$` + "`" + `'"<>()\[\]{}!\\\x00-\x1f\x7f]*)+$`)
 
+const invalidRemotePathMsg = "must be an absolute path with no shell metacharacters"
+
 // SSHSession manages an SSH connection with a PTY.
 type SSHSession struct {
 	mu      sync.RWMutex
@@ -239,90 +241,19 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 
 	sess, err := client.NewSession()
 	if err != nil {
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
+		closeSSHResources(nil, client, jumpClient)
 		return nil, fmt.Errorf("new ssh session: %w", err)
 	}
 
-	// Request PTY
-	modes := ssh.TerminalModes{
-		ssh.ECHO:          1,
-		ssh.TTY_OP_ISPEED: 14400,
-		ssh.TTY_OP_OSPEED: 14400,
-	}
-	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
-		return nil, fmt.Errorf("request pty: %w", err)
-	}
-
-	stdin, err := sess.StdinPipe()
+	stdin, pr, pw, err := setupSSHPTY(sess)
 	if err != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
-		return nil, fmt.Errorf("stdin pipe: %w", err)
+		closeSSHResources(sess, client, jumpClient)
+		return nil, err
 	}
 
-	pr, pw := io.Pipe()
-	sess.Stdout = pw
-	sess.Stderr = pw
-
-	// Start the shell. If a working directory is configured, validate it with
-	// the regex guard (CodeQL go/command-injection recommended pattern for
-	// arguments) before embedding it in the remote shell command.
-	// sess.Shell() and sess.Start() are mutually exclusive in the SSH protocol.
-	var startErr error
-	if cfg.Shell != "" {
-		// Shell override: validate path before embedding in remote command.
-		if !validRemotePath.MatchString(cfg.Shell) {
-			sess.Close()
-			client.Close()
-			if jumpClient != nil {
-				jumpClient.Close()
-			}
-			return nil, fmt.Errorf("invalid shell %q: must be an absolute path with no shell metacharacters", cfg.Shell)
-		}
-		if cfg.Cwd != "" {
-			if !validRemotePath.MatchString(cfg.Cwd) {
-				sess.Close()
-				client.Close()
-				if jumpClient != nil {
-					jumpClient.Close()
-				}
-				return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
-			}
-			startErr = sess.Start(fmt.Sprintf("cd %s && exec %s", shellQuotePath(cfg.Cwd), shellQuotePath(cfg.Shell)))
-		} else {
-			startErr = sess.Start("exec " + shellQuotePath(cfg.Shell))
-		}
-	} else if cfg.Cwd != "" {
-		if !validRemotePath.MatchString(cfg.Cwd) {
-			sess.Close()
-			client.Close()
-			if jumpClient != nil {
-				jumpClient.Close()
-			}
-			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
-		}
-		startErr = sess.Start(fmt.Sprintf("cd %s && exec $SHELL", shellQuotePath(cfg.Cwd)))
-	} else {
-		startErr = sess.Shell()
-	}
-	if startErr != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
-		return nil, fmt.Errorf("start shell: %w", startErr)
+	if err := startSSHShell(sess, cfg); err != nil {
+		closeSSHResources(sess, client, jumpClient)
+		return nil, err
 	}
 
 	s := &SSHSession{
@@ -337,16 +268,97 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		jumpClient:     jumpClient,
 	}
 
-	// Monitor session exit
+	monitorSSHSession(sess, pw, func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.state = StateExited
+	})
+
+	return s, nil
+}
+
+func setupSSHPTY(sess *ssh.Session) (io.WriteCloser, *io.PipeReader, *io.PipeWriter, error) {
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}
+	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
+		return nil, nil, nil, fmt.Errorf("request pty: %w", err)
+	}
+	stdin, err := sess.StdinPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	pr, pw := io.Pipe()
+	sess.Stdout = pw
+	sess.Stderr = pw
+	return stdin, pr, pw, nil
+}
+
+func startSSHShell(sess *ssh.Session, cfg SSHConfig) error {
+	cmd, err := sshShellCommand(cfg)
+	if err != nil {
+		return err
+	}
+	if cmd == "" {
+		return sess.Shell()
+	}
+	if err := sess.Start(cmd); err != nil {
+		return fmt.Errorf("start shell: %w", err)
+	}
+	return nil
+}
+
+func sshShellCommand(cfg SSHConfig) (string, error) {
+	if cfg.Shell != "" {
+		if err := validateRemotePath("shell", cfg.Shell); err != nil {
+			return "", err
+		}
+		if cfg.Cwd == "" {
+			return "exec " + shellQuotePath(cfg.Shell), nil
+		}
+		if err := validateRemotePath("working directory", cfg.Cwd); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(
+			"cd %s && exec %s",
+			shellQuotePath(cfg.Cwd),
+			shellQuotePath(cfg.Shell),
+		), nil
+	}
+	if cfg.Cwd == "" {
+		return "", nil
+	}
+	if err := validateRemotePath("working directory", cfg.Cwd); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("cd %s && exec $SHELL", shellQuotePath(cfg.Cwd)), nil
+}
+
+func validateRemotePath(label, path string) error {
+	if validRemotePath.MatchString(path) {
+		return nil
+	}
+	return fmt.Errorf("invalid %s %q: %s", label, path, invalidRemotePathMsg)
+}
+
+func closeSSHResources(sess *ssh.Session, client, jumpClient *ssh.Client) {
+	if sess != nil {
+		sess.Close()
+	}
+	client.Close()
+	if jumpClient != nil {
+		jumpClient.Close()
+	}
+}
+
+func monitorSSHSession(sess *ssh.Session, pw *io.PipeWriter, markExited func()) {
 	go func() {
 		sess.Wait()
 		pw.Close()
-		s.mu.Lock()
-		s.state = StateExited
-		s.mu.Unlock()
+		markExited()
 	}()
-
-	return s, nil
 }
 
 // DetectRemoteShell connects to the remote host via SSH and returns the value of $SHELL.

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -89,6 +89,10 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 	return s, nil
 }
 
+// tmuxSSHCommand builds the remote tmux command.
+// -As attaches to an existing session or creates one if absent.
+// -c sets the working directory for newly created sessions only; it has no
+// effect when attaching to an existing session.
 func tmuxSSHCommand(tmuxSession string, cfg SSHConfig) (string, error) {
 	cmd := fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)
 	if cfg.Cwd == "" {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -33,7 +33,10 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		tmuxSession = "0"
 	}
 	if !validTmuxSessionName.MatchString(tmuxSession) {
-		return nil, fmt.Errorf("invalid tmux session name %q: must match ^[a-zA-Z0-9_.-]+$", tmuxSession)
+		return nil, fmt.Errorf(
+			"invalid tmux session name %q: must match ^[a-zA-Z0-9_.-]+$",
+			tmuxSession,
+		)
 	}
 
 	client, jumpClient, err := dialSSHClient(cfg)
@@ -43,65 +46,24 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 
 	sess, err := client.NewSession()
 	if err != nil {
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
+		closeSSHResources(nil, client, jumpClient)
 		return nil, fmt.Errorf("new ssh session: %w", err)
 	}
 
-	modes := ssh.TerminalModes{
-		ssh.ECHO:          1,
-		ssh.TTY_OP_ISPEED: 14400,
-		ssh.TTY_OP_OSPEED: 14400,
-	}
-	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
-		return nil, fmt.Errorf("request pty: %w", err)
-	}
-
-	stdin, err := sess.StdinPipe()
+	stdin, pr, pw, err := setupSSHPTY(sess)
 	if err != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
-		return nil, fmt.Errorf("stdin pipe: %w", err)
+		closeSSHResources(sess, client, jumpClient)
+		return nil, err
 	}
 
-	pr, pw := io.Pipe()
-	sess.Stdout = pw
-	sess.Stderr = pw
-
-	// Attach to existing tmux session or create it if absent.
-	// -c sets the working directory for newly created sessions; it has no
-	// effect when attaching to an existing session.
-	// (tmuxSession is validated as [a-zA-Z0-9_.-]+ by config)
-	tmuxCmd := fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)
-	if cfg.Cwd != "" {
-		// Validate cwd with the regex guard before embedding in the shell command
-		// (CodeQL go/command-injection recommended pattern for arguments).
-		if !validRemotePath.MatchString(cfg.Cwd) {
-			sess.Close()
-			client.Close()
-			if jumpClient != nil {
-				jumpClient.Close()
-			}
-			return nil, fmt.Errorf("invalid working directory %q: must be an absolute path with no shell metacharacters", cfg.Cwd)
-		}
-		tmuxCmd += fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd))
+	tmuxCmd, err := tmuxSSHCommand(tmuxSession, cfg)
+	if err != nil {
+		closeSSHResources(sess, client, jumpClient)
+		return nil, err
 	}
+
 	if err := sess.Start(tmuxCmd); err != nil {
-		sess.Close()
-		client.Close()
-		if jumpClient != nil {
-			jumpClient.Close()
-		}
+		closeSSHResources(sess, client, jumpClient)
 		return nil, fmt.Errorf("starting tmux attach: %w", err)
 	}
 
@@ -118,15 +80,24 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		jumpClient:     jumpClient,
 	}
 
-	go func() {
-		sess.Wait()
-		pw.Close()
+	monitorSSHSession(sess, pw, func() {
 		s.mu.Lock()
+		defer s.mu.Unlock()
 		s.state = StateExited
-		s.mu.Unlock()
-	}()
+	})
 
 	return s, nil
+}
+
+func tmuxSSHCommand(tmuxSession string, cfg SSHConfig) (string, error) {
+	cmd := fmt.Sprintf("tmux new-session -As '%s'", tmuxSession)
+	if cfg.Cwd == "" {
+		return cmd, nil
+	}
+	if err := validateRemotePath("working directory", cfg.Cwd); err != nil {
+		return "", err
+	}
+	return cmd + fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd)), nil
 }
 
 func (s *TmuxSSHSession) ID() string    { return s.id }

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -49,71 +49,78 @@ func ParseHosts(path string) ([]Host, error) {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
+		key, val, ok := parseDirective(line)
+		if !ok {
 			continue
 		}
-
-		parts := strings.SplitN(line, " ", 2)
-		if len(parts) < 2 {
-			continue
-		}
-		key := strings.ToLower(strings.TrimSpace(parts[0]))
-		val := strings.TrimSpace(parts[1])
 
 		if key == "host" {
-			// Save previous host if non-wildcard
-			if current != nil {
-				if current.Hostname == "" {
-					current.Hostname = current.Name
-				}
-				hosts = append(hosts, *current)
-			}
-			// Start new host block, skip wildcards
-			if strings.ContainsAny(val, "*?") {
-				current = nil
-			} else {
-				current = &Host{Name: val}
-			}
+			hosts = appendHost(hosts, current)
+			current = newHostBlock(val)
 			continue
 		}
 
 		if current == nil {
 			continue
 		}
-
-		switch key {
-		case "hostname":
-			current.Hostname = val
-		case "user":
-			current.User = val
-		case "port":
-			p, err := strconv.Atoi(val)
-			if err == nil {
-				current.Port = p
-			}
-		case "identityfile":
-			current.IdentityFile = val
-		case "proxyjump":
-			current.ProxyJump = val
-		case "proxycommand":
-			current.ProxyCommand = val
-		}
+		applyHostDirective(current, key, val)
 	}
 
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan ssh config: %w", err)
 	}
 
-	// Save last block
-	if current != nil {
-		if current.Hostname == "" {
-			current.Hostname = current.Name
-		}
-		hosts = append(hosts, *current)
-	}
+	return appendHost(hosts, current), nil
+}
 
-	return hosts, nil
+func parseDirective(line string) (string, string, bool) {
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	parts := strings.SplitN(line, " ", 2)
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	return strings.ToLower(strings.TrimSpace(parts[0])),
+		strings.TrimSpace(parts[1]),
+		true
+}
+
+func newHostBlock(name string) *Host {
+	if strings.ContainsAny(name, "*?") {
+		return nil
+	}
+	return &Host{Name: name}
+}
+
+func appendHost(hosts []Host, host *Host) []Host {
+	if host == nil {
+		return hosts
+	}
+	if host.Hostname == "" {
+		host.Hostname = host.Name
+	}
+	return append(hosts, *host)
+}
+
+func applyHostDirective(host *Host, key, val string) {
+	switch key {
+	case "hostname":
+		host.Hostname = val
+	case "user":
+		host.User = val
+	case "port":
+		p, err := strconv.Atoi(val)
+		if err == nil {
+			host.Port = p
+		}
+	case "identityfile":
+		host.IdentityFile = val
+	case "proxyjump":
+		host.ProxyJump = val
+	case "proxycommand":
+		host.ProxyCommand = val
+	}
 }
 
 // AppendHost appends a new Host block to the SSH config file at path.

--- a/internal/sshconfig/parse_test.go
+++ b/internal/sshconfig/parse_test.go
@@ -213,7 +213,12 @@ func TestParseHosts_ProxyCommand(t *testing.T) {
 	hosts, err := ParseHosts(f)
 	require.NoError(t, err)
 	require.Len(t, hosts, 1)
-	assert.Equal(t, "gcloud compute start-iap-tunnel bastion %p --listen-on-stdin --project=my-project --zone=us-central1-a", hosts[0].ProxyCommand)
+	assert.Equal(
+		t,
+		"gcloud compute start-iap-tunnel bastion %p "+
+			"--listen-on-stdin --project=my-project --zone=us-central1-a",
+		hosts[0].ProxyCommand,
+	)
 	assert.Equal(t, "", hosts[0].ProxyJump)
 }
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -131,6 +131,7 @@ func (h *Handler) handleWebSocketMessage(
 ) {
 	switch msgType {
 	case websocket.BinaryMessage:
+		// Discard silently if the session is already gone.
 		if sess.State() == session.StateExited {
 			return
 		}

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -45,9 +45,8 @@ func NewHandler(manager *session.Manager) *Handler {
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "sessionID")
 
-	sess, ok := h.manager.Get(sessionID)
-	if !ok {
-		http.Error(w, "session not found", http.StatusNotFound)
+	sess := h.sessionForRequest(w, sessionID)
+	if sess == nil {
 		return
 	}
 
@@ -58,62 +57,98 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close() //nolint:errcheck
 
-	// Send initial connected status
 	h.sendStatus(conn, "connected")
+	done := h.pipeTerminalToWebSocket(conn, sess, sessionID)
+	h.pipeWebSocketToTerminal(conn, sess, sessionID)
+	waitForTerminalPipe(done)
+}
 
-	// Monitor session state changes
+func (h *Handler) sessionForRequest(w http.ResponseWriter, sessionID string) session.Session {
+	sess, ok := h.manager.Get(sessionID)
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return nil
+	}
+	return sess
+}
+
+func (h *Handler) pipeTerminalToWebSocket(
+	conn *websocket.Conn,
+	sess session.Session,
+	sessionID string,
+) <-chan struct{} {
 	done := make(chan struct{})
-
-	// terminal → WebSocket (binary frames)
 	go func() {
 		defer close(done)
-		buf := make([]byte, 4096)
-		for {
-			n, err := sess.Read(buf)
-			if n > 0 {
-				if writeErr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); writeErr != nil {
-					return
-				}
-			}
-			if err != nil {
-				if err != io.EOF {
-					log.Printf("session %s read error: %v", sessionID, err)
-				}
-				h.sendStatus(conn, "exited")
+		h.forwardTerminalOutput(conn, sess, sessionID)
+	}()
+	return done
+}
+
+func (h *Handler) forwardTerminalOutput(
+	conn *websocket.Conn,
+	sess session.Session,
+	sessionID string,
+) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := sess.Read(buf)
+		if n > 0 {
+			if writeErr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); writeErr != nil {
 				return
 			}
 		}
-	}()
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("session %s read error: %v", sessionID, err)
+			}
+			h.sendStatus(conn, "exited")
+			return
+		}
+	}
+}
 
-	// WebSocket → terminal
+func (h *Handler) pipeWebSocketToTerminal(
+	conn *websocket.Conn,
+	sess session.Session,
+	sessionID string,
+) {
 	for {
 		msgType, data, err := conn.ReadMessage()
 		if err != nil {
-			break
+			return
 		}
-
-		switch msgType {
-		case websocket.BinaryMessage:
-			// Raw terminal input — discard silently if the session is already gone.
-			if sess.State() == session.StateExited {
-				continue
-			}
-			if _, err := sess.Write(data); err != nil {
-				log.Printf("session %s write error: %v", sessionID, err)
-			}
-
-		case websocket.TextMessage:
-			// JSON control message
-			var msg ControlMessage
-			if err := json.Unmarshal(data, &msg); err != nil {
-				log.Printf("invalid control message: %v", err)
-				continue
-			}
-			h.handleControl(conn, sess, msg)
-		}
+		h.handleWebSocketMessage(conn, sess, sessionID, msgType, data)
 	}
+}
 
-	// Wait for the terminal reader goroutine to finish
+func (h *Handler) handleWebSocketMessage(
+	conn *websocket.Conn,
+	sess session.Session,
+	sessionID string,
+	msgType int,
+	data []byte,
+) {
+	switch msgType {
+	case websocket.BinaryMessage:
+		if sess.State() == session.StateExited {
+			return
+		}
+		if _, err := sess.Write(data); err != nil {
+			log.Printf("session %s write error: %v", sessionID, err)
+		}
+
+	case websocket.TextMessage:
+		var msg ControlMessage
+		if err := json.Unmarshal(data, &msg); err != nil {
+			log.Printf("invalid control message: %v", err)
+			return
+		}
+		h.handleControl(conn, sess, msg)
+	}
+}
+
+func waitForTerminalPipe(done <-chan struct{}) {
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):

--- a/main.go
+++ b/main.go
@@ -19,59 +19,75 @@ import (
 
 var version = "dev"
 
+type cliOptions struct {
+	configPath  string
+	openBrowser bool
+	port        int
+	showVersion bool
+}
+
 //go:embed frontend/dist
 var frontendFS embed.FS
 
 func main() {
-	var (
-		configPath  = flag.String("config", "", "Path to YAML config file")
-		openBrowser = flag.Bool("open", false, "Open Chrome automatically")
-		port        = flag.Int("port", 0, "Override server port")
-		showVersion = flag.Bool("version", false, "Print version and exit")
-	)
-	flag.Parse()
+	opts := parseOptions()
 
-	if *showVersion {
+	if opts.showVersion {
 		fmt.Println(version)
 		os.Exit(0)
 	}
 
-	// Load config
-	var cfg *config.Config
-	if *configPath != "" {
-		var err error
-		cfg, err = config.Load(*configPath)
-		if err != nil {
-			log.Fatalf("Failed to load config: %v", err)
-		}
-	} else {
-		var err error
-		cfg, err = config.LoadOrDefault()
-		if err != nil {
-			log.Fatalf("Failed to load config: %v", err)
-		}
+	cfg, err := loadConfig(opts)
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
 	}
 
-	if *port != 0 {
-		cfg.Server.Port = *port
-	}
-
-	// Create session manager and start all sessions defined in config
 	manager := session.NewManager()
 	if err := startSessionsFromConfig(cfg, manager); err != nil {
 		log.Fatalf("Failed to start sessions: %v", err)
 	}
 
-	// Start HTTP server
 	srv := server.New(cfg, manager, frontendFS)
 	addr := fmt.Sprintf("http://%s", srv.Addr())
 	log.Printf("Listening on %s", addr)
 
-	if *openBrowser {
+	if opts.openBrowser {
 		go openChrome(addr)
 	}
 
-	// Wait for interrupt signal
+	runServer(srv, manager)
+}
+
+func parseOptions() cliOptions {
+	var opts cliOptions
+	flag.StringVar(&opts.configPath, "config", "", "Path to YAML config file")
+	flag.BoolVar(&opts.openBrowser, "open", false, "Open Chrome automatically")
+	flag.IntVar(&opts.port, "port", 0, "Override server port")
+	flag.BoolVar(&opts.showVersion, "version", false, "Print version and exit")
+	flag.Parse()
+	return opts
+}
+
+func loadConfig(opts cliOptions) (*config.Config, error) {
+	var (
+		cfg *config.Config
+		err error
+	)
+	if opts.configPath != "" {
+		cfg, err = config.Load(opts.configPath)
+	} else {
+		cfg, err = config.LoadOrDefault()
+	}
+	if err != nil {
+		return nil, err
+	}
+	if opts.port != 0 {
+		cfg.Server.Port = opts.port
+	}
+	return cfg, nil
+}
+
+func runServer(srv *server.Server, manager *session.Manager) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
@@ -87,7 +103,7 @@ func main() {
 		}
 	case <-sigCh:
 		log.Println("Shutting down...")
-		ctx, cancel := context.WithTimeout(context.Background(), 5000000000) // 5s
+		ctx, cancel := context.WithTimeout(context.Background(), 5_000_000_000)
 		defer cancel()
 		if err := srv.Shutdown(ctx); err != nil {
 			log.Printf("Shutdown error: %v", err)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	"panemux/internal/config"
 	"panemux/internal/server"
@@ -103,7 +104,7 @@ func runServer(srv *server.Server, manager *session.Manager) {
 		}
 	case <-sigCh:
 		log.Println("Shutting down...")
-		ctx, cancel := context.WithTimeout(context.Background(), 5_000_000_000)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(ctx); err != nil {
 			log.Printf("Shutdown error: %v", err)


### PR DESCRIPTION
## Summary
- enable golangci-lint funlen and lll
- refactor existing long Go functions into smaller helpers
- wrap existing long Go lines and test literals to satisfy lll
- remove the broken golangci-lint action setup step so CI uses the Makefile-managed linter install path

## Test plan
- [x] make install-deps-ci
- [x] env PATH="/Users/tomo/go/bin:$PATH" make check
- [x] gh pr checks 59 --watch --interval 8