### PR TITLE
feat: add workspace rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ workspaces:
 
 Older config files with a top-level `layout:` are still accepted. When the config is next saved, panemux migrates that layout into a `default` workspace and writes the `workspaces:` format.
 
-If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add control; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab also has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace is persisted so the same workspace is restored after restart.
+If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add control; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab can be renamed inline and has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace is persisted so the same workspace is restored after restart.
 
 ### Pane types
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,8 +49,8 @@ ssh_connections:
 # `workspaces:` format.
 #
 # The tab bar is hidden during normal use when only one workspace exists. Turn on
-# edit mode to add or delete workspaces. New workspaces start with one local
-# terminal pane. Deleting a workspace asks for confirmation, and the last
+# edit mode to add, rename, or delete workspaces. New workspaces start with one
+# local terminal pane. Deleting a workspace asks for confirmation, and the last
 # remaining workspace cannot be deleted. The active workspace selection is saved.
 #
 # Split node  — has `direction` and `children` (no `pane`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,7 @@ Workspace-related endpoints:
 
 - `GET /api/workspaces` returns the workspace list, active workspace ID, tab position, and each workspace layout.
 - `POST /api/workspaces` adds a single-local-pane workspace while edit mode is enabled and makes it active.
+- `PUT /api/workspaces/{id}` renames a workspace while edit mode is enabled.
 - `DELETE /api/workspaces/{id}` removes a workspace while edit mode is enabled, closes that workspace's sessions after persistence succeeds, and refuses to delete the last workspace.
 - `PUT /api/workspaces/active` switches the active workspace and persists the selection.
 - `PUT /api/workspaces/{id}/layout` updates a specific workspace layout.
@@ -129,7 +130,7 @@ Why Vite:
 
 ### `useLayout`
 
-Fetches `/api/workspaces` and `/api/display`, applies runtime validation, tracks the active workspace layout, and persists layout changes back to the active workspace. The tab bar is hidden when only one workspace exists during normal use; edit mode exposes workspace add and delete controls. Delete uses a confirmation dialog before calling the workspace delete API.
+Fetches `/api/workspaces` and `/api/display`, applies runtime validation, tracks the active workspace layout, and persists layout changes back to the active workspace. The tab bar is hidden when only one workspace exists during normal use; edit mode exposes workspace add, inline rename, and delete controls. Delete uses a confirmation dialog before calling the workspace delete API.
 
 Why this hook:
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -26,6 +26,7 @@ const workspaces: WorkspacesResponse = {
 }
 
 const mockDeleteWorkspace = vi.fn()
