### PR TITLE
feat: allow workspace tab position changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ workspaces:
 
 Older config files with a top-level `layout:` are still accepted. When the config is next saved, panemux migrates that layout into a `default` workspace and writes the `workspaces:` format.
 
-If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add control; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab can be renamed inline and has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace is persisted so the same workspace is restored after restart.
+If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add and tab-position controls; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab can be renamed inline and has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace and changing `tab_position` are persisted so the same workspace and tab placement are restored after restart.
 
 ### Pane types
 
@@ -150,7 +150,7 @@ Authentication is attempted in order: configured `key_file` → configured `pass
 
 Click the lock icon in the bottom-right corner to toggle **edit mode**.
 
-- **ON** — layout changes are persisted to the config file; terminal input is blocked and a visual overlay shows which panes are locked; drag any pane by its body (not just the header) to reorder it
+- **ON** — layout changes and workspace tab placement are persisted to the config file; terminal input is blocked and a visual overlay shows which panes are locked; drag any pane by its body (not just the header) to reorder it
 - **OFF** — terminal is fully interactive; drag-resize and close are applied in-memory only
 
 ---

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,9 +49,10 @@ ssh_connections:
 # `workspaces:` format.
 #
 # The tab bar is hidden during normal use when only one workspace exists. Turn on
-# edit mode to add, rename, or delete workspaces. New workspaces start with one
-# local terminal pane. Deleting a workspace asks for confirmation, and the last
-# remaining workspace cannot be deleted. The active workspace selection is saved.
+# edit mode to add, rename, delete, or move workspace tabs. New workspaces start
+# with one local terminal pane. Deleting a workspace asks for confirmation, and
+# the last remaining workspace cannot be deleted. The active workspace selection
+# and tab_position are saved.
 #
 # Split node  — has `direction` and `children` (no `pane`)
 # Leaf node   — has `pane` (no `direction` / `children`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,6 +71,7 @@ Workspace-related endpoints:
 
 - `GET /api/workspaces` returns the workspace list, active workspace ID, tab position, and each workspace layout.
 - `POST /api/workspaces` adds a single-local-pane workspace while edit mode is enabled and makes it active.
+- `PUT /api/workspaces/tab-position` changes `workspaces.tab_position` while edit mode is enabled and persists it.
 - `PUT /api/workspaces/{id}` renames a workspace while edit mode is enabled.
 - `DELETE /api/workspaces/{id}` removes a workspace while edit mode is enabled, closes that workspace's sessions after persistence succeeds, and refuses to delete the last workspace.
 - `PUT /api/workspaces/active` switches the active workspace and persists the selection.
@@ -130,7 +131,7 @@ Why Vite:
 
 ### `useLayout`
 
-Fetches `/api/workspaces` and `/api/display`, applies runtime validation, tracks the active workspace layout, and persists layout changes back to the active workspace. The tab bar is hidden when only one workspace exists during normal use; edit mode exposes workspace add, inline rename, and delete controls. Delete uses a confirmation dialog before calling the workspace delete API.
+Fetches `/api/workspaces` and `/api/display`, applies runtime validation, tracks the active workspace layout, and persists layout changes back to the active workspace. The tab bar is hidden when only one workspace exists during normal use; edit mode exposes workspace add, inline rename, delete, and tab-position controls. Delete uses a confirmation dialog before calling the workspace delete API.
 
 Why this hook:
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -101,7 +101,8 @@ Host-key verification uses `known_hosts_file` if configured, or `~/.ssh/known_ho
 Persistence behavior:
 
 - `PUT /api/layout` updates in-memory layout always
-- file persistence happens only when edit mode is ON (`PUT /api/edit-mode {"editMode":true}`)
+- workspace tab placement changes require edit mode and are persisted immediately
+- layout file persistence happens only when edit mode is ON (`PUT /api/edit-mode {"editMode":true}`)
 - when no `--config` is given, the default save path is `~/.config/panemux/config.yaml`; the directory is created automatically on first save
 
 ## REST API
