### PR TITLE
ci: expand golangci lint coverage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,27 +7,55 @@ linters:
   default: standard
   enable:
     - errcheck
+    - errname
+    - goconst
     - govet
     - ineffassign
     - funlen
     - lll
+    - makezero
+    - misspell
+    - nilerr
+    - perfsprint
+    - revive
     - staticcheck
     - unused
+    - whitespace
+    - wrapcheck
   settings:
+    misspell:
+      locale: US
+    revive:
+      enable-default-rules: true
+      rules:
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: unused-parameter
+          disabled: true
     staticcheck:
       checks: ["all"]
+    whitespace:
+      multi-if: true
   exclusions:
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
       # Session package manages OS processes and SSH connections; Close/Wait/Kill
       # errors in teardown paths are not actionable.
       - path: internal/session/
         linters:
           - errcheck
+          - wrapcheck
       # Test cleanup (defer conn.Close(), SetReadDeadline, ReadMessage) does not
       # require error handling — test failures surface through assertions.
       - path: _test\.go
         linters:
           - errcheck
+          - goconst
 
 formatters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,8 @@ linters:
       multi-if: true
   exclusions:
     presets:
+      # Keep standard-library edge cases from drowning out project-specific
+      # errcheck/wrapcheck findings.
       - common-false-positives
       - legacy
       - std-error-handling

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -411,7 +412,7 @@ func (h *Handler) validateVSCodeCWD(
 	switch sess.Type() {
 	case session.TypeLocal, session.TypeTmux:
 		if _, err := os.Stat(cwd); err != nil {
-			writeValidationError(w, fmt.Sprintf("working directory no longer exists: %s", cwd))
+			writeValidationError(w, "working directory no longer exists: "+cwd)
 			return false
 		}
 	}
@@ -423,11 +424,11 @@ func vscodeArgs(sess session.Session, cwd string) ([]string, error) {
 	case session.TypeSSH, session.TypeSSHTmux:
 		namer, ok := sess.(session.SSHConnNamer)
 		if !ok {
-			return nil, fmt.Errorf("SSH session missing connection name")
+			return nil, errors.New("SSH session missing connection name")
 		}
 		connName := namer.ConnectionName()
 		if !validHostName.MatchString(connName) {
-			return nil, fmt.Errorf("SSH connection name contains invalid characters")
+			return nil, errors.New("SSH connection name contains invalid characters")
 		}
 		return []string{"--remote", "ssh-remote+" + connName, cwd}, nil
 	default:
@@ -450,7 +451,7 @@ func (h *Handler) findVSCode() (string, error) {
 			return p, nil
 		}
 	}
-	return "", fmt.Errorf("code binary not found")
+	return "", errors.New("code binary not found")
 }
 
 type detectShellResponse struct {
@@ -552,7 +553,11 @@ func (h *Handler) findGit() (string, error) {
 	if h.gitBinaryPath != "" {
 		return h.gitBinaryPath, nil
 	}
-	return exec.LookPath("git")
+	path, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("finding git binary: %w", err)
+	}
+	return path, nil
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -929,7 +929,7 @@ func TestGetDetectShell_Local_Success(t *testing.T) {
 	h.sshConfigPath = filepath.Join(os.TempDir(), "nonexistent")
 	h.detectLocalShellFn = func() (string, error) { return "/usr/bin/zsh", nil }
 	h.detectRemoteShellFn = func(cfg session.SSHConfig) (string, error) {
-		return "", fmt.Errorf("should not be called")
+		return "", errors.New("should not be called")
 	}
 	r := setupRouterWithHandler(h)
 
@@ -982,7 +982,7 @@ func TestGetDetectShell_SSH_ConnectionNotFound(t *testing.T) {
 
 func TestGetDetectShell_DetectFails(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), session.NewManager())
-	h.detectLocalShellFn = func() (string, error) { return "", fmt.Errorf("cannot detect") }
+	h.detectLocalShellFn = func() (string, error) { return "", errors.New("cannot detect") }
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -992,7 +992,7 @@ func TestGetDetectShell_DetectFails(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-// initTempGitRepo creates a temporary directory with an initialised git repo
+// initTempGitRepo creates a temporary directory with an initialized git repo
 // on a branch named "main" and returns the directory path.
 func initTempGitRepo(t *testing.T) string {
 	t.Helper()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,7 +172,7 @@ func DefaultConfigPath() (string, error) {
 func LoadOrDefault() (*Config, error) {
 	path, err := DefaultConfigPath()
 	if err != nil {
-		return Default(), nil
+		return nil, fmt.Errorf("default config path: %w", err)
 	}
 	return loadOrDefaultAt(path)
 }
@@ -201,7 +201,10 @@ func (c *Config) SaveLayout(layout LayoutNode) error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	return os.WriteFile(c.filePath, data, 0644)
+	if err := os.WriteFile(c.filePath, data, 0644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
 }
 
 // UpdateLayout updates the in-memory layout without persisting to disk.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,9 +172,15 @@ func DefaultConfigPath() (string, error) {
 func LoadOrDefault() (*Config, error) {
 	path, err := DefaultConfigPath()
 	if err != nil {
-		return nil, fmt.Errorf("default config path: %w", err)
+		return defaultAfterConfigPathError()
 	}
 	return loadOrDefaultAt(path)
+}
+
+func defaultAfterConfigPathError() (*Config, error) {
+	// Preserve the historical startup fallback when the user's home directory
+	// cannot be resolved.
+	return Default(), nil
 }
 
 func loadOrDefaultAt(path string) (*Config, error) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -11,6 +11,8 @@ import (
 
 var tmuxSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
+const paneTypeSSHTmux = "ssh_tmux"
+
 // Validate checks the configuration for correctness.
 // It collects all errors and returns them as a single combined error.
 func (c *Config) Validate() error {
@@ -125,7 +127,7 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 	}
 
 	switch p.Type {
-	case "local", "ssh", "tmux", "ssh_tmux":
+	case "local", "ssh", "tmux", paneTypeSSHTmux:
 		// valid
 	default:
 		errs = append(
@@ -138,7 +140,7 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 		)
 	}
 
-	if p.Type == "ssh" || p.Type == "ssh_tmux" {
+	if p.Type == "ssh" || p.Type == paneTypeSSHTmux {
 		if p.Connection == "" {
 			errs = append(errs, fmt.Sprintf("pane %q: ssh connection name must not be empty", p.ID))
 		} else if sshConns != nil {
@@ -152,7 +154,7 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 		errs = append(errs, fmt.Sprintf("pane %q: shell must be an absolute path, got %q", p.ID, p.Shell))
 	}
 
-	if p.Type == "tmux" || p.Type == "ssh_tmux" {
+	if p.Type == "tmux" || p.Type == paneTypeSSHTmux {
 		if p.TmuxSession == "" {
 			errs = append(errs, fmt.Sprintf("pane %q: tmux_session must not be empty", p.ID))
 		} else if !tmuxSessionNameRe.MatchString(p.TmuxSession) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,12 +93,18 @@ func (s *Server) Addr() string {
 
 // Start begins listening and serving.
 func (s *Server) Start() error {
-	return s.httpSrv.ListenAndServe()
+	if err := s.httpSrv.ListenAndServe(); err != nil {
+		return fmt.Errorf("starting HTTP server: %w", err)
+	}
+	return nil
 }
 
 // Shutdown gracefully stops the server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	return s.httpSrv.Shutdown(ctx)
+	if err := s.httpSrv.Shutdown(ctx); err != nil {
+		return fmt.Errorf("shutting down HTTP server: %w", err)
+	}
+	return nil
 }
 
 func corsMiddleware(next http.Handler) http.Handler {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -94,6 +95,9 @@ func (s *Server) Addr() string {
 // Start begins listening and serving.
 func (s *Server) Start() error {
 	if err := s.httpSrv.ListenAndServe(); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			return http.ErrServerClosed
+		}
 		return fmt.Errorf("starting HTTP server: %w", err)
 	}
 	return nil

--- a/internal/session/factory.go
+++ b/internal/session/factory.go
@@ -94,7 +94,7 @@ func resolveSSHConfig(name string, sshConns map[string]config.SSHConnection, ssh
 					keyFile = filepath.Join(home, keyFile[2:])
 				} else if !filepath.IsAbs(keyFile) {
 					// Relative paths (e.g. ".ssh/id_ed25519") are relative to HOME,
-					// matching OpenSSH behaviour.
+					// matching OpenSSH behavior.
 					keyFile = filepath.Join(home, keyFile)
 				}
 			}

--- a/internal/session/factory_test.go
+++ b/internal/session/factory_test.go
@@ -1,9 +1,9 @@
 package session
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -158,7 +158,7 @@ func writeTempSSHConfig(t *testing.T, name, hostname, user string, port int) str
 }
 
 func itoa(i int) string {
-	return fmt.Sprintf("%d", i)
+	return strconv.Itoa(i)
 }
 
 // TestResolveSSHConfig_FromSSHConfigMap verifies that resolveSSHConfig returns

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -117,7 +118,7 @@ func (s *LocalSession) Close() error {
 // On Linux it reads /proc/<pid>/cwd; on macOS it runs lsof.
 func (s *LocalSession) GetCWD() (string, error) {
 	if s.pid == 0 {
-		return "", fmt.Errorf("session has no PID")
+		return "", errors.New("session has no PID")
 	}
 	switch runtime.GOOS {
 	case "linux":
@@ -141,7 +142,7 @@ func (s *LocalSession) GetCWD() (string, error) {
 				return strings.TrimSpace(p), nil
 			}
 		}
-		return "", fmt.Errorf("cwd not found in lsof output")
+		return "", errors.New("cwd not found in lsof output")
 	default:
 		return "", fmt.Errorf("GetCWD not supported on %s", runtime.GOOS)
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -96,7 +98,7 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	if port == 0 {
 		port = 22
 	}
-	addr := net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", port))
+	addr := net.JoinHostPort(cfg.Host, strconv.Itoa(port))
 
 	sshCfg := &ssh.ClientConfig{
 		User:              cfg.User,
@@ -162,7 +164,7 @@ func dialThroughJump(jumpCfg SSHConfig, targetAddr string) (net.Conn, *ssh.Clien
 }
 
 // proxyCommandConn wraps an exec.Cmd's stdin/stdout as a net.Conn, mirroring
-// OpenSSH's ProxyCommand behaviour where a subprocess acts as a transparent
+// OpenSSH's ProxyCommand behavior where a subprocess acts as a transparent
 // bidirectional pipe to the remote host.
 type proxyCommandConn struct {
 	cmd    *exec.Cmd
@@ -199,7 +201,7 @@ func substituteProxyCommand(cmd, host string, port int) string {
 	// Temporarily replace %% to avoid double-substitution
 	result := strings.ReplaceAll(cmd, "%%", "\x00")
 	result = strings.ReplaceAll(result, "%h", host)
-	result = strings.ReplaceAll(result, "%p", fmt.Sprintf("%d", port))
+	result = strings.ReplaceAll(result, "%p", strconv.Itoa(port))
 	return strings.ReplaceAll(result, "\x00", "%")
 }
 
@@ -209,7 +211,7 @@ func substituteProxyCommand(cmd, host string, port int) string {
 func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 	cmd := substituteProxyCommand(proxyCmd, host, port)
 	// Pass to /bin/sh -c so the command is interpreted by a shell, matching
-	// OpenSSH behaviour. /bin/sh is a hardcoded trusted binary.
+	// OpenSSH behavior. /bin/sh is a hardcoded trusted binary.
 	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec // cmd is from trusted ~/.ssh/config
 	c.Stderr = os.Stderr
 
@@ -228,7 +230,7 @@ func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 		cmd:    c,
 		stdin:  stdin,
 		stdout: stdout,
-		raddr:  proxyAddr(net.JoinHostPort(host, fmt.Sprintf("%d", port))),
+		raddr:  proxyAddr(net.JoinHostPort(host, strconv.Itoa(port))),
 	}, nil
 }
 
@@ -389,7 +391,7 @@ func DetectRemoteShell(cfg SSHConfig) (string, error) {
 
 	shell := strings.TrimSpace(string(out))
 	if shell == "" {
-		return "", fmt.Errorf("remote $SHELL is not set")
+		return "", errors.New("remote $SHELL is not set")
 	}
 	return shell, nil
 }
@@ -498,7 +500,7 @@ func buildAuthMethods(cfg SSHConfig) ([]ssh.AuthMethod, error) {
 		methods = append(methods, ssh.Password(cfg.Password))
 	}
 
-	// If no explicit auth method, try common default key files (mirrors OpenSSH behaviour).
+	// If no explicit auth method, try common default key files (mirrors OpenSSH behavior).
 	if len(methods) == 0 {
 		home, _ := os.UserHomeDir()
 		for _, name := range []string{"id_ed25519", "id_rsa", "id_ecdsa"} {
@@ -516,7 +518,7 @@ func buildAuthMethods(cfg SSHConfig) ([]ssh.AuthMethod, error) {
 	}
 
 	if len(methods) == 0 {
-		return nil, fmt.Errorf("no auth methods configured for SSH connection")
+		return nil, errors.New("no auth methods configured for SSH connection")
 	}
 
 	return methods, nil
@@ -574,7 +576,7 @@ func (s *SSHSession) ConnectionName() string { return s.connectionName }
 //     the interactive shell (started before any exec-channel children).
 //  3. We read the CWD of that PID via /proc (Linux) or lsof (macOS).
 //  4. If neither technique is available, we fall back to `pwd` (home dir),
-//     which is the previous behaviour.
+//     which is the previous behavior.
 const sshGetCWDCmd = `PID=$(pgrep -P $PPID -o 2>/dev/null) && [ -n "$PID" ] && ` +
 	`{ readlink /proc/$PID/cwd 2>/dev/null || ` +
 	`lsof -a -p $PID -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2)}'; } || ` +

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -53,7 +53,7 @@ func TestBuildAuthMethods_NoKeyNoPassword_NoDefaultKeys_Error(t *testing.T) {
 
 // TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound verifies that when no
 // explicit KeyFile is set but a default key exists at ~/.ssh/id_ed25519,
-// it is used automatically (mirrors OpenSSH behaviour).
+// it is used automatically (mirrors OpenSSH behavior).
 // This tests the fix for the case where ~/.ssh/config entries omit IdentityFile.
 func TestBuildAuthMethods_NoKeyNoPassword_DefaultKeyFound(t *testing.T) {
 	home := t.TempDir()

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -101,7 +101,7 @@ func tmuxSSHCommand(tmuxSession string, cfg SSHConfig) (string, error) {
 	if err := validateRemotePath("working directory", cfg.Cwd); err != nil {
 		return "", err
 	}
-	return cmd + fmt.Sprintf(" -c %s", shellQuotePath(cfg.Cwd)), nil
+	return cmd + " -c " + shellQuotePath(cfg.Cwd), nil
 }
 
 func (s *TmuxSSHSession) ID() string    { return s.id }

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	srv := server.New(cfg, manager, frontendFS)
-	addr := fmt.Sprintf("http://%s", srv.Addr())
+	addr := "http://" + srv.Addr()
 	log.Printf("Listening on %s", addr)
 
 	if opts.openBrowser {
@@ -80,7 +80,7 @@ func loadConfig(opts cliOptions) (*config.Config, error) {
 		cfg, err = config.LoadOrDefault()
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loading config: %w", err)
 	}
 	if opts.port != 0 {
 		cfg.Server.Port = opts.port


### PR DESCRIPTION
## Summary
- enable additional golangci-lint linters requested for Go code
- configure misspell locale, whitespace handling, revive defaults, and exclusion presets
- fix existing code issues surfaced by the added linters

## Test plan
- [x] golangci-lint config verify
- [x] make build-frontend
- [x] make lint-go
- [x] make test-go