+const mockRenameWorkspace = vi.fn()
 
 vi.mock('./hooks/useLayout', () => ({
   useLayout: () => ({
@@ -40,6 +41,7 @@ vi.mock('./hooks/useLayout', () => ({
     setActiveWorkspace: vi.fn(),
     addWorkspace: vi.fn(),
     deleteWorkspace: mockDeleteWorkspace,
+    renameWorkspace: mockRenameWorkspace,
   }),
 }))
 
@@ -65,6 +67,7 @@ vi.mock('./hooks/usePaneSettings', () => ({
 describe('App workspace deletion', () => {
   afterEach(() => {
     mockDeleteWorkspace.mockClear()
+    mockRenameWorkspace.mockClear()
     vi.restoreAllMocks()
   })
 
@@ -85,5 +88,15 @@ describe('App workspace deletion', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete Dev workspace' }))
 
     expect(mockDeleteWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('passes workspace rename from edit-mode tabs', () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Dev workspace' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(mockRenameWorkspace).toHaveBeenCalledWith('dev', 'Development')
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import type { SSHConfigHost } from './schemas'
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
 
 export const App: React.FC = () => {
-  const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace } = useLayout()
+  const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace } = useLayout()
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
@@ -110,6 +110,7 @@ export const App: React.FC = () => {
             tabPosition={workspaces.tab_position}
             onSelect={setActiveWorkspace}
             onAdd={editMode ? addWorkspace : undefined}
+            onRename={editMode ? renameWorkspace : undefined}
             onDelete={editMode ? (workspaceId) => {
               const workspace = workspaces.items.find((item) => item.id === workspaceId)
               if (!workspace) return

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -67,6 +67,44 @@ describe('WorkspaceTabs', () => {
     expect(screen.queryByRole('button', { name: 'Delete Dev workspace' })).not.toBeInTheDocument()
   })
 
+  it('renames a workspace inline with Enter', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Dev workspace' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onRename).toHaveBeenCalledWith('dev', 'Development')
+  })
+
+  it('cancels inline rename with Escape', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.doubleClick(screen.getByRole('tab', { name: 'Dev' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByRole('tab', { name: 'Dev' })).toBeInTheDocument()
+  })
+
+  it('does not save a blank inline rename', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Dev workspace' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: '   ' } })
+    fireEvent.blur(input)
+
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByRole('tab', { name: 'Dev' })).toBeInTheDocument()
+  })
+
   it('uses vertical orientation for left and right positions', () => {
     for (const tabPosition of ['left', 'right'] as const) {
       const { unmount } = render(

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -79,6 +79,33 @@ describe('WorkspaceTabs', () => {
     expect(onRename).toHaveBeenCalledWith('dev', 'Development')
   })
 
+  it('saves a valid inline rename on blur', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Dev workspace' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.blur(input)
+
+    expect(onRename).toHaveBeenCalledTimes(1)
+    expect(onRename).toHaveBeenCalledWith('dev', 'Development')
+  })
+
+  it('does not save twice when Enter is followed by blur', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Dev workspace' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.blur(input)
+
+    expect(onRename).toHaveBeenCalledTimes(1)
+    expect(onRename).toHaveBeenCalledWith('dev', 'Development')
+  })
+
   it('cancels inline rename with Escape', () => {
     const onRename = vi.fn()
     render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
@@ -87,6 +114,20 @@ describe('WorkspaceTabs', () => {
     const input = screen.getByLabelText('Workspace name')
     fireEvent.change(input, { target: { value: 'Development' } })
     fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByRole('tab', { name: 'Dev' })).toBeInTheDocument()
+  })
+
+  it('does not save when Escape is followed by blur', () => {
+    const onRename = vi.fn()
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onRename={onRename} />)
+
+    fireEvent.doubleClick(screen.getByRole('tab', { name: 'Dev' }))
+    const input = screen.getByLabelText('Workspace name')
+    fireEvent.change(input, { target: { value: 'Development' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    fireEvent.blur(input)
 
     expect(onRename).not.toHaveBeenCalled()
     expect(screen.getByRole('tab', { name: 'Dev' })).toBeInTheDocument()

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import type { TabPosition, Workspace } from '../types'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
@@ -9,6 +9,7 @@ interface WorkspaceTabsProps {
   onSelect: (workspaceId: string) => void
   onAdd?: () => void
   onDelete?: (workspaceId: string) => void
+  onRename?: (workspaceId: string, title: string) => void
 }
 
 export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
@@ -18,9 +19,40 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   onSelect,
   onAdd,
   onDelete,
+  onRename,
 }) => {
   const vertical = tabPosition === 'left' || tabPosition === 'right'
   const showTabs = workspaces.length > 1
+  const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null)
+  const [draftTitle, setDraftTitle] = useState('')
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (editingWorkspaceId) {
+      inputRef.current?.focus()
+      inputRef.current?.select()
+    }
+  }, [editingWorkspaceId])
+
+  const startRename = (workspace: Workspace) => {
+    if (!onRename) return
+    setEditingWorkspaceId(workspace.id)
+    setDraftTitle(workspace.title)
+  }
+
+  const commitRename = (workspace: Workspace) => {
+    if (editingWorkspaceId !== workspace.id) return
+    const title = draftTitle.trim()
+    setEditingWorkspaceId(null)
+    if (title && title !== workspace.title) {
+      onRename?.(workspace.id, title)
+    }
+  }
+
+  const cancelRename = () => {
+    setEditingWorkspaceId(null)
+  }
+
   return (
     <div
       style={{
@@ -56,6 +88,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
         >
           {workspaces.map((workspace) => {
             const active = workspace.id === activeWorkspaceId
+            const editing = editingWorkspaceId === workspace.id
             return (
               <div
                 key={workspace.id}
@@ -69,32 +102,88 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
                   minWidth: vertical ? '100%' : 96,
                   maxWidth: vertical ? '100%' : 180,
                 }}
-              >
-                <button
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => onSelect(workspace.id)}
-                  title={workspace.title}
-                  style={{
-                    appearance: 'none',
-                    border: 'none',
-                    backgroundColor: 'transparent',
-                    color: active ? '#ffffff' : '#b8beca',
-                    cursor: active ? 'default' : 'pointer',
-                    flex: 1,
-                    fontFamily: TERMINAL_FONT_FAMILY,
-                    fontSize: 13,
-                    height: '100%',
-                    minWidth: 0,
-                    padding: onDelete ? '0 6px 0 12px' : '0 12px',
-                    textAlign: 'left',
-                    whiteSpace: 'nowrap',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                  }}
                 >
-                  {workspace.title}
-                </button>
+                {editing ? (
+                  <input
+                    ref={inputRef}
+                    aria-label="Workspace name"
+                    value={draftTitle}
+                    onChange={(event) => setDraftTitle(event.target.value)}
+                    onBlur={() => commitRename(workspace)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        commitRename(workspace)
+                      } else if (event.key === 'Escape') {
+                        cancelRename()
+                      }
+                    }}
+                    style={{
+                      appearance: 'none',
+                      border: '1px solid #5f6b7a',
+                      borderRadius: 3,
+                      backgroundColor: '#15171a',
+                      color: '#ffffff',
+                      flex: 1,
+                      fontFamily: TERMINAL_FONT_FAMILY,
+                      fontSize: 14,
+                      height: vertical ? 28 : 26,
+                      margin: '0 6px',
+                      minWidth: 0,
+                      padding: '0 6px',
+                    }}
+                  />
+                ) : (
+                  <button
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => onSelect(workspace.id)}
+                    onDoubleClick={() => startRename(workspace)}
+                    title={workspace.title}
+                    style={{
+                      appearance: 'none',
+                      border: 'none',
+                      backgroundColor: 'transparent',
+                      color: active ? '#ffffff' : '#b8beca',
+                      cursor: active ? 'default' : 'pointer',
+                      flex: 1,
+                      fontFamily: TERMINAL_FONT_FAMILY,
+                      fontSize: 13,
+                      height: '100%',
+                      minWidth: 0,
+                      padding: onDelete || onRename ? '0 6px 0 12px' : '0 12px',
+                      textAlign: 'left',
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                    }}
+                  >
+                    {workspace.title}
+                  </button>
+                )}
+                {onRename && !editing && (
+                  <button
+                    type="button"
+                    aria-label={`Rename ${workspace.title} workspace`}
+                    title="Rename workspace"
+                    onClick={() => startRename(workspace)}
+                    style={{
+                      appearance: 'none',
+                      border: 'none',
+                      backgroundColor: 'transparent',
+                      color: active ? '#d7dce5' : '#8f96a3',
+                      cursor: 'pointer',
+                      flex: '0 0 28px',
+                      fontFamily: TERMINAL_FONT_FAMILY,
+                      fontSize: 13,
+                      height: '100%',
+                      lineHeight: vertical ? '38px' : '34px',
+                      padding: 0,
+                      textAlign: 'center',
+                    }}
+                  >
+                    ✎
+                  </button>
+                )}
                 {onDelete && (
                   <button
                     type="button"

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -26,6 +26,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null)
   const [draftTitle, setDraftTitle] = useState('')
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const renameFinalizedRef = useRef(false)
 
   useEffect(() => {
     if (editingWorkspaceId) {
@@ -36,12 +37,15 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
 
   const startRename = (workspace: Workspace) => {
     if (!onRename) return
+    renameFinalizedRef.current = false
     setEditingWorkspaceId(workspace.id)
     setDraftTitle(workspace.title)
   }
 
   const commitRename = (workspace: Workspace) => {
+    if (renameFinalizedRef.current) return
     if (editingWorkspaceId !== workspace.id) return
+    renameFinalizedRef.current = true
     const title = draftTitle.trim()
     setEditingWorkspaceId(null)
     if (title && title !== workspace.title) {
@@ -50,6 +54,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   }
 
   const cancelRename = () => {
+    renameFinalizedRef.current = true
     setEditingWorkspaceId(null)
   }
 
@@ -102,7 +107,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
                   minWidth: vertical ? '100%' : 96,
                   maxWidth: vertical ? '100%' : 180,
                 }}
-                >
+              >
                 {editing ? (
                   <input
                     ref={inputRef}

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -192,6 +192,53 @@ describe('useLayout', () => {
     expect(result.current.workspaces?.items).toHaveLength(2)
   })
 
+  it('renames a workspace and keeps the current layout', async () => {
+    const renamedWorkspaces = {
+      ...validWorkspaces,
+      items: [
+        { ...validWorkspaces.items[0], title: 'Development' },
+        validWorkspaces.items[1],
+      ],
+    }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(renamedWorkspaces) } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    await act(async () => {
+      await result.current.renameWorkspace('dev', 'Development')
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/dev', expect.objectContaining({
+      method: 'PUT',
+      body: JSON.stringify({ title: 'Development' }),
+    }))
+    expect(result.current.workspaces?.items[0].title).toBe('Development')
+    expect(result.current.layout?.children[0].pane?.id).toBe('main')
+  })
+
+  it('sets error when renaming a workspace fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 422 } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    await act(async () => {
+      await result.current.renameWorkspace('dev', '   ')
+    })
+
+    expect(result.current.error).toContain('422')
+    expect(result.current.workspaces?.items[0].title).toBe('Dev')
+  })
+
   it('fetches display config on mount', async () => {
     window.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -94,6 +94,24 @@ export function useLayout() {
     }
   }, [])
 
+  const renameWorkspace = useCallback(async (workspaceID: string, title: string) => {
+    try {
+      setError(null)
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(workspaceID)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+      })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const parsed = WorkspacesResponseSchema.parse(await response.json())
+      setWorkspaces(parsed)
+      const active = parsed.items.find((workspace) => workspace.id === parsed.active) ?? parsed.items[0]
+      setLayout(active.layout)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to rename workspace')
+    }
+  }, [])
+
   const splitPane = useCallback(
     async (targetPaneId: string, direction: 'horizontal' | 'vertical') => {
       if (!layout) return
@@ -177,7 +195,7 @@ export function useLayout() {
     [layout, workspaces?.active],
   )
 
-  return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace }
+  return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace }
 }
 
 function replaceActiveWorkspaceLayout(workspaces: WorkspacesResponse, layout: LayoutNode): WorkspacesResponse {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -67,6 +67,10 @@ type activeWorkspaceRequest struct {
 	ID string `json:"id"`
 }
 
+type workspaceRequest struct {
+	Title string `json:"title"`
+}
+
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
@@ -182,6 +186,36 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, pane := range panesInLayout(workspace.Layout) {
 		_ = h.manager.Remove(pane.ID)
+	}
+	writeJSON(w, h.cfg.WorkspacesView())
+}
+
+// PutWorkspace updates workspace metadata while edit mode is enabled.
+func (h *Handler) PutWorkspace(w http.ResponseWriter, r *http.Request) {
+	if !h.editMode.Load() {
+		http.Error(w, "edit mode required", http.StatusForbidden)
+		return
+	}
+	id := chi.URLParam(r, "id")
+	var req workspaceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "workspace title must not be empty"})
+		return
+	}
+	if !h.cfg.RenameWorkspace(id, title) {
+		http.Error(w, "workspace not found", http.StatusNotFound)
+		return
+	}
+	if err := h.cfg.SaveWorkspaces(); err != nil {
+		http.Error(w, "failed to save workspaces", http.StatusInternalServerError)
+		return
 	}
 	writeJSON(w, h.cfg.WorkspacesView())
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -54,6 +54,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Get("/api/workspaces", h.GetWorkspaces)
 	r.Post("/api/workspaces", h.PostWorkspace)
 	r.Put("/api/workspaces/active", h.PutActiveWorkspace)
+	r.Put("/api/workspaces/{id}", h.PutWorkspace)
 	r.Delete("/api/workspaces/{id}", h.DeleteWorkspace)
 	r.Put("/api/workspaces/{id}/layout", h.PutWorkspaceLayout)
 	r.Get("/api/sessions", h.GetSessions)
@@ -356,6 +357,86 @@ func TestDeleteWorkspace_EditModeOn_RemovesWorkspaceSessionsAndPersists(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, "one", loaded.Workspaces.Active)
 	require.Len(t, loaded.Workspaces.Items, 1)
+}
+
+func TestPutWorkspace_EditModeOff_Returns403(t *testing.T) {
+	r := setupRouter(workspaceTestConfig(), session.NewManager())
+	body := bytes.NewBufferString(`{"title":"Renamed"}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/one", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestPutWorkspace_EditModeOn_RenamesWorkspaceAndPersists(t *testing.T) {
+	cfg, path := loadWorkspaceTestConfigFromFile(t)
+	h := NewHandler(cfg, session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+
+	body := bytes.NewBufferString(`{"title":"Renamed Workspace"}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/one", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var workspaces config.WorkspacesConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&workspaces))
+	assert.Equal(t, "Renamed Workspace", workspaces.Items[0].Title)
+	assert.Equal(t, "Two", workspaces.Items[1].Title)
+	assert.Equal(t, "one", workspaces.Active)
+	assert.Equal(t, "horizontal", cfg.ActiveLayout().Direction)
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed Workspace", loaded.Workspaces.Items[0].Title)
+}
+
+func TestPutWorkspace_InvalidBody_Returns400(t *testing.T) {
+	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/one", bytes.NewBufferString("not json"))
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPutWorkspace_BlankTitle_Returns422(t *testing.T) {
+	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+
+	body := bytes.NewBufferString(`{"title":"   "}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/one", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPutWorkspace_NotFound_Returns404(t *testing.T) {
+	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+
+	body := bytes.NewBufferString(`{"title":"Missing"}`)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/missing", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestPutWorkspaceLayout_UpdatesOnlyTargetWorkspace(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,6 +282,17 @@ func (c *Config) RemoveWorkspace(id string) (WorkspaceConfig, bool) {
 	return WorkspaceConfig{}, false
 }
 
+func (c *Config) RenameWorkspace(id string, title string) bool {
+	c.normalizeWorkspaces()
+	for i := range c.Workspaces.Items {
+		if c.Workspaces.Items[i].ID == id {
+			c.Workspaces.Items[i].Title = title
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Config) nextWorkspaceID(start int) string {
 	seen := make(map[string]bool, len(c.Workspaces.Items))
 	for _, workspace := range c.Workspaces.Items {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,6 +133,17 @@ func TestValidate_WorkspaceIdentityErrors(t *testing.T) {
 			want: "id must not be empty",
 		},
 		{
+			name: "blank workspace title",
+			workspaces: WorkspacesConfig{
+				Active:      "one",
+				TabPosition: "top",
+				Items: []WorkspaceConfig{
+					{ID: "one", Title: "   ", Layout: singlePaneLayout("one-main")},
+				},
+			},
+			want: "title must not be empty",
+		},
+		{
 			name: "duplicate workspace id",
 			workspaces: WorkspacesConfig{
 				Active:      "dup",
@@ -162,6 +173,33 @@ func TestValidate_WorkspaceIdentityErrors(t *testing.T) {
 			assert.Contains(t, strings.Join(errs, "; "), tt.want)
 		})
 	}
+}
+
+func TestRenameWorkspace_UpdatesOnlyTitle(t *testing.T) {
+	cfg := validConfig()
+	cfg.Workspaces = WorkspacesConfig{
+		Active:      "one",
+		TabPosition: "top",
+		Items: []WorkspaceConfig{
+			{ID: "one", Title: "One", Layout: singlePaneLayout("one-main")},
+			{ID: "two", Title: "Two", Layout: singlePaneLayout("two-main")},
+		},
+	}
+	require.True(t, cfg.SetActiveWorkspace("one"))
+
+	require.True(t, cfg.RenameWorkspace("two", "Renamed"))
+
+	assert.Equal(t, "One", cfg.Workspaces.Items[0].Title)
+	assert.Equal(t, "Renamed", cfg.Workspaces.Items[1].Title)
+	assert.Equal(t, "one", cfg.Workspaces.Active)
+	assert.Equal(t, "one-main", cfg.ActiveLayout().Children[0].Pane.ID)
+}
+
+func TestRenameWorkspace_NotFound_ReturnsFalse(t *testing.T) {
+	cfg := validConfig()
+	cfg.normalizeWorkspaces()
+
+	assert.False(t, cfg.RenameWorkspace("missing", "Missing"))
 }
 
 func TestValidate_PaneEmptyID_Error(t *testing.T) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -87,6 +87,9 @@ func validateWorkspaces(workspaces WorkspacesConfig, sshConns map[string]SSHConn
 		if workspace.ID == "" {
 			errs = append(errs, fmt.Sprintf("workspace[%d] id must not be empty", i))
 		}
+		if strings.TrimSpace(workspace.Title) == "" {
+			errs = append(errs, fmt.Sprintf("workspace[%d] title must not be empty", i))
+		}
 		if seenIDs[workspace.ID] {
 			errs = append(errs, fmt.Sprintf("duplicate workspace id: %q", workspace.ID))
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Get("/workspaces", apiHandler.GetWorkspaces)
 		r.Post("/workspaces", apiHandler.PostWorkspace)
 		r.Put("/workspaces/active", apiHandler.PutActiveWorkspace)
+		r.Put("/workspaces/{id}", apiHandler.PutWorkspace)
 		r.Delete("/workspaces/{id}", apiHandler.DeleteWorkspace)
 		r.Put("/workspaces/{id}/layout", apiHandler.PutWorkspaceLayout)
 		r.Get("/sessions", apiHandler.GetSessions)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,6 +23,22 @@ func testConfig() *config.Config {
 			Port: 8080,
 			Host: "127.0.0.1",
 		},
+		Workspaces: config.WorkspacesConfig{
+			Active:      "default",
+			TabPosition: "top",
+			Items: []config.WorkspaceConfig{
+				{
+					ID:    "default",
+					Title: "Default",
+					Layout: config.LayoutNode{
+						Direction: "horizontal",
+						Children: []config.LayoutChild{
+							{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -98,4 +114,25 @@ func TestServer_APIRoutesWired(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/layout", nil)
 	srv.httpSrv.Handler.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
+	cfg := testConfig()
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, emptyFS)
+	require.NotNil(t, srv)
+
+	editRec := httptest.NewRecorder()
+	editReq := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewBufferString(`{"editMode":true}`))
+	editReq.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(editRec, editReq)
+	require.Equal(t, http.StatusOK, editRec.Code)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/default", bytes.NewBufferString(`{"title":"Renamed"}`))
+	req.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "Renamed", cfg.Workspaces.Items[0].Title)
 }


### PR DESCRIPTION
## Summary
- Add an edit-mode workspace rename API that updates only workspace titles and persists them.
- Add inline workspace tab renaming in the frontend with Enter/blur save and Escape cancel.
- Document rename support for workspace tabs.

## Test plan
- [x] make install-deps-ci
- [x] make build-frontend
- [x] make test-go
- [x] make test-frontend
- [x] make lint-go
- [x] make lint-frontend