@@ -117,6 +118,20 @@ Accepts a layout JSON document, validates it, updates in-memory state, and persi
 - `400`: invalid JSON
 - `422`: structurally invalid layout
 - `200`: accepted and returned
+
+### `GET /api/workspaces`
+
+Returns the active workspace ID, `tab_position`, and all workspace layouts.
+
+### `PUT /api/workspaces/tab-position`
+
+Accepts `{ "tab_position": "top" | "bottom" | "left" | "right" }`, validates it, persists the workspace config, and returns the updated workspace response. Edit mode must be enabled.
+
+- `400`: invalid JSON
+- `403`: edit mode is off
+- `422`: invalid tab position
+- `500`: unable to save the config
+- `200`: updated and returned
 
 ### `GET /api/sessions`
 
@@ -263,6 +278,7 @@ Edit mode is toggled by the fixed button in the bottom-right corner. When edit m
 - The entire pane body becomes a drag surface; the user can drag any pane onto any other pane to swap their positions in the layout tree.
 - Terminal keyboard input is blocked — `onData` and `onBinary` handlers do not forward bytes to the session while edit mode is active.
 - A semi-transparent overlay covers each terminal area and intercepts pointer events, preventing the terminal from gaining focus.
+- Workspace controls can add, rename, delete, and move the tab bar to the top, bottom, left, or right.
 - Layout changes (including drag-resize) are persisted to the config file via `PUT /api/layout`.
 
 When edit mode is OFF, terminal input is fully restored and layout changes are applied in-memory only.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -55,6 +55,8 @@ The terminal overlay is a `position: absolute` layer over the xterm.js canvas. I
 
 The inset `box-shadow` border marks every pane as part of an "edit zone" without affecting layout geometry. Using `box-shadow` rather than `border` or `outline` keeps the frame cosmetic and avoids shifting sibling sizes.
 
