### PR TITLE
fix: tighten config permissions with gosec lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - errcheck
     - errname
     - goconst
+    - gosec
     - govet
     - ineffassign
     - funlen

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -390,7 +390,7 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Launch VSCode detached — we do not wait for it to exit.
-	cmd := exec.Command(codePath, args...) //nolint:gosec // codePath is from trusted lookup
+	cmd := exec.Command(codePath, args...) //nolint:gosec // G204: codePath is from trusted lookup
 	if err := cmd.Start(); err != nil {
 		http.Error(w, fmt.Sprintf("failed to launch VSCode: %v", err), http.StatusInternalServerError)
 		return
@@ -411,7 +411,7 @@ func (h *Handler) validateVSCodeCWD(
 ) bool {
 	switch sess.Type() {
 	case session.TypeLocal, session.TypeTmux:
-		if _, err := os.Stat(cwd); err != nil { //nolint:gosec // cwd is reported by the local session process
+		if _, err := os.Stat(cwd); err != nil { //nolint:gosec // G703: cwd is from local session process
 			writeValidationError(w, "working directory no longer exists: "+cwd)
 			return false
 		}
@@ -519,7 +519,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	toplevelOut, err := exec.Command( //nolint:gosec // gitPath is from trusted lookup
+	toplevelOut, err := exec.Command( //nolint:gosec // G204: gitPath is from trusted lookup
 		gitPath,
 		"-C",
 		cwd,
@@ -532,7 +532,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	repo := filepath.Base(strings.TrimSpace(string(toplevelOut)))
 
-	branchOut, err := exec.Command( //nolint:gosec // gitPath is from trusted lookup
+	branchOut, err := exec.Command( //nolint:gosec // G204: gitPath is from trusted lookup
 		gitPath,
 		"-C",
 		cwd,

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -411,7 +411,7 @@ func (h *Handler) validateVSCodeCWD(
 ) bool {
 	switch sess.Type() {
 	case session.TypeLocal, session.TypeTmux:
-		if _, err := os.Stat(cwd); err != nil {
+		if _, err := os.Stat(cwd); err != nil { //nolint:gosec // cwd is reported by the local session process
 			writeValidationError(w, "working directory no longer exists: "+cwd)
 			return false
 		}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -970,7 +970,7 @@ func initTempGitRepo(t *testing.T) string {
 		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
 	}
 	for _, args := range cmds {
-		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec // trusted test args
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec // G204: trusted test args
 		require.NoError(t, err, "git init step failed: %s", string(out))
 	}
 	return dir

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -970,7 +970,7 @@ func initTempGitRepo(t *testing.T) string {
 		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
 	}
 	for _, args := range cmds {
-		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec -- trusted test args
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec // trusted test args
 		require.NoError(t, err, "git init step failed: %s", string(out))
 	}
 	return dir

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const configFileMode os.FileMode = 0600
+
 type ServerConfig struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
@@ -83,6 +85,9 @@ func Load(path string) (*Config, error) {
 
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	if err := tightenConfigFilePermissions(path); err != nil {
+		return nil, err
 	}
 
 	return &cfg, nil
@@ -202,8 +207,22 @@ func (c *Config) SaveLayout(layout LayoutNode) error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	if err := os.WriteFile(c.filePath, data, 0600); err != nil {
+	if err := os.WriteFile(c.filePath, data, configFileMode); err != nil {
 		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}
+
+func tightenConfigFilePermissions(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("checking config permissions: %w", err)
+	}
+	if info.Mode().Perm() == configFileMode {
+		return nil
+	}
+	if err := os.Chmod(path, configFileMode); err != nil {
+		return fmt.Errorf("tightening config permissions: %w", err)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 	if err := tightenConfigFilePermissions(path); err != nil {
-		//nolint:gosec // local filesystem warning
+		//nolint:gosec // G706: local filesystem warning
 		log.Printf("Warning: failed to tighten config file permissions to 0600: %v", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,7 +202,7 @@ func (c *Config) SaveLayout(layout LayoutNode) error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	if err := os.WriteFile(c.filePath, data, 0644); err != nil {
+	if err := os.WriteFile(c.filePath, data, 0600); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,8 @@ import (
 )
 
 const configFileMode os.FileMode = 0600
+
+var chmodConfigFile = os.Chmod
 
 type ServerConfig struct {
 	Host string `yaml:"host"`
@@ -87,7 +90,8 @@ func Load(path string) (*Config, error) {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 	if err := tightenConfigFilePermissions(path); err != nil {
-		return nil, err
+		//nolint:gosec // local filesystem warning
+		log.Printf("Warning: failed to tighten config file permissions to 0600: %v", err)
 	}
 
 	return &cfg, nil
@@ -221,7 +225,7 @@ func tightenConfigFilePermissions(path string) error {
 	if info.Mode().Perm() == configFileMode {
 		return nil
 	}
-	if err := os.Chmod(path, configFileMode); err != nil {
+	if err := chmodConfigFile(path, configFileMode); err != nil {
 		return fmt.Errorf("tightening config permissions: %w", err)
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"bytes"
+	"errors"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +174,39 @@ layout:
 	info, err := os.Stat(f)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestLoad_ChmodFailureWarnsAndContinues(t *testing.T) {
+	content := `
+server:
+  port: 8080
+  host: "127.0.0.1"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+	f := writeTempFile(t, content)
+	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // legacy config permission under test
+
+	oldChmod := chmodConfigFile
+	chmodConfigFile = func(string, os.FileMode) error {
+		return errors.New("read-only filesystem")
+	}
+	t.Cleanup(func() { chmodConfigFile = oldChmod })
+
+	var logs bytes.Buffer
+	oldOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(oldOutput) })
+
+	cfg, err := Load(f)
+	require.NoError(t, err)
+	assert.Equal(t, 8080, cfg.Server.Port)
+	assert.Contains(t, logs.String(), "Warning: failed to tighten config file permissions")
 }
 
 func TestLoad_InvalidYAML(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -166,7 +166,7 @@ layout:
         type: local
 `
 	f := writeTempFile(t, content)
-	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // legacy config permission under test
+	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // G302: legacy config permission under test
 
 	_, err := Load(f)
 	require.NoError(t, err)
@@ -190,7 +190,7 @@ layout:
         type: local
 `
 	f := writeTempFile(t, content)
-	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // legacy config permission under test
+	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // G302: legacy config permission under test
 
 	oldChmod := chmodConfigFile
 	chmodConfigFile = func(string, os.FileMode) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -149,6 +149,30 @@ layout:
 	assert.Equal(t, "horizontal", cfg.Layout.Direction)
 }
 
+func TestLoad_TightensExistingFilePermissions(t *testing.T) {
+	content := `
+server:
+  port: 8080
+  host: "127.0.0.1"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+	f := writeTempFile(t, content)
+	require.NoError(t, os.Chmod(f, 0644)) //nolint:gosec // legacy config permission under test
+
+	_, err := Load(f)
+	require.NoError(t, err)
+
+	info, err := os.Stat(f)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
 func TestLoad_InvalidYAML(t *testing.T) {
 	f := writeTempFile(t, "::invalid yaml::")
 	_, err := Load(f)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -400,8 +400,9 @@ func TestSaveLayout_CreatesParentDirectory(t *testing.T) {
 	cfg.filePath = path
 	err := cfg.SaveLayout(cfg.Layout)
 	require.NoError(t, err)
-	_, statErr := os.Stat(path)
-	assert.NoError(t, statErr, "config file should have been created")
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr, "config file should have been created")
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }
 
 func TestSaveLayout_NewFilePreservesYAMLKeyOrder(t *testing.T) {
@@ -469,6 +470,6 @@ func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()
 	f := filepath.Join(dir, "config.yaml")
-	require.NoError(t, os.WriteFile(f, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(f, []byte(content), 0600))
 	return f
 }

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -126,7 +126,7 @@ func (s *LocalSession) GetCWD() (string, error) {
 	case "darwin":
 		// -a ANDs the -p and -d conditions; without -a they are OR'd, which
 		// causes -d cwd to dump the cwd of every process on the system.
-		out, err := exec.Command( //nolint:gosec // lsof is trusted and pid is an internal process ID
+		out, err := exec.Command( //nolint:gosec // G204: lsof is trusted and pid is an internal process ID
 			"lsof",
 			"-a",
 			"-p",
@@ -201,7 +201,7 @@ func DetectLocalShell() (string, error) {
 	}
 	// /etc/passwd lookup failed (expected on macOS) — try dscl.
 	return detectLocalShellDscl(currentUser.Username, func(username string) ([]byte, error) {
-		return exec.Command( //nolint:gosec // username comes from os/user.Current for the local account
+		return exec.Command( //nolint:gosec // G204: username comes from os/user.Current for the local account
 			"/usr/bin/dscl",
 			".",
 			"-read",

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -126,7 +126,15 @@ func (s *LocalSession) GetCWD() (string, error) {
 	case "darwin":
 		// -a ANDs the -p and -d conditions; without -a they are OR'd, which
 		// causes -d cwd to dump the cwd of every process on the system.
-		out, err := exec.Command("lsof", "-a", "-p", strconv.Itoa(s.pid), "-d", "cwd", "-Fn").Output()
+		out, err := exec.Command( //nolint:gosec // lsof is trusted and pid is an internal process ID
+			"lsof",
+			"-a",
+			"-p",
+			strconv.Itoa(s.pid),
+			"-d",
+			"cwd",
+			"-Fn",
+		).Output()
 		if err != nil {
 			return "", fmt.Errorf("lsof: %w", err)
 		}
@@ -193,7 +201,13 @@ func DetectLocalShell() (string, error) {
 	}
 	// /etc/passwd lookup failed (expected on macOS) — try dscl.
 	return detectLocalShellDscl(currentUser.Username, func(username string) ([]byte, error) {
-		return exec.Command("/usr/bin/dscl", ".", "-read", "/Users/"+username, "UserShell").Output()
+		return exec.Command( //nolint:gosec // username comes from os/user.Current for the local account
+			"/usr/bin/dscl",
+			".",
+			"-read",
+			"/Users/"+username,
+			"UserShell",
+		).Output()
 	})
 }
 

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -128,7 +128,7 @@ func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
 	// Create a real executable that is not listed in /etc/shells.
 	dir := t.TempDir()
 	fakePath := dir + "/fakeshell"
-	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755)) //nolint:gosec // executable fixture
+	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755)) //nolint:gosec // G306: executable fixture
 
 	_, err := validateShell(fakePath)
 	require.Error(t, err)

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -128,7 +128,7 @@ func TestValidateShell_NotInEtcShells_Error(t *testing.T) {
 	// Create a real executable that is not listed in /etc/shells.
 	dir := t.TempDir()
 	fakePath := dir + "/fakeshell"
-	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755))
+	require.NoError(t, os.WriteFile(fakePath, []byte("#!/bin/sh\n"), 0755)) //nolint:gosec // executable fixture
 
 	_, err := validateShell(fakePath)
 	require.Error(t, err)
@@ -160,7 +160,7 @@ func TestDetectLocalShellFrom_MatchesCurrentUID(t *testing.T) {
 	}
 	content += currentUser.Username + ":x:" + currentUser.Uid + ":1000::/home/user:/usr/bin/bash\n"
 	tmpFile := filepath.Join(t.TempDir(), "passwd")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0600))
 
 	shell, err := detectLocalShellFrom(tmpFile)
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestDetectLocalShellFrom_MatchesCurrentUID(t *testing.T) {
 func TestDetectLocalShellFrom_UserNotFound_Error(t *testing.T) {
 	content := "nobody:x:99999:99999::/nonexistent:/bin/false\n"
 	tmpFile := filepath.Join(t.TempDir(), "passwd")
-	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
+	require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0600))
 
 	_, err := detectLocalShellFrom(tmpFile)
 	require.Error(t, err)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/hmac"
-	"crypto/sha1" //nolint:gosec // OpenSSH hashed known_hosts entries use HMAC-SHA1
+	"crypto/sha1" //nolint:gosec // G505: OpenSSH hashed known_hosts entries use HMAC-SHA1
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -212,7 +212,7 @@ func dialViaProxyCommand(proxyCmd, host string, port int) (net.Conn, error) {
 	cmd := substituteProxyCommand(proxyCmd, host, port)
 	// Pass to /bin/sh -c so the command is interpreted by a shell, matching
 	// OpenSSH behavior. /bin/sh is a hardcoded trusted binary.
-	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec // cmd is from trusted ~/.ssh/config
+	c := exec.Command("/bin/sh", "-c", cmd) //nolint:gosec // G204: ProxyCommand is trusted SSH config
 	c.Stderr = os.Stderr
 
 	stdin, err := c.StdinPipe()

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // OpenSSH hashed known_hosts entries use HMAC-SHA1
 	"encoding/base64"
 	"errors"
 	"fmt"

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -102,7 +102,14 @@ func (s *TmuxLocalSession) Resize(cols, rows uint16) error {
 
 // GetCWD returns the current working directory of the active tmux pane.
 func (s *TmuxLocalSession) GetCWD() (string, error) {
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", s.tmuxSession, "#{pane_current_path}").Output()
+	out, err := exec.Command( //nolint:gosec // tmuxSession is validated config for a tmux target
+		"tmux",
+		"display-message",
+		"-p",
+		"-t",
+		s.tmuxSession,
+		"#{pane_current_path}",
+	).Output()
 	if err != nil {
 		return "", fmt.Errorf("tmux display-message: %w", err)
 	}

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -102,7 +102,7 @@ func (s *TmuxLocalSession) Resize(cols, rows uint16) error {
 
 // GetCWD returns the current working directory of the active tmux pane.
 func (s *TmuxLocalSession) GetCWD() (string, error) {
-	out, err := exec.Command( //nolint:gosec // tmuxSession is validated config for a tmux target
+	out, err := exec.Command( //nolint:gosec // G204: tmuxSession is validated config for a tmux target
 		"tmux",
 		"display-message",
 		"-p",

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -52,7 +52,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Printf("ws upgrade error for session %s: %v", sessionID, err) //nolint:gosec // config ID
+		//nolint:gosec // sessionID is a config-defined identifier
+		log.Printf("ws upgrade error for session %s: %v", sessionID, err)
 		return
 	}
 	defer conn.Close() //nolint:errcheck

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Printf("ws upgrade error for session %s: %v", sessionID, err)
+		log.Printf("ws upgrade error for session %s: %v", sessionID, err) //nolint:gosec // config ID
 		return
 	}
 	defer conn.Close() //nolint:errcheck
@@ -100,7 +100,7 @@ func (h *Handler) forwardTerminalOutput(
 		}
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("session %s read error: %v", sessionID, err)
+				log.Printf("session %s read error: %v", sessionID, err) //nolint:gosec // sessionID is a config-defined identifier
 			}
 			h.sendStatus(conn, "exited")
 			return
@@ -136,7 +136,7 @@ func (h *Handler) handleWebSocketMessage(
 			return
 		}
 		if _, err := sess.Write(data); err != nil {
-			log.Printf("session %s write error: %v", sessionID, err)
+			log.Printf("session %s write error: %v", sessionID, err) //nolint:gosec // sessionID is a config-defined identifier
 		}
 
 	case websocket.TextMessage:

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -52,7 +52,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		//nolint:gosec // sessionID is a config-defined identifier
+		//nolint:gosec // G706: sessionID is a config-defined identifier
 		log.Printf("ws upgrade error for session %s: %v", sessionID, err)
 		return
 	}
@@ -101,7 +101,7 @@ func (h *Handler) forwardTerminalOutput(
 		}
 		if err != nil {
 			if err != io.EOF {
-				//nolint:gosec // sessionID is a config-defined identifier
+				//nolint:gosec // G706: sessionID is a config-defined identifier
 				log.Printf("session %s read error: %v", sessionID, err)
 			}
 			h.sendStatus(conn, "exited")
@@ -138,7 +138,7 @@ func (h *Handler) handleWebSocketMessage(
 			return
 		}
 		if _, err := sess.Write(data); err != nil {
-			//nolint:gosec // sessionID is a config-defined identifier
+			//nolint:gosec // G706: sessionID is a config-defined identifier
 			log.Printf("session %s write error: %v", sessionID, err)
 		}
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -101,7 +101,8 @@ func (h *Handler) forwardTerminalOutput(
 		}
 		if err != nil {
 			if err != io.EOF {
-				log.Printf("session %s read error: %v", sessionID, err) //nolint:gosec // sessionID is a config-defined identifier
+				//nolint:gosec // sessionID is a config-defined identifier
+				log.Printf("session %s read error: %v", sessionID, err)
 			}
 			h.sendStatus(conn, "exited")
 			return
@@ -137,7 +138,8 @@ func (h *Handler) handleWebSocketMessage(
 			return
 		}
 		if _, err := sess.Write(data); err != nil {
-			log.Printf("session %s write error: %v", sessionID, err) //nolint:gosec // sessionID is a config-defined identifier
+			//nolint:gosec // sessionID is a config-defined identifier
+			log.Printf("session %s write error: %v", sessionID, err)
 		}
 
 	case websocket.TextMessage:

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func openChrome(url string) {
 	case "darwin":
 		cmd = exec.Command("open", "-a", "Google Chrome", url)
 	case "linux":
-		cmd = exec.Command("google-chrome", "--app="+url) //nolint:gosec // url is constructed from local server host and port
+		cmd = exec.Command("google-chrome", "--app="+url) //nolint:gosec // G204: URL is local server host/port
 	case "windows":
 		cmd = exec.Command("cmd", "/c", "start", "chrome", url)
 	default:

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func openChrome(url string) {
 	case "darwin":
 		cmd = exec.Command("open", "-a", "Google Chrome", url)
 	case "linux":
-		cmd = exec.Command("google-chrome", "--app="+url)
+		cmd = exec.Command("google-chrome", "--app="+url) //nolint:gosec // url is constructed from local server host and port
 	case "windows":
 		cmd = exec.Command("cmd", "/c", "start", "chrome", url)
 	default:


### PR DESCRIPTION
## Summary
- enable gosec in golangci-lint
- tighten config file permissions to 0600 when loading existing configs and when saving new changes
- warn and continue if an existing readable config cannot be chmod'd
- document targeted gosec suppressions for trusted OS/protocol integration points

## Test plan
- [x] go test ./internal/config -run 'TestLoad_(TightensExistingFilePermissions|ChmodFailureWarnsAndContinues)' -count=1
- [x] make lint-go
- [x] make test-go