### PR TITLE
ci: enable additional golangci checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ run:
 linters:
   default: standard
   enable:
+    - dupl
     - errcheck
     - errname
     - goconst
@@ -18,11 +19,18 @@ linters:
     - nilerr
     - perfsprint
     - revive
+    - sloglint
     - staticcheck
     - unused
     - whitespace
     - wrapcheck
   settings:
+    dupl:
+      threshold: 100
+    govet:
+      enable:
+        - fieldalignment
+        - shadow
     misspell:
       locale: US
     revive:

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -26,13 +26,13 @@ import (
 type Handler struct {
 	cfg                 *config.Config
 	manager             *session.Manager
-	editMode            atomic.Bool
-	sshConfigPath       string
-	codeBinaryPath      string // empty = auto-detect; overridden in tests
-	gitBinaryPath       string // empty = auto-detect; overridden in tests
 	createSession       func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
 	detectLocalShellFn  func() (string, error)
 	detectRemoteShellFn func(cfg session.SSHConfig) (string, error)
+	sshConfigPath       string
+	codeBinaryPath      string // empty = auto-detect; overridden in tests
+	gitBinaryPath       string // empty = auto-detect; overridden in tests
+	editMode            atomic.Bool
 }
 
 type editModeResponse struct {
@@ -51,16 +51,16 @@ type sshConfigHostInfo struct {
 	Name         string `json:"name"`
 	Hostname     string `json:"hostname"`
 	User         string `json:"user"`
-	Port         int    `json:"port,omitempty"`
 	IdentityFile string `json:"identity_file,omitempty"`
+	Port         int    `json:"port,omitempty"`
 }
 
 type sshConfigHostRequest struct {
 	Name         string `json:"name"`
 	Hostname     string `json:"hostname"`
 	User         string `json:"user"`
-	Port         int    `json:"port,omitempty"`
 	IdentityFile string `json:"identity_file,omitempty"`
+	Port         int    `json:"port,omitempty"`
 }
 
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
@@ -487,9 +487,9 @@ func (h *Handler) GetDetectShell(w http.ResponseWriter, r *http.Request) {
 }
 
 type gitInfoResponse struct {
-	IsGit  bool   `json:"is_git"`
 	Branch string `json:"branch,omitempty"`
 	Repo   string `json:"repo,omitempty"`
+	IsGit  bool   `json:"is_git"`
 }
 
 // GetGitInfo returns git repository information for the session's current working directory.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -94,6 +94,15 @@ func TestGetLayout_ReturnsJSON(t *testing.T) {
 func TestPutLayout_ValidBody_Updates(t *testing.T) {
 	cfg := defaultTestConfig()
 	r := setupRouter(cfg, session.NewManager())
+	rec := putVerticalLayout(t, r)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "vertical", cfg.Layout.Direction)
+}
+
+func putVerticalLayout(t *testing.T, r http.Handler) *httptest.ResponseRecorder {
+	t.Helper()
+
 	layout := config.LayoutNode{
 		Direction: "vertical",
 		Children:  []config.LayoutChild{{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}}},
@@ -103,9 +112,7 @@ func TestPutLayout_ValidBody_Updates(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "vertical", cfg.Layout.Direction)
+	return rec
 }
 
 func TestPutLayout_InvalidJSON_Returns400(t *testing.T) {
@@ -326,15 +333,7 @@ func TestPutLayout_EditModeOff_DoesNotPersist(t *testing.T) {
 	r := setupRouter(cfg, session.NewManager())
 
 	// editMode is false by default
-	layout := config.LayoutNode{
-		Direction: "vertical",
-		Children:  []config.LayoutChild{{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}}},
-	}
-	body, _ := json.Marshal(layout)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/layout", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(rec, req)
+	rec := putVerticalLayout(t, r)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	// In-memory layout should be updated
@@ -652,17 +651,24 @@ func TestPostSSHConfigHost_ValidHost_201(t *testing.T) {
 }
 
 func TestPostSSHConfigHost_MissingName_422(t *testing.T) {
+	rec := postSSHConfigHost(t, sshConfigHostRequest{Hostname: "host.example.com", User: "ubuntu"})
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func postSSHConfigHost(t *testing.T, body sshConfigHostRequest) *httptest.ResponseRecorder {
+	t.Helper()
+
 	h := NewHandler(defaultTestConfig(), session.NewManager())
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
-	body, _ := json.Marshal(sshConfigHostRequest{Hostname: "host.example.com", User: "ubuntu"})
+	payload, _ := json.Marshal(body)
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	return rec
 }
 
 func TestPostSSHConfigHost_InvalidNameChars_422(t *testing.T) {
@@ -680,29 +686,13 @@ func TestPostSSHConfigHost_InvalidNameChars_422(t *testing.T) {
 }
 
 func TestPostSSHConfigHost_MissingHostname_422(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
-	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
-	r := setupRouterWithHandler(h)
-
-	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", User: "ubuntu"})
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(rec, req)
+	rec := postSSHConfigHost(t, sshConfigHostRequest{Name: "myhost", User: "ubuntu"})
 
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 }
 
 func TestPostSSHConfigHost_MissingUser_422(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
-	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
-	r := setupRouterWithHandler(h)
-
-	body, _ := json.Marshal(sshConfigHostRequest{Name: "myhost", Hostname: "myhost.example.com"})
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/ssh-config/hosts", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(rec, req)
+	rec := postSSHConfigHost(t, sshConfigHostRequest{Name: "myhost", Hostname: "myhost.example.com"})
 
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 }
@@ -757,8 +747,8 @@ func TestPostSSHConfigHost_InvalidBody_400(t *testing.T) {
 // mockCWDSession is a mockSession that also implements session.CWDGetter.
 type mockCWDSession struct {
 	mockSession
-	cwd    string
 	cwdErr error
+	cwd    string
 }
 
 func (m *mockCWDSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
@@ -805,23 +795,31 @@ func TestPostOpenVSCode_NoCWDGetter_422(t *testing.T) {
 
 func TestPostOpenVSCode_Local_200(t *testing.T) {
 	dir := t.TempDir()
-	mgr := session.NewManager()
-	mgr.Add(&mockCWDSession{
+	resp := postOpenVSCodeOK(t, "local1", &mockCWDSession{
 		mockSession: mockSession{id: "local1", typ: session.TypeLocal},
 		cwd:         dir,
 	})
+
+	assert.Equal(t, dir, resp.Cwd)
+}
+
+func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
+	t.Helper()
+
+	mgr := session.NewManager()
+	mgr.Add(sess)
 	h := NewHandler(defaultTestConfig(), mgr)
-	h.codeBinaryPath = "/bin/echo" // stub: echo instead of opening VSCode
+	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/sessions/local1/open-vscode", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/open-vscode", nil)
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp openVSCodeResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
-	assert.Equal(t, dir, resp.Cwd)
+	return resp
 }
 
 func TestPostOpenVSCode_Local_DeletedDir_422(t *testing.T) {
@@ -844,23 +842,12 @@ func TestPostOpenVSCode_Local_DeletedDir_422(t *testing.T) {
 }
 
 func TestPostOpenVSCode_SSH_200(t *testing.T) {
-	mgr := session.NewManager()
-	mgr.Add(&mockSSHCWDSession{
+	resp := postOpenVSCodeOK(t, "ssh1", &mockSSHCWDSession{
 		mockSession: mockSession{id: "ssh1", typ: session.TypeSSH},
 		cwd:         "/home/user/code",
 		connName:    "myserver",
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
-	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/sessions/ssh1/open-vscode", nil)
-	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp openVSCodeResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "/home/user/code", resp.Cwd)
 }
 
@@ -884,43 +871,21 @@ func TestPostOpenVSCode_SSH_InvalidConnName_422(t *testing.T) {
 
 func TestPostOpenVSCode_Tmux_200(t *testing.T) {
 	dir := t.TempDir()
-	mgr := session.NewManager()
-	mgr.Add(&mockCWDSession{
+	resp := postOpenVSCodeOK(t, "tmux1", &mockCWDSession{
 		mockSession: mockSession{id: "tmux1", typ: session.TypeTmux},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
-	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/sessions/tmux1/open-vscode", nil)
-	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp openVSCodeResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, dir, resp.Cwd)
 }
 
 func TestPostOpenVSCode_SSHTmux_200(t *testing.T) {
-	mgr := session.NewManager()
-	mgr.Add(&mockSSHCWDSession{
+	resp := postOpenVSCodeOK(t, "sshtmux1", &mockSSHCWDSession{
 		mockSession: mockSession{id: "sshtmux1", typ: session.TypeSSHTmux},
 		cwd:         "/home/user/remote",
 		connName:    "remote-box",
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
-	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/sessions/sshtmux1/open-vscode", nil)
-	r.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp openVSCodeResponse
-	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "/home/user/remote", resp.Cwd)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,17 +54,19 @@ type LayoutChild struct {
 	Size      float64       `yaml:"size"               json:"size"`
 }
 
-type Config struct {
+// Config field order controls YAML serialization order for newly written
+// config files, so it intentionally prioritizes user-facing output over
+// fieldalignment.
+type Config struct { //nolint:govet
+	Server         ServerConfig             `yaml:"server"`
 	SSHConnections map[string]SSHConnection `yaml:"ssh_connections,omitempty"`
+	Layout         LayoutNode               `yaml:"layout"`
+	Display        DisplayConfig            `yaml:"display,omitempty" json:"display"`
 
 	// internal: raw yaml node for comment-preserving writes
 	rawNode       *yaml.Node
 	filePath      string
 	sshConfigPath string // overridable for tests; empty = use sshconfig.DefaultPath()
-
-	Layout  LayoutNode    `yaml:"layout"`
-	Server  ServerConfig  `yaml:"server"`
-	Display DisplayConfig `yaml:"display,omitempty" json:"display"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,17 +11,17 @@ import (
 )
 
 type ServerConfig struct {
-	Port int    `yaml:"port"`
 	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
 }
 
 type SSHConnection struct {
 	Host           string `yaml:"host"`
-	Port           int    `yaml:"port"`
 	User           string `yaml:"user"`
 	KeyFile        string `yaml:"key_file"`
 	Password       string `yaml:"password,omitempty"`
 	KnownHostsFile string `yaml:"known_hosts_file,omitempty" json:"known_hosts_file,omitempty"`
+	Port           int    `yaml:"port"`
 }
 
 type DisplayConfig struct {
@@ -30,6 +30,8 @@ type DisplayConfig struct {
 }
 
 type PaneConfig struct {
+	ShowHeader    *bool  `yaml:"show_header,omitempty"    json:"show_header,omitempty"`
+	ShowStatusBar *bool  `yaml:"show_status_bar,omitempty" json:"show_status_bar,omitempty"`
 	ID            string `yaml:"id"           json:"id"`
 	Type          string `yaml:"type"         json:"type"` // local | ssh | tmux | ssh_tmux
 	Shell         string `yaml:"shell,omitempty"        json:"shell,omitempty"`
@@ -37,33 +39,32 @@ type PaneConfig struct {
 	Title         string `yaml:"title,omitempty"        json:"title,omitempty"`
 	Connection    string `yaml:"connection,omitempty"   json:"connection,omitempty"` // ssh_connections key
 	TmuxSession   string `yaml:"tmux_session,omitempty" json:"tmux_session,omitempty"`
-	ShowHeader    *bool  `yaml:"show_header,omitempty"    json:"show_header,omitempty"`
-	ShowStatusBar *bool  `yaml:"show_status_bar,omitempty" json:"show_status_bar,omitempty"`
 }
 
 type LayoutNode struct {
+	Pane      *PaneConfig   `yaml:"pane,omitempty"      json:"pane,omitempty"`
 	Direction string        `yaml:"direction,omitempty" json:"direction,omitempty"` // horizontal | vertical
 	Children  []LayoutChild `yaml:"children,omitempty"  json:"children,omitempty"`
-	Pane      *PaneConfig   `yaml:"pane,omitempty"      json:"pane,omitempty"`
 }
 
 type LayoutChild struct {
-	Size      float64       `yaml:"size"               json:"size"`
 	Pane      *PaneConfig   `yaml:"pane,omitempty"     json:"pane,omitempty"`
 	Direction string        `yaml:"direction,omitempty" json:"direction,omitempty"`
 	Children  []LayoutChild `yaml:"children,omitempty"  json:"children,omitempty"`
+	Size      float64       `yaml:"size"               json:"size"`
 }
 
 type Config struct {
-	Server         ServerConfig             `yaml:"server"`
 	SSHConnections map[string]SSHConnection `yaml:"ssh_connections,omitempty"`
-	Layout         LayoutNode               `yaml:"layout"`
-	Display        DisplayConfig            `yaml:"display,omitempty" json:"display"`
 
 	// internal: raw yaml node for comment-preserving writes
 	rawNode       *yaml.Node
 	filePath      string
 	sshConfigPath string // overridable for tests; empty = use sshconfig.DefaultPath()
+
+	Layout  LayoutNode    `yaml:"layout"`
+	Server  ServerConfig  `yaml:"server"`
+	Display DisplayConfig `yaml:"display,omitempty" json:"display"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,8 +63,6 @@ type Config struct { //nolint:govet
 	Layout         LayoutNode               `yaml:"layout"`
 	Display        DisplayConfig            `yaml:"display,omitempty" json:"display"`
 
-	// internal: raw yaml node for comment-preserving writes
-	rawNode       *yaml.Node
 	filePath      string
 	sshConfigPath string // overridable for tests; empty = use sshconfig.DefaultPath()
 }
@@ -75,17 +73,11 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("reading config: %w", err)
 	}
 
-	var rawNode yaml.Node
-	if err := yaml.Unmarshal(data, &rawNode); err != nil {
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
-	var cfg Config
-	if err := rawNode.Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("decoding config: %w", err)
-	}
-
-	cfg.rawNode = &rawNode
 	cfg.filePath = path
 	cfg.expandPaths()
 
@@ -195,7 +187,7 @@ func loadOrDefaultAt(path string) (*Config, error) {
 	return Load(path)
 }
 
-// SaveLayout updates the layout section and writes back to file, preserving comments.
+// SaveLayout updates the layout section and writes the config file.
 func (c *Config) SaveLayout(layout LayoutNode) error {
 	c.Layout = layout
 	if c.filePath == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -404,6 +404,23 @@ func TestSaveLayout_CreatesParentDirectory(t *testing.T) {
 	assert.NoError(t, statErr, "config file should have been created")
 }
 
+func TestSaveLayout_NewFilePreservesYAMLKeyOrder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := Default()
+	cfg.filePath = path
+
+	require.NoError(t, cfg.SaveLayout(cfg.Layout))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	serverIndex := strings.Index(content, "server:")
+	layoutIndex := strings.Index(content, "layout:")
+	require.NotEqual(t, -1, serverIndex)
+	require.NotEqual(t, -1, layoutIndex)
+	assert.Less(t, serverIndex, layoutIndex)
+}
+
 func TestUpdateLayout_UpdatesMemoryOnly(t *testing.T) {
 	cfg := &Config{}
 	newLayout := LayoutNode{Direction: "horizontal", Children: []LayoutChild{{Size: 100}}}

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -24,12 +24,12 @@ var validShellPath = regexp.MustCompile(`^(/[a-zA-Z0-9._\-/]+)$`)
 
 // LocalSession is a local PTY-based terminal session.
 type LocalSession struct {
-	mu    sync.RWMutex
+	cmd   *exec.Cmd
+	ptmx  *os.File
 	id    string
 	title string
 	state State
-	cmd   *exec.Cmd
-	ptmx  *os.File
+	mu    sync.RWMutex
 	pid   int
 }
 

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -52,14 +52,14 @@ func TestNewLocal_Write_Read(t *testing.T) {
 	require.NoError(t, err)
 
 	type result struct {
-		n   int
 		err error
+		n   int
 	}
 	ch := make(chan result, 1)
 	go func() {
 		buf := make([]byte, 1024)
 		n, err := sess.Read(buf)
-		ch <- result{n, err}
+		ch <- result{err: err, n: n}
 	}()
 
 	select {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -7,8 +7,8 @@ import (
 
 // Manager manages the lifecycle of all terminal sessions.
 type Manager struct {
-	mu       sync.RWMutex
 	sessions map[string]Session
+	mu       sync.RWMutex
 }
 
 // NewManager creates a new session manager.

--- a/internal/session/mock_test.go
+++ b/internal/session/mock_test.go
@@ -5,9 +5,9 @@ import "io"
 type mockSession struct {
 	id     string
 	title  string
+	buf    chan []byte
 	typ    Type
 	state  State
-	buf    chan []byte
 	closed bool
 }
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -34,32 +34,32 @@ const invalidRemotePathMsg = "must be an absolute path with no shell metacharact
 
 // SSHSession manages an SSH connection with a PTY.
 type SSHSession struct {
-	mu      sync.RWMutex
-	id      string
-	title   string
-	state   State
-	client  *ssh.Client
-	session *ssh.Session
-	stdin   io.WriteCloser
+	client     *ssh.Client
+	session    *ssh.Session
+	jumpClient *ssh.Client // non-nil when connected via ProxyJump; closed after client
+	stdin      io.WriteCloser
 	// combined reader for stdout+stderr
 	reader         io.Reader
+	id             string
+	title          string
 	connectionName string
-	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
+	state          State
+	mu             sync.RWMutex
 }
 
 // SSHConfig holds parameters for establishing an SSH connection.
 type SSHConfig struct {
+	JumpHost       *SSHConfig // non-nil when ProxyJump is configured
 	Host           string
-	Port           int
 	User           string
 	KeyFile        string
 	Password       string
 	KnownHostsFile string
-	Cwd            string     // initial working directory on the remote host
-	Shell          string     // override login shell (empty = use remote login shell)
-	ConnectionName string     // alias used in panemux (for VSCode Remote SSH)
-	JumpHost       *SSHConfig // non-nil when ProxyJump is configured
-	ProxyCommand   string     // shell command used as stdin/stdout pipe (ProxyCommand directive)
+	Cwd            string // initial working directory on the remote host
+	Shell          string // override login shell (empty = use remote login shell)
+	ConnectionName string // alias used in panemux (for VSCode Remote SSH)
+	ProxyCommand   string // shell command used as stdin/stdout pipe (ProxyCommand directive)
+	Port           int
 }
 
 // shellQuotePath wraps path in single quotes and escapes any single quotes

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -14,15 +14,15 @@ import (
 
 // TmuxLocalSession attaches to an existing local tmux session via PTY.
 type TmuxLocalSession struct {
-	mu          sync.RWMutex
-	id          string
-	title       string
-	tmuxSession string
-	state       State
 	cmd         *exec.Cmd
 	ptmx        *os.File
 	pr          *io.PipeReader // Read() reads from here
 	pw          *io.PipeWriter // background goroutine writes output then closes
+	id          string
+	title       string
+	tmuxSession string
+	state       State
+	mu          sync.RWMutex
 }
 
 // NewTmuxLocal creates a new session that attaches to a local tmux session.

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -14,17 +14,17 @@ var validTmuxSessionName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // TmuxSSHSession attaches to a tmux session on a remote host via SSH.
 type TmuxSSHSession struct {
-	mu             sync.RWMutex
+	client         *ssh.Client
+	session        *ssh.Session
+	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
+	stdin          io.WriteCloser
+	reader         io.Reader
 	id             string
 	title          string
 	tmuxSession    string
-	state          State
-	client         *ssh.Client
-	session        *ssh.Session
-	stdin          io.WriteCloser
-	reader         io.Reader
 	connectionName string
-	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
+	state          State
+	mu             sync.RWMutex
 }
 
 // NewTmuxSSH creates a session that attaches to a remote tmux session.

--- a/internal/sshconfig/parse.go
+++ b/internal/sshconfig/parse.go
@@ -15,10 +15,10 @@ type Host struct {
 	Name         string // Host alias (e.g. "prod-web")
 	Hostname     string // HostName directive (defaults to Name if not set)
 	User         string
-	Port         int // 0 = not set (caller uses default 22)
 	IdentityFile string
 	ProxyJump    string // ProxyJump directive (alias or user@host)
 	ProxyCommand string // ProxyCommand directive (shell command acting as stdin/stdout pipe)
+	Port         int    // 0 = not set (caller uses default 22)
 }
 
 // DefaultPath returns the default SSH config path (~/.ssh/config).

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -25,10 +25,10 @@ var upgrader = websocket.Upgrader{
 // ControlMessage is a JSON control frame exchanged over WebSocket.
 type ControlMessage struct {
 	Type    string `json:"type"`
-	Cols    uint16 `json:"cols,omitempty"`
-	Rows    uint16 `json:"rows,omitempty"`
 	State   string `json:"state,omitempty"`
 	Message string `json:"message,omitempty"`
+	Cols    uint16 `json:"cols,omitempty"`
+	Rows    uint16 `json:"rows,omitempty"`
 }
 
 // Handler handles WebSocket connections for terminal sessions.

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -20,10 +20,10 @@ import (
 // wsMockSession implements session.Session for WebSocket handler tests.
 type wsMockSession struct {
 	id      string
-	state   session.State // configurable; defaults to StateConnected
-	out     chan []byte   // data sent to WS client (session output)
-	in      chan []byte   // data received from WS client (session input)
+	out     chan []byte // data sent to WS client (session output)
+	in      chan []byte // data received from WS client (session input)
 	resizes chan [2]uint16
+	state   session.State // configurable; defaults to StateConnected
 	closed  bool
 }
 

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ var version = "dev"
 type cliOptions struct {
 	configPath  string
 	openBrowser bool
-	port        int
 	showVersion bool
+	port        int
 }
 
 //go:embed frontend/dist


### PR DESCRIPTION
## Summary
- Enable dupl with threshold 100 and sloglint in golangci-lint
- Enable govet fieldalignment and shadow analyzers
- Adjust existing tests and struct field order to satisfy the new checks

## Test plan
- [x] make lint-go
- [x] make test-go