+Workspace tab position controls are also shown only in edit mode. They use four compact directional buttons for top, bottom, left, and right placement, with `aria-pressed` marking the current position. This keeps persistent layout-level changes grouped with the rest of the editing surface while avoiding extra text in the tab bar.
+
 ---
 
 ## Drag and Drop

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -27,6 +27,7 @@ const workspaces: WorkspacesResponse = {
 
 const mockDeleteWorkspace = vi.fn()
 const mockRenameWorkspace = vi.fn()
+const mockSetWorkspaceTabPosition = vi.fn()
 
 vi.mock('./hooks/useLayout', () => ({
   useLayout: () => ({
@@ -42,6 +43,7 @@ vi.mock('./hooks/useLayout', () => ({
     addWorkspace: vi.fn(),
     deleteWorkspace: mockDeleteWorkspace,
     renameWorkspace: mockRenameWorkspace,
+    setWorkspaceTabPosition: mockSetWorkspaceTabPosition,
   }),
 }))
 
@@ -68,6 +70,7 @@ describe('App workspace deletion', () => {
   afterEach(() => {
     mockDeleteWorkspace.mockClear()
     mockRenameWorkspace.mockClear()
+    mockSetWorkspaceTabPosition.mockClear()
     vi.restoreAllMocks()
   })
 
@@ -98,5 +101,12 @@ describe('App workspace deletion', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(mockRenameWorkspace).toHaveBeenCalledWith('dev', 'Development')
+  })
+
+  it('passes workspace tab position changes from edit-mode tabs', () => {
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Place workspace tabs on right' }))
+
+    expect(mockSetWorkspaceTabPosition).toHaveBeenCalledWith('right')
   })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,7 +15,7 @@ import type { SSHConfigHost } from './schemas'
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
 
 export const App: React.FC = () => {
-  const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace } = useLayout()
+  const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition } = useLayout()
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
@@ -111,6 +111,7 @@ export const App: React.FC = () => {
             onSelect={setActiveWorkspace}
             onAdd={editMode ? addWorkspace : undefined}
             onRename={editMode ? renameWorkspace : undefined}
+            onTabPositionChange={editMode ? setWorkspaceTabPosition : undefined}
             onDelete={editMode ? (workspaceId) => {
               const workspace = workspaces.items.find((item) => item.id === workspaceId)
               if (!workspace) return

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -53,6 +53,30 @@ describe('WorkspaceTabs', () => {
     expect(onAdd).toHaveBeenCalled()
   })
 
+  it('renders tab position controls when a position change handler is provided', () => {
+    const onTabPositionChange = vi.fn()
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        onSelect={() => {}}
+        onTabPositionChange={onTabPositionChange}
+      />,
+    )
+
+    expect(screen.getByRole('group', { name: 'Workspace tab position' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Place workspace tabs at top' })).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(screen.getByRole('button', { name: 'Place workspace tabs on left' }))
+    expect(onTabPositionChange).toHaveBeenCalledWith('left')
+  })
+
+  it('hides tab position controls when the position change handler is omitted', () => {
+    render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} />)
+
+    expect(screen.queryByRole('group', { name: 'Workspace tab position' })).not.toBeInTheDocument()
+  })
+
   it('renders delete controls when delete handler is provided', () => {
     const onDelete = vi.fn()
     render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} onDelete={onDelete} />)

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -10,6 +10,7 @@ interface WorkspaceTabsProps {
   onAdd?: () => void
   onDelete?: (workspaceId: string) => void
   onRename?: (workspaceId: string, title: string) => void
+  onTabPositionChange?: (position: TabPosition) => void
 }
 
 export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
@@ -20,6 +21,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   onAdd,
   onDelete,
   onRename,
+  onTabPositionChange,
 }) => {
   const vertical = tabPosition === 'left' || tabPosition === 'right'
   const showTabs = workspaces.length > 1
@@ -57,6 +59,57 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     renameFinalizedRef.current = true
     setEditingWorkspaceId(null)
   }
+
+  const positionControls = onTabPositionChange ? (
+    <div
+      role="group"
+      aria-label="Workspace tab position"
+      style={{
+        display: 'flex',
+        flexDirection: vertical ? 'column' : 'row',
+        borderLeft: !vertical ? '1px solid #333842' : undefined,
+        borderTop: vertical ? '1px solid #333842' : undefined,
+        flexShrink: 0,
+      }}
+    >
+      {([
+        ['top', '▲', 'Place workspace tabs at top'],
+        ['bottom', '▼', 'Place workspace tabs at bottom'],
+        ['left', '◀', 'Place workspace tabs on left'],
+        ['right', '▶', 'Place workspace tabs on right'],
+      ] as const).map(([position, label, ariaLabel]) => {
+        const selected = tabPosition === position
+        return (
+          <button
+            key={position}
+            type="button"
+            aria-label={ariaLabel}
+            aria-pressed={selected}
+            title={ariaLabel}
+            onClick={() => onTabPositionChange(position)}
+            style={{
+              appearance: 'none',
+              border: 'none',
+              borderRight: !vertical ? '1px solid #333842' : undefined,
+              borderBottom: vertical ? '1px solid #333842' : undefined,
+              backgroundColor: selected ? '#3a4350' : 'transparent',
+              color: selected ? '#ffffff' : '#b8beca',
+              cursor: selected ? 'default' : 'pointer',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: 12,
+              height: vertical ? 30 : 34,
+              lineHeight: vertical ? '30px' : '34px',
+              minWidth: vertical ? '100%' : 34,
+              padding: 0,
+              textAlign: 'center',
+            }}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  ) : null
 
   return (
     <div
@@ -244,6 +297,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
           +
         </button>
       )}
+      {positionControls}
     </div>
   )
 }

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -262,6 +262,33 @@ describe('useLayout', () => {
     expect(result.current.layout?.children[0].pane?.id).toBe('main')
   })
 
+  it('adopts server top-level workspace fields while preserving current items when updating tab position', async () => {
+    const updatedWorkspaces = {
+      ...validWorkspaces,
+      active: 'ops',
+      tab_position: 'right' as const,
+      items: validWorkspaces.items.map((workspace) => (
+        workspace.id === 'dev' ? { ...workspace, title: 'Server Dev' } : workspace
+      )),
+    }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkspaces) } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    await act(async () => {
+      await result.current.setWorkspaceTabPosition('right')
+    })
+
+    expect(result.current.workspaces?.active).toBe('ops')
+    expect(result.current.workspaces?.tab_position).toBe('right')
+    expect(result.current.workspaces?.items[0].title).toBe('Dev')
+  })
+
   it('preserves a pending local layout change when updating workspace tab position', async () => {
     const pendingLayout: LayoutNode = {
       direction: 'vertical',

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -239,6 +239,111 @@ describe('useLayout', () => {
     expect(result.current.workspaces?.items[0].title).toBe('Dev')
   })
 
+  it('updates workspace tab position from the returned response', async () => {
+    const updatedWorkspaces = { ...validWorkspaces, tab_position: 'left' as const }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkspaces) } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    await act(async () => {
+      await result.current.setWorkspaceTabPosition('left')
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/tab-position', expect.objectContaining({
+      method: 'PUT',
+      body: JSON.stringify({ tab_position: 'left' }),
+    }))
+    expect(result.current.workspaces?.tab_position).toBe('left')
+    expect(result.current.layout?.children[0].pane?.id).toBe('main')
+  })
+
+  it('preserves a pending local layout change when updating workspace tab position', async () => {
+    const pendingLayout: LayoutNode = {
+      direction: 'vertical',
+      children: [{ size: 100, pane: { id: 'pending-main', type: 'local' } }],
+    }
+    const staleServerWorkspaces = { ...validWorkspaces, tab_position: 'left' as const }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(staleServerWorkspaces) } as Response)
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    vi.useFakeTimers()
+    try {
+      act(() => {
+        result.current.updateSizes(pendingLayout)
+      })
+
+      expect(result.current.layout?.children[0].pane?.id).toBe('pending-main')
+
+      await act(async () => {
+        await result.current.setWorkspaceTabPosition('left')
+      })
+
+      expect(result.current.workspaces?.tab_position).toBe('left')
+      expect(result.current.layout?.children[0].pane?.id).toBe('pending-main')
+      expect(result.current.workspaces?.items[0].layout.children[0].pane?.id).toBe('pending-main')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('accepts a tab position response before workspace state has loaded', async () => {
+    const updatedWorkspaces = { ...validWorkspaces, tab_position: 'left' as const }
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === '/api/workspaces' && init?.method === undefined) {
+        return new Promise<Response>(() => {})
+      }
+      if (url === '/api/display') {
+        return Promise.resolve({ ok: false } as Response)
+      }
+      if (url === '/api/workspaces/tab-position') {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(updatedWorkspaces) } as Response)
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`))
+    })
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    expect(result.current.workspaces).toBeNull()
+
+    await act(async () => {
+      await result.current.setWorkspaceTabPosition('left')
+    })
+
+    expect(result.current.workspaces?.tab_position).toBe('left')
+    expect(result.current.layout).toBeNull()
+  })
+
+  it('sets error when updating workspace tab position fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 422 } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    await act(async () => {
+      await result.current.setWorkspaceTabPosition('left')
+    })
+
+    expect(result.current.error).toContain('422')
+    expect(result.current.workspaces?.tab_position).toBe('top')
+  })
+
   it('fetches display config on mount', async () => {
     window.fetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -123,7 +123,7 @@ export function useLayout() {
       })
       if (!response.ok) throw new Error(`HTTP ${response.status}`)
       const parsed = WorkspacesResponseSchema.parse(await response.json())
-      setWorkspaces((current) => current ? { ...current, tab_position: parsed.tab_position } : parsed)
+      setWorkspaces((current) => current ? { ...parsed, items: current.items } : parsed)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to update workspace tab position')
     }

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { DetectShellResponseSchema, DisplayConfig, DisplayConfigSchema, LayoutNode, PaneConfig, WorkspacesResponse, WorkspacesResponseSchema } from '../schemas'
+import { DetectShellResponseSchema, DisplayConfig, DisplayConfigSchema, LayoutNode, PaneConfig, TabPosition, WorkspacesResponse, WorkspacesResponseSchema, WorkspaceTabPositionRequestSchema } from '../schemas'
 import { findPaneById, generatePaneId, generateTmuxSessionName, removePaneFromTree, splitPaneInTree, swapPanesInTree } from '../utils/layoutTree'
 
 export function useLayout() {
@@ -112,6 +112,23 @@ export function useLayout() {
     }
   }, [])
 
+  const setWorkspaceTabPosition = useCallback(async (position: TabPosition) => {
+    try {
+      setError(null)
+      const request = WorkspaceTabPositionRequestSchema.parse({ tab_position: position })
+      const response = await fetch('/api/workspaces/tab-position', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const parsed = WorkspacesResponseSchema.parse(await response.json())
+      setWorkspaces((current) => current ? { ...current, tab_position: parsed.tab_position } : parsed)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update workspace tab position')
+    }
+  }, [])
+
   const splitPane = useCallback(
     async (targetPaneId: string, direction: 'horizontal' | 'vertical') => {
       if (!layout) return
@@ -195,7 +212,7 @@ export function useLayout() {
     [layout, workspaces?.active],
   )
 
-  return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace }
+  return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition }
 }
 
 function replaceActiveWorkspaceLayout(workspaces: WorkspacesResponse, layout: LayoutNode): WorkspacesResponse {

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -9,6 +9,7 @@ import {
   SSHConfigHostSchema,
   SSHConfigHostsResponseSchema,
   DetectShellResponseSchema,
+  WorkspaceTabPositionRequestSchema,
   WorkspacesResponseSchema,
 } from './index'
 
@@ -182,6 +183,20 @@ describe('WorkspacesResponseSchema', () => {
         },
       ],
     }).success).toBe(false)
+  })
+})
+
+describe('WorkspaceTabPositionRequestSchema', () => {
+  it('accepts every tab position', () => {
+    for (const tabPosition of ['top', 'bottom', 'left', 'right']) {
+      const result = WorkspaceTabPositionRequestSchema.safeParse({ tab_position: tabPosition })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid or missing tab position', () => {
+    expect(WorkspaceTabPositionRequestSchema.safeParse({ tab_position: 'diagonal' }).success).toBe(false)
+    expect(WorkspaceTabPositionRequestSchema.safeParse({}).success).toBe(false)
   })
 })
 

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -52,6 +52,12 @@ export const TabPositionSchema = z.enum(['top', 'bottom', 'left', 'right'])
 
 export type TabPosition = z.infer<typeof TabPositionSchema>
 
+export const WorkspaceTabPositionRequestSchema = z.object({
+  tab_position: TabPositionSchema,
+})
+
+export type WorkspaceTabPositionRequest = z.infer<typeof WorkspaceTabPositionRequestSchema>
+
 export const WorkspaceSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -71,6 +71,10 @@ type workspaceRequest struct {
 	Title string `json:"title"`
 }
 
+type workspaceTabPositionRequest struct {
+	TabPosition string `json:"tab_position"`
+}
+
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
@@ -130,6 +134,30 @@ func (h *Handler) PutActiveWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	if !h.cfg.SetActiveWorkspace(req.ID) {
 		http.Error(w, "workspace not found", http.StatusNotFound)
+		return
+	}
+	if err := h.cfg.SaveWorkspaces(); err != nil {
+		http.Error(w, "failed to save workspaces", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, h.cfg.WorkspacesView())
+}
+
+// PutWorkspaceTabPosition updates workspace tab placement while edit mode is enabled.
+func (h *Handler) PutWorkspaceTabPosition(w http.ResponseWriter, r *http.Request) {
+	if !h.editMode.Load() {
+		http.Error(w, "edit mode required", http.StatusForbidden)
+		return
+	}
+	var req workspaceTabPositionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if err := h.cfg.SetWorkspaceTabPosition(req.TabPosition); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 		return
 	}
 	if err := h.cfg.SaveWorkspaces(); err != nil {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -54,6 +54,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Get("/api/workspaces", h.GetWorkspaces)
 	r.Post("/api/workspaces", h.PostWorkspace)
 	r.Put("/api/workspaces/active", h.PutActiveWorkspace)
+	r.Put("/api/workspaces/tab-position", h.PutWorkspaceTabPosition)
 	r.Put("/api/workspaces/{id}", h.PutWorkspace)
 	r.Delete("/api/workspaces/{id}", h.DeleteWorkspace)
 	r.Put("/api/workspaces/{id}/layout", h.PutWorkspaceLayout)
@@ -241,6 +242,82 @@ func TestPutActiveWorkspace_NotFound_Returns404AndKeepsActive(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Equal(t, "one", cfg.Workspaces.Active)
+}
+
+func TestPutWorkspaceTabPosition_EditModeOff_Returns403(t *testing.T) {
+	cfg := workspaceTestConfig()
+	r := setupRouter(cfg, session.NewManager())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/workspaces/tab-position",
+		bytes.NewBufferString(`{"tab_position":"left"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "top", cfg.Workspaces.TabPosition)
+}
+
+func TestPutWorkspaceTabPosition_EditModeOn_UpdatesEveryValidPositionAndPersists(t *testing.T) {
+	for _, position := range []string{"top", "bottom", "left", "right"} {
+		t.Run(position, func(t *testing.T) {
+			cfg, path := loadWorkspaceTestConfigFromFile(t)
+			h := NewHandler(cfg, session.NewManager())
+			h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+			h.editMode.Store(true)
+			r := setupRouterWithHandler(h)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(
+				http.MethodPut,
+				"/api/workspaces/tab-position",
+				bytes.NewBufferString(`{"tab_position":"`+position+`"}`),
+			)
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			var workspaces config.WorkspacesConfig
+			require.NoError(t, json.NewDecoder(rec.Body).Decode(&workspaces))
+			assert.Equal(t, position, workspaces.TabPosition)
+
+			loaded, err := config.Load(path)
+			require.NoError(t, err)
+			assert.Equal(t, position, loaded.Workspaces.TabPosition)
+		})
+	}
+}
+
+func TestPutWorkspaceTabPosition_InvalidBody_Returns400(t *testing.T) {
+	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/tab-position", bytes.NewBufferString("not json"))
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPutWorkspaceTabPosition_InvalidPosition_Returns422AndKeepsExistingValue(t *testing.T) {
+	cfg := workspaceTestConfig()
+	h := NewHandler(cfg, session.NewManager())
+	h.editMode.Store(true)
+	r := setupRouterWithHandler(h)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/workspaces/tab-position",
+		bytes.NewBufferString(`{"tab_position":"diagonal"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Equal(t, "top", cfg.Workspaces.TabPosition)
+	assert.Contains(t, rec.Body.String(), "invalid tab_position")
 }
 
 func TestPostWorkspace_EditModeOff_Returns403(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -293,6 +293,15 @@ func (c *Config) RenameWorkspace(id string, title string) bool {
 	return false
 }
 
+func (c *Config) SetWorkspaceTabPosition(position string) error {
+	if err := ValidateWorkspaceTabPosition(position); err != nil {
+		return err
+	}
+	c.normalizeWorkspaces()
+	c.Workspaces.TabPosition = position
+	return nil
+}
+
 func (c *Config) nextWorkspaceID(start int) string {
 	seen := make(map[string]bool, len(c.Workspaces.Items))
 	for _, workspace := range c.Workspaces.Items {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -202,6 +202,28 @@ func TestRenameWorkspace_NotFound_ReturnsFalse(t *testing.T) {
 	assert.False(t, cfg.RenameWorkspace("missing", "Missing"))
 }
 
+func TestSetWorkspaceTabPosition_AllValidPositions(t *testing.T) {
+	for _, position := range []string{"top", "bottom", "left", "right"} {
+		t.Run(position, func(t *testing.T) {
+			cfg := validConfig()
+			require.NoError(t, cfg.SetWorkspaceTabPosition(position))
+
+			assert.Equal(t, position, cfg.Workspaces.TabPosition)
+		})
+	}
+}
+
+func TestSetWorkspaceTabPosition_InvalidPositionKeepsExistingValue(t *testing.T) {
+	cfg := validConfig()
+	require.NoError(t, cfg.SetWorkspaceTabPosition("left"))
+
+	err := cfg.SetWorkspaceTabPosition("diagonal")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tab_position")
+	assert.Equal(t, "left", cfg.Workspaces.TabPosition)
+}
+
 func TestValidate_PaneEmptyID_Error(t *testing.T) {
 	cfg := validConfig()
 	cfg.Layout.Children[0].Pane.ID = ""

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -18,6 +18,10 @@ const (
 	paneTypeSSH         = "ssh"
 	paneTypeTmux        = "tmux"
 	paneTypeSSHTmux     = "ssh_tmux"
+	tabPositionTop      = "top"
+	tabPositionBottom   = "bottom"
+	tabPositionLeft     = "left"
+	tabPositionRight    = "right"
 )
 
 // Validate checks the configuration for correctness.
@@ -65,16 +69,10 @@ func (c *Config) Validate() error {
 
 func validateWorkspaces(workspaces WorkspacesConfig, sshConns map[string]SSHConnection) []string {
 	var errs []string
-	if workspaces.TabPosition != "" &&
-		workspaces.TabPosition != "top" &&
-		workspaces.TabPosition != "bottom" &&
-		workspaces.TabPosition != "left" &&
-		workspaces.TabPosition != "right" {
-
-		errs = append(
-			errs,
-			fmt.Sprintf("invalid tab_position %q: must be top, bottom, left, or right", workspaces.TabPosition),
-		)
+	if workspaces.TabPosition != "" {
+		if err := ValidateWorkspaceTabPosition(workspaces.TabPosition); err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 	if len(workspaces.Items) == 0 {
 		errs = append(errs, "workspaces.items must not be empty")
@@ -103,6 +101,16 @@ func validateWorkspaces(workspaces WorkspacesConfig, sshConns map[string]SSHConn
 		errs = append(errs, fmt.Sprintf("active workspace %q is not defined", workspaces.Active))
 	}
 	return errs
+}
+
+// ValidateWorkspaceTabPosition validates the workspace tab bar placement.
+func ValidateWorkspaceTabPosition(position string) error {
+	switch position {
+	case tabPositionTop, tabPositionBottom, tabPositionLeft, tabPositionRight:
+		return nil
+	default:
+		return fmt.Errorf("invalid tab_position %q: must be top, bottom, left, or right", position)
+	}
 }
 
 // ValidatePane validates a standalone PaneConfig without ssh_connections context.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Get("/workspaces", apiHandler.GetWorkspaces)
 		r.Post("/workspaces", apiHandler.PostWorkspace)
 		r.Put("/workspaces/active", apiHandler.PutActiveWorkspace)
+		r.Put("/workspaces/tab-position", apiHandler.PutWorkspaceTabPosition)
 		r.Put("/workspaces/{id}", apiHandler.PutWorkspace)
 		r.Delete("/workspaces/{id}", apiHandler.DeleteWorkspace)
 		r.Put("/workspaces/{id}/layout", apiHandler.PutWorkspaceLayout)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -136,3 +136,29 @@ func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "Renamed", cfg.Workspaces.Items[0].Title)
 }
+
+func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
+	cfg := testConfig()
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, emptyFS)
+	require.NotNil(t, srv)
+
+	editRec := httptest.NewRecorder()
+	editReq := httptest.NewRequest(http.MethodPut, "/api/edit-mode", bytes.NewBufferString(`{"editMode":true}`))
+	editReq.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(editRec, editReq)
+	require.Equal(t, http.StatusOK, editRec.Code)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/api/workspaces/tab-position",
+		bytes.NewBufferString(`{"tab_position":"right"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "right", cfg.Workspaces.TabPosition)
+	assert.Equal(t, "Default", cfg.Workspaces.Items[0].Title)
+}


### PR DESCRIPTION
## Summary
- add a tab-position update API for workspace tabs
- add edit-mode controls to move workspace tabs top, bottom, left, or right
- preserve pending local layout changes when changing tab position
- update docs and examples

## Test plan
- [x] make check
- [x] GOCACHE=/tmp/panemux-go-build-cache make build-backend

## Notes
- Full make build was not used as the final verification because its repeated test phase hit sandbox-only environment constraints after make check had already passed; backend build was verified separately.