### PR TITLE
feat: add agent attention notifications

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -105,6 +105,22 @@ Persistence behavior:
 - layout file persistence happens only when edit mode is ON (`PUT /api/edit-mode {"editMode":true}`)
 - when no `--config` is given, the default save path is `~/.config/panemux/config.yaml`; the directory is created automatically on first save
 
+## Agent Attention Notifications
+
+The frontend watches terminal output for conservative agent confirmation prompts such as approval,
+permission, or proceed requests. Detection runs on the rendered terminal connection so the bytes used
+for detection are also written to the terminal buffer. When a prompt is detected:
+
+- the pane frame flashes until the pane receives focus or a click
+- the containing workspace tab flashes when that workspace is not active, and clears when selected
+- the browser Notification API is used when available; if permission has not been decided, the
+  browser may prompt before showing OS-level notifications
+
+Attention detection is frontend-only and only runs while the pane is rendered in the browser app.
+Inactive workspace panes are not watched by a separate background reader, because each WebSocket
+connection consumes directly from the session stream. It does not persist missed prompts across
+workspace switches, browser reloads, or closed browser windows.
+
 ## REST API
 
 ### `GET /api/layout`

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,15 +1,22 @@
+import { useContext } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { App } from './App'
+import { LayoutActionsContext } from './components/SplitContainer'
 import type { LayoutNode, WorkspacesResponse } from './schemas'
 
+const mockTerminalPane = vi.hoisted(() => vi.fn(({ pane }: { pane: { id: string } }) => <div data-pane-id={pane.id} />))
+
 vi.mock('./components/TerminalPane', () => ({
-  TerminalPane: ({ pane }: { pane: { id: string } }) => <div data-pane-id={pane.id} />,
+  TerminalPane: mockTerminalPane,
 }))
 
 const layout: LayoutNode = {
   direction: 'horizontal',
-  children: [{ size: 100, pane: { id: 'main', type: 'local' } }],
+  children: [
+    { size: 50, pane: { id: 'main', type: 'local' } },
+    { size: 50, pane: { id: 'side', type: 'local' } },
+  ],
 }
 
 const workspaces: WorkspacesResponse = {
@@ -25,6 +32,8 @@ const workspaces: WorkspacesResponse = {
   ],
 }
 
+let currentWorkspaces = workspaces
+
 const mockDeleteWorkspace = vi.fn()
 const mockRenameWorkspace = vi.fn()
 const mockSetWorkspaceTabPosition = vi.fn()
@@ -32,7 +41,7 @@ const mockSetWorkspaceTabPosition = vi.fn()
 vi.mock('./hooks/useLayout', () => ({
   useLayout: () => ({
     layout,
-    workspaces,
+    workspaces: currentWorkspaces,
     displayConfig: { show_header: false, show_status_bar: false },
     error: null,
     updateSizes: vi.fn(),
@@ -71,7 +80,54 @@ describe('App workspace deletion', () => {
     mockDeleteWorkspace.mockClear()
     mockRenameWorkspace.mockClear()
     mockSetWorkspaceTabPosition.mockClear()
+    mockTerminalPane.mockClear()
+    currentWorkspaces = workspaces
     vi.restoreAllMocks()
+  })
+
+
+  it('does not mount inactive workspace panes or background readers that would consume hidden output', () => {
+    render(<App />)
+
+    expect(mockTerminalPane).toHaveBeenCalledWith(
+      expect.objectContaining({ pane: expect.objectContaining({ id: 'main' }) }),
+      expect.anything(),
+    )
+    expect(mockTerminalPane).not.toHaveBeenCalledWith(
+      expect.objectContaining({ pane: expect.objectContaining({ id: 'ops-main' }) }),
+      expect.anything(),
+    )
+  })
+
+  it('keeps workspace attention while another pane in that workspace still needs attention', () => {
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
+      const ctx = useContext(LayoutActionsContext)
+      return (
+        <div data-pane-id={pane.id} data-attention={ctx?.hasPaneAttention(pane.id) ? 'true' : undefined}>
+          <button onClick={() => ctx?.onPaneAttention(pane.id)}>Notify {pane.id}</button>
+          <button onClick={() => ctx?.clearPaneAttention(pane.id)}>Clear {pane.id}</button>
+        </div>
+      )
+    })
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Notify main' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Notify side' }))
+
+    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
+    expect(screen.getByText('Notify main').closest('[data-pane-id="main"]')).toHaveAttribute('data-attention', 'true')
+    expect(screen.getByText('Notify side').closest('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear main' }))
+
+    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
+    expect(screen.getByText('Notify main').closest('[data-pane-id="main"]')).not.toHaveAttribute('data-attention')
+    expect(screen.getByText('Notify side').closest('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear side' }))
+
+    expect(screen.getByRole('tab', { name: 'Dev' })).not.toHaveAttribute('data-attention')
   })
 
   it('confirms before deleting a workspace from edit-mode tabs', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
 import { EditModeToggle } from './components/EditModeToggle'
 import { PaneSettingsDialog } from './components/PaneSettingsDialog'
@@ -9,7 +9,7 @@ import { useEditMode } from './hooks/useEditMode'
 import { usePaneSettings } from './hooks/usePaneSettings'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
-import { findPaneById } from './utils/layoutTree'
+import { findPaneById, layoutContainsPane } from './utils/layoutTree'
 import type { SSHConfigHost } from './schemas'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
@@ -19,12 +19,69 @@ export const App: React.FC = () => {
   const { editMode, toggleEditMode } = useEditMode()
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
+  const [attentionPaneIds, setAttentionPaneIds] = useState<Set<string>>(() => new Set())
   const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell } =
     usePaneSettings(layout, updateSizes)
 
   const [isAddSSHHostOpen, setIsAddSSHHostOpen] = useState(false)
   const [addSSHHostError, setAddSSHHostError] = useState<string | null>(null)
   const [isAddSSHHostSaving, setIsAddSSHHostSaving] = useState(false)
+
+  const findWorkspaceForPane = useCallback((paneId: string) => {
+    return workspaces?.items.find((workspace) => layoutContainsPane(workspace.layout, paneId)) ?? null
+  }, [workspaces])
+
+  const attentionWorkspaceIds = useMemo(() => {
+    const workspaceIds = new Set<string>()
+    if (!workspaces) return workspaceIds
+
+    for (const paneId of attentionPaneIds) {
+      const workspace = workspaces.items.find((item) => layoutContainsPane(item.layout, paneId))
+      if (workspace) workspaceIds.add(workspace.id)
+    }
+
+    return workspaceIds
+  }, [attentionPaneIds, workspaces])
+
+  const clearWorkspaceAttention = useCallback((workspaceId: string) => {
+    const workspace = workspaces?.items.find((item) => item.id === workspaceId)
+    if (!workspace) return
+
+    setAttentionPaneIds((current) => {
+      const next = new Set<string>()
+      let removed = false
+      for (const paneId of current) {
+        if (layoutContainsPane(workspace.layout, paneId)) {
+          removed = true
+        } else {
+          next.add(paneId)
+        }
+      }
+      return removed ? next : current
+    })
+  }, [workspaces])
+
+  const clearPaneAttention = useCallback((paneId: string) => {
+    setAttentionPaneIds((current) => {
+      if (!current.has(paneId)) return current
+      const next = new Set(current)
+      next.delete(paneId)
+      return next
+    })
+  }, [])
+
+  const notifyAttention = useCallback((paneId: string) => {
+    const workspace = findWorkspaceForPane(paneId)
+    const pane = workspace ? findPaneById(workspace.layout, paneId) : layout ? findPaneById(layout, paneId) : null
+    const paneTitle = pane?.title ?? paneId
+    const workspaceTitle = workspace?.title
+
+    setAttentionPaneIds((current) => new Set(current).add(paneId))
+    showBrowserNotification(
+      'Agent confirmation requested',
+      workspaceTitle ? `${paneTitle} in ${workspaceTitle}` : paneTitle,
+    )
+  }, [findWorkspaceForPane, layout])
 
   const handleAddSSHHost = useCallback(async (host: SSHConfigHost) => {
     setIsAddSSHHostSaving(true)
@@ -86,6 +143,9 @@ export const App: React.FC = () => {
       setDragSourcePaneId,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
       editMode,
+      onPaneAttention: notifyAttention,
+      clearPaneAttention,
+      hasPaneAttention: (paneId: string) => attentionPaneIds.has(paneId),
     }}>
       <div
         style={{
@@ -109,6 +169,8 @@ export const App: React.FC = () => {
             activeWorkspaceId={workspaces.active}
             tabPosition={workspaces.tab_position}
             onSelect={setActiveWorkspace}
+            attentionWorkspaceIds={attentionWorkspaceIds}
+            onClearAttention={clearWorkspaceAttention}
             onAdd={editMode ? addWorkspace : undefined}
             onRename={editMode ? renameWorkspace : undefined}
             onTabPositionChange={editMode ? setWorkspaceTabPosition : undefined}
@@ -146,4 +208,21 @@ export const App: React.FC = () => {
       </div>
     </LayoutActionsContext.Provider>
   )
+}
+
+function showBrowserNotification(title: string, body: string) {
+  if (!('Notification' in window)) return
+
+  if (Notification.permission === 'granted') {
+    new Notification(title, { body })
+    return
+  }
+
+  if (Notification.permission === 'default') {
+    void Notification.requestPermission().then((permission) => {
+      if (permission === 'granted') {
+        new Notification(title, { body })
+      }
+    })
+  }
 }

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -30,6 +30,9 @@ function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
     setDragSourcePaneId: vi.fn(),
     displayConfig: { show_header: false, show_status_bar: false },
     editMode: false,
+    onPaneAttention: vi.fn(),
+    clearPaneAttention: vi.fn(),
+    hasPaneAttention: vi.fn(() => false),
   }
 }
 

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -14,6 +14,9 @@ export interface LayoutActionsContextValue {
   setDragSourcePaneId: (id: string | null) => void
   displayConfig: DisplayConfig
   editMode: boolean
+  onPaneAttention: (paneId: string) => void
+  clearPaneAttention: (paneId: string) => void
+  hasPaneAttention: (paneId: string) => boolean
 }
 
 export const LayoutActionsContext = React.createContext<LayoutActionsContextValue | null>(null)

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -25,6 +25,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const ctx = useContext(LayoutActionsContext)
   const displayConfig = ctx?.displayConfig ?? DEFAULT_DISPLAY
   const editMode = ctx?.editMode ?? false
+  const hasAttention = ctx?.hasPaneAttention(pane.id) ?? false
   // Derive from context rather than local state: when the DOM element is moved
   // by React during a swap, the browser may not fire dragend on the source pane,
   // leaving local isDragging=true permanently. Using the global dragSourcePaneId
@@ -35,6 +36,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
     sessionId: pane.id,
     container: containerEl,
     editMode,
+    onAttention: ctx?.onPaneAttention,
   })
 
   const gitInfo = useGitInfo(pane.id)
@@ -84,12 +86,16 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
 
   return (
     <div
+      className={hasAttention ? 'panemux-pane-attention' : undefined}
       draggable={editMode}
+      data-attention={hasAttention ? 'true' : undefined}
       onDragStart={editMode ? handleDragStart : undefined}
       onDragEnd={editMode ? handleDragEnd : undefined}
       onDragOver={editMode ? handleDragOver : undefined}
       onDragLeave={editMode ? handleDragLeave : undefined}
       onDrop={editMode ? handleDrop : undefined}
+      onMouseDown={() => ctx?.clearPaneAttention(pane.id)}
+      onFocusCapture={() => ctx?.clearPaneAttention(pane.id)}
       style={{
         display: 'flex',
         flexDirection: 'column',
@@ -102,10 +108,12 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
           ? '2px solid #569cd6'
           : isDragging
           ? '2px dashed rgba(86, 156, 214, 0.7)'
+          : hasAttention
+          ? '2px solid rgba(244, 191, 79, 0.95)'
           : 'none',
         outlineOffset: '-2px',
         // Subtle inset frame to mark pane as "in edit zone"
-        boxShadow: editMode && !isDragOver
+        boxShadow: editMode && !isDragOver && !hasAttention
           ? 'inset 0 0 0 1px rgba(86, 156, 214, 0.18)'
           : 'none',
         // "Lifted" appearance when this pane is the drag source

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -26,6 +26,41 @@ describe('WorkspaceTabs', () => {
     expect(onSelect).toHaveBeenCalledWith('ops')
   })
 
+  it('marks inactive workspaces that need attention', () => {
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        attentionWorkspaceIds={new Set(['ops'])}
+        onSelect={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('tab', { name: 'Ops' })).toHaveAttribute('data-attention', 'true')
+    expect(screen.getByRole('tab', { name: 'Dev' })).not.toHaveAttribute('data-attention')
+  })
+
+  it('clears workspace attention before selecting the tab', () => {
+    const onSelect = vi.fn()
+    const onClearAttention = vi.fn()
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        attentionWorkspaceIds={new Set(['ops'])}
+        onSelect={onSelect}
+        onClearAttention={onClearAttention}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Ops' }))
+
+    expect(onClearAttention).toHaveBeenCalledWith('ops')
+    expect(onSelect).toHaveBeenCalledWith('ops')
+  })
+
   it('hides workspace tabs for a single workspace while keeping add available', () => {
     const onAdd = vi.fn()
     render(

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -11,6 +11,8 @@ interface WorkspaceTabsProps {
   onDelete?: (workspaceId: string) => void
   onRename?: (workspaceId: string, title: string) => void
   onTabPositionChange?: (position: TabPosition) => void
+  attentionWorkspaceIds?: ReadonlySet<string>
+  onClearAttention?: (workspaceId: string) => void
 }
 
 export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
@@ -22,6 +24,8 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   onDelete,
   onRename,
   onTabPositionChange,
+  attentionWorkspaceIds,
+  onClearAttention,
 }) => {
   const vertical = tabPosition === 'left' || tabPosition === 'right'
   const showTabs = workspaces.length > 1
@@ -147,9 +151,11 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
           {workspaces.map((workspace) => {
             const active = workspace.id === activeWorkspaceId
             const editing = editingWorkspaceId === workspace.id
+            const hasAttention = !active && (attentionWorkspaceIds?.has(workspace.id) ?? false)
             return (
               <div
                 key={workspace.id}
+                className={hasAttention ? 'panemux-workspace-tab-attention' : undefined}
                 style={{
                   borderRight: !vertical ? '1px solid #333842' : undefined,
                   borderBottom: vertical ? '1px solid #333842' : undefined,
@@ -194,7 +200,11 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
                   <button
                     role="tab"
                     aria-selected={active}
-                    onClick={() => onSelect(workspace.id)}
+                    data-attention={hasAttention ? 'true' : undefined}
+                    onClick={() => {
+                      onClearAttention?.(workspace.id)
+                      onSelect(workspace.id)
+                    }}
                     onDoubleClick={() => startRename(workspace)}
                     title={workspace.title}
                     style={{

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -217,6 +217,74 @@ describe('useTerminal', () => {
     expect(mockWrite).toHaveBeenCalledWith(expect.any(Uint8Array))
   })
 
+  it('notifies when terminal output asks for agent confirmation', () => {
+    const container = makeContainer()
+    const onAttention = vi.fn()
+    renderHook(() => useTerminal({ sessionId: 's1', container, onAttention }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer,
+      )
+    )
+
+    expect(onAttention).toHaveBeenCalledWith('s1')
+  })
+
+  it('streams binary decoding so split Japanese confirmation prompts are detected', () => {
+    const container = makeContainer()
+    const onAttention = vi.fn()
+    renderHook(() => useTerminal({ sessionId: 's1', container, onAttention }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const bytes = new TextEncoder().encode('Codex: 確認が必要です。承認してください')
+    const split = 'Codex: '.length + 1
+    act(() => MockWebSocket.instances[0].simulateMessage(bytes.slice(0, split).buffer))
+
+    expect(onAttention).not.toHaveBeenCalled()
+
+    act(() => MockWebSocket.instances[0].simulateMessage(bytes.slice(split).buffer))
+
+    expect(onAttention).toHaveBeenCalledWith('s1')
+  })
+
+  it('deduplicates repeated agent confirmation redraws', () => {
+    const container = makeContainer()
+    const onAttention = vi.fn()
+    renderHook(() => useTerminal({ sessionId: 's1', container, onAttention }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const prompt = new TextEncoder().encode('Agent is waiting for confirmation: proceed?').buffer
+    act(() => MockWebSocket.instances[0].simulateMessage(prompt))
+    act(() => MockWebSocket.instances[0].simulateMessage(prompt))
+
+    expect(onAttention).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not notify for unrelated output after an old confirmation prompt ages past the throttle', () => {
+    vi.useFakeTimers()
+    const container = makeContainer()
+    const onAttention = vi.fn()
+    renderHook(() => useTerminal({ sessionId: 's1', container, onAttention }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer,
+      )
+    )
+    act(() => vi.advanceTimersByTime(11_000))
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        new TextEncoder().encode('\nmake test passed').buffer,
+      )
+    )
+
+    expect(onAttention).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+
   it('writes error message to terminal on error control frame', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -1,14 +1,19 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { MutableRefObject } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useWebSocket } from './useWebSocket'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+import { createAgentAttentionDetector } from '../utils/agentAttention'
+
+const ATTENTION_NOTIFY_INTERVAL_MS = 10_000
 
 interface UseTerminalOptions {
   sessionId: string
   container: HTMLElement | null
   editMode?: boolean
+  onAttention?: (sessionId: string) => void
 }
 
 interface TerminalEntry {
@@ -22,12 +27,15 @@ interface TerminalEntry {
 
 const terminalEntries = new Map<string, TerminalEntry>()
 
-export function useTerminal({ sessionId, container, editMode = false }: UseTerminalOptions) {
+export function useTerminal({ sessionId, container, editMode = false, onAttention }: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const initializedRef = useRef(false)
   const sendRef = useRef<((data: string | ArrayBuffer | Uint8Array) => void) | null>(null)
   const entryRef = useRef<TerminalEntry | null>(null)
+  const attentionDetectorRef = useRef(createAgentAttentionDetector())
+  const outputDecoderRef = useRef(new TextDecoder())
+  const lastAttentionAtRef = useRef<number | null>(null)
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null)
   const [sessionExited, setSessionExited] = useState(false)
 
@@ -35,7 +43,12 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
     if (!termRef.current) return
 
     if (isBinary) {
-      termRef.current.write(new Uint8Array(data as ArrayBuffer))
+      const bytes = new Uint8Array(data as ArrayBuffer)
+      termRef.current.write(bytes)
+      const text = outputDecoderRef.current.decode(bytes, { stream: true })
+      if (shouldNotifyAttention(attentionDetectorRef.current.feed(text), lastAttentionAtRef)) {
+        onAttention?.(sessionId)
+      }
     } else {
       try {
         const msg = JSON.parse(data as string)
@@ -50,15 +63,22 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
         }
       } catch {
         // Not JSON, treat as text
-        termRef.current.write(data as string)
+        const text = data as string
+        termRef.current.write(text)
+        if (shouldNotifyAttention(attentionDetectorRef.current.feed(text), lastAttentionAtRef)) {
+          onAttention?.(sessionId)
+        }
       }
     }
-  }, [sessionId])
+  }, [onAttention, sessionId])
 
   const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/${sessionId}`
   const { send, connected, reconnect } = useWebSocket(wsUrl, {
     onMessage: handleMessage,
     onOpen: () => {
+      lastAttentionAtRef.current = null
+      attentionDetectorRef.current.reset()
+      outputDecoderRef.current = new TextDecoder()
       setSessionExited(false)
       if (fitAddonRef.current && termRef.current) {
         fitAddonRef.current.fit()
@@ -286,4 +306,19 @@ function fallbackCopy(text: string) {
   textarea.select()
   document.execCommand('copy')
   document.body.removeChild(textarea)
+}
+
+function shouldNotifyAttention(detected: boolean, lastAttentionAtRef: MutableRefObject<number | null>): boolean {
+  if (!detected) return false
+
+  const now = Date.now()
+  if (
+    lastAttentionAtRef.current !== null &&
+    now - lastAttentionAtRef.current < ATTENTION_NOTIFY_INTERVAL_MS
+  ) {
+    return false
+  }
+
+  lastAttentionAtRef.current = now
+  return true
 }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -104,5 +104,6 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
 }
 
 function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  // Vitest can deliver ArrayBuffer values from a different JS realm.
   return value instanceof ArrayBuffer || Object.prototype.toString.call(value) === '[object ArrayBuffer]'
 }

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -43,7 +43,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
     }
 
     ws.onmessage = (event) => {
-      const isBinary = event.data instanceof ArrayBuffer
+      const isBinary = isArrayBuffer(event.data)
       if (!isBinary) {
         // Validate text frames before passing to handler
         try {
@@ -101,4 +101,8 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
   }, [connect])
 
   return { send, connected, reconnect }
+}
+
+function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return value instanceof ArrayBuffer || Object.prototype.toString.call(value) === '[object ArrayBuffer]'
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import '@xterm/xterm/css/xterm.css'
 import { App } from './App'
 import './styles/fonts.css'
+import './styles/attention.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/frontend/src/styles/attention.css
+++ b/frontend/src/styles/attention.css
@@ -1,0 +1,27 @@
+@keyframes panemux-attention-frame {
+  0%, 100% {
+    box-shadow: inset 0 0 0 2px rgba(244, 191, 79, 0.95), 0 0 0 rgba(244, 191, 79, 0);
+  }
+
+  50% {
+    box-shadow: inset 0 0 0 2px rgba(244, 191, 79, 0.35), 0 0 16px rgba(244, 191, 79, 0.34);
+  }
+}
+
+@keyframes panemux-attention-tab {
+  0%, 100% {
+    background-color: rgba(244, 191, 79, 0.22);
+  }
+
+  50% {
+    background-color: rgba(244, 191, 79, 0.06);
+  }
+}
+
+.panemux-pane-attention {
+  animation: panemux-attention-frame 1.1s ease-in-out infinite;
+}
+
+.panemux-workspace-tab-attention {
+  animation: panemux-attention-tab 1.1s ease-in-out infinite;
+}

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -15,11 +15,31 @@ describe('createAgentAttentionDetector', () => {
     expect(detector.feed('irmation\x1b[0m: proceed?')).toBe(true)
   })
 
+  it('detects agent confirmation prompts split across terminal lines', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('Codex is waiting for your\napproval before it can proceed.')).toBe(true)
+  })
+
+  it('detects Japanese approval prompts split across terminal lines', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('操作の承認\nが必要です')).toBe(true)
+  })
+
   it('detects Codex approval menus with yes and no options', () => {
     const detector = createAgentAttentionDetector()
 
     expect(
       detector.feed(' 1. Yes, proceed (y)\n 2. No, and tell Codex what to do differently (esc)'),
+    ).toBe(true)
+  })
+
+  it('detects Claude approval menus with yes and no options', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(' 1. Yes, proceed (y)\n 2. No, and tell Claude what to do differently (esc)'),
     ).toBe(true)
   })
 
@@ -54,6 +74,31 @@ describe('createAgentAttentionDetector', () => {
           '› 1. Yes, proceed (y)',
           "  2. Yes, and don't ask again for commands that start with `gh pr comment` (p)",
           '  3. No, and tell Codex what to do differently (esc)',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects Claude bash command approval menus', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Bash command',
+          '',
+          '  gh api repos/tomo-chan/panemux/pulls/74/reviews \\',
+          '    --method POST \\',
+          '    --field event="COMMENT"',
+          '  Post follow-up review for PR #74 at new head SHA',
+          '',
+          'Brace expansion',
+          '',
+          'Do you want to proceed?',
+          '❯ 1. Yes',
+          '  2. No',
+          '',
+          'Esc to cancel · Tab to amend · ctrl+e to explain',
         ].join('\n'),
       ),
     ).toBe(true)

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -23,6 +23,22 @@ describe('createAgentAttentionDetector', () => {
     ).toBe(true)
   })
 
+  it('detects Codex edit approval menus with a do-not-ask-again option', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Would you like to make the following edits?',
+          '',
+          '› 1. Yes, proceed (y)',
+          "  2. Yes, and don't ask again for these files (a)",
+          '  3. No, and tell Codex what to do differently (esc)',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
   it('does not match ordinary terminal output', () => {
     const detector = createAgentAttentionDetector()
 

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { createAgentAttentionDetector } from './agentAttention'
+
+describe('createAgentAttentionDetector', () => {
+  it('detects an agent confirmation prompt in terminal output', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toBe(true)
+  })
+
+  it('detects prompts split across terminal frames after stripping ANSI escapes', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('\x1b[33mAgent is waiting for conf')).toBe(false)
+    expect(detector.feed('irmation\x1b[0m: proceed?')).toBe(true)
+  })
+
+  it('does not match ordinary terminal output', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('npm test finished successfully')).toBe(false)
+  })
+
+  it('does not keep matching stale prompt text after it has emitted', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toBe(true)
+    expect(detector.feed('\nnormal command output after the prompt')).toBe(false)
+  })
+})

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -15,6 +15,14 @@ describe('createAgentAttentionDetector', () => {
     expect(detector.feed('irmation\x1b[0m: proceed?')).toBe(true)
   })
 
+  it('detects Codex approval menus with yes and no options', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(' 1. Yes, proceed (y)\n 2. No, and tell Codex what to do differently (esc)'),
+    ).toBe(true)
+  })
+
   it('does not match ordinary terminal output', () => {
     const detector = createAgentAttentionDetector()
 

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -39,6 +39,26 @@ describe('createAgentAttentionDetector', () => {
     ).toBe(true)
   })
 
+  it('detects Codex command approval menus with scoped do-not-ask-again options', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Would you like to run the following command?',
+          '',
+          '  Reason: PR #74 にフォローアップコメントを投稿するため、GitHub API へのネットワークアクセス付きで gh pr comment を再実行してよいですか？',
+          '',
+          '  $ gh pr comment 74 --body-file /tmp/pr74-comment-8f80598.md',
+          '',
+          '› 1. Yes, proceed (y)',
+          "  2. Yes, and don't ask again for commands that start with `gh pr comment` (p)",
+          '  3. No, and tell Codex what to do differently (esc)',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
   it('does not match ordinary terminal output', () => {
     const detector = createAgentAttentionDetector()
 

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -21,6 +21,13 @@ describe('createAgentAttentionDetector', () => {
     expect(detector.feed('npm test finished successfully')).toBe(false)
   })
 
+  it('does not match generic non-agent confirmation prompts', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(detector.feed('Need to install the following packages: vite. Proceed? [y/N]')).toBe(false)
+    expect(detector.feed('Allow Homebrew to make changes?')).toBe(false)
+  })
+
   it('does not keep matching stale prompt text after it has emitted', () => {
     const detector = createAgentAttentionDetector()
 

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -2,7 +2,6 @@ const MAX_TAIL_LENGTH = 1200
 
 const ATTENTION_PATTERNS = [
   /\b(codex|claude|agent)\b.{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
-  /\b(confirm|approve|allow|proceed)\b.{0,120}\?/i,
   /(確認|承認|許可).{0,120}(必要|してください|しますか|待ち)/,
 ]
 

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -1,9 +1,10 @@
 const MAX_TAIL_LENGTH = 1200
 
 const ATTENTION_PATTERNS = [
-  /\b(codex|claude|agent)\b.{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
-  /\bYes,\s*proceed\s*\(y\)[\s\S]{0,160}\bNo,\s*and\s*tell\s+Codex\s+what\s+to\s+do\s+differently\s*\(esc\)/i,
-  /(確認|承認|許可).{0,120}(必要|してください|しますか|待ち)/,
+  /\b(codex|claude|agent)\b[\s\S]{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
+  /\bYes,\s*proceed\s*\(y\)[\s\S]{0,160}\bNo,\s*and\s*tell\s+(Codex|Claude|agent)\s+what\s+to\s+do\s+differently\s*\(esc\)/i,
+  /Do you want to proceed\?[\s\S]{0,120}\b1\.\s*Yes\b[\s\S]{0,80}\b2\.\s*No\b[\s\S]{0,160}Esc to cancel\s*·\s*Tab to amend\s*·\s*ctrl\+e to explain/i,
+  /(確認|承認|許可)[\s\S]{0,120}(必要|してください|しますか|待ち)/,
 ]
 
 export interface AgentAttentionDetector {

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -2,6 +2,7 @@ const MAX_TAIL_LENGTH = 1200
 
 const ATTENTION_PATTERNS = [
   /\b(codex|claude|agent)\b.{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
+  /\bYes,\s*proceed\s*\(y\)[\s\S]{0,160}\bNo,\s*and\s*tell\s+Codex\s+what\s+to\s+do\s+differently\s*\(esc\)/i,
   /(確認|承認|許可).{0,120}(必要|してください|しますか|待ち)/,
 ]
 

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -1,0 +1,34 @@
+const MAX_TAIL_LENGTH = 1200
+
+const ATTENTION_PATTERNS = [
+  /\b(codex|claude|agent)\b.{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
+  /\b(confirm|approve|allow|proceed)\b.{0,120}\?/i,
+  /(確認|承認|許可).{0,120}(必要|してください|しますか|待ち)/,
+]
+
+export interface AgentAttentionDetector {
+  feed: (chunk: string) => boolean
+  reset: () => void
+}
+
+export function createAgentAttentionDetector(): AgentAttentionDetector {
+  let tail = ''
+
+  return {
+    feed(chunk: string) {
+      tail = (tail + stripAnsi(chunk)).slice(-MAX_TAIL_LENGTH)
+      const matched = ATTENTION_PATTERNS.some((pattern) => pattern.test(tail))
+      if (matched) {
+        tail = ''
+      }
+      return matched
+    },
+    reset() {
+      tail = ''
+    },
+  }
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g, '')
+}

--- a/frontend/src/utils/layoutTree.ts
+++ b/frontend/src/utils/layoutTree.ts
@@ -108,6 +108,23 @@ export function findPaneById(layout: LayoutNode, paneId: string): PaneConfig | n
   return null
 }
 
+export function layoutContainsPane(layout: LayoutNode, paneId: string): boolean {
+  return findPaneById(layout, paneId) !== null
+}
+
+export function listPaneIds(layout: LayoutNode): string[] {
+  const paneIds: string[] = []
+  collectPaneIds(layout.children, paneIds)
+  return paneIds
+}
+
+function collectPaneIds(children: LayoutChild[], paneIds: string[]) {
+  for (const child of children) {
+    if (child.pane) paneIds.push(child.pane.id)
+    if (child.children?.length) collectPaneIds(child.children, paneIds)
+  }
+}
+
 /**
  * Replaces the pane matching `updated.id` in the layout tree with `updated`.
  * Returns the tree unchanged if the id is not found.

--- a/frontend/src/utils/layoutTree.ts
+++ b/frontend/src/utils/layoutTree.ts
@@ -112,19 +112,6 @@ export function layoutContainsPane(layout: LayoutNode, paneId: string): boolean 
   return findPaneById(layout, paneId) !== null
 }
 
-export function listPaneIds(layout: LayoutNode): string[] {
-  const paneIds: string[] = []
-  collectPaneIds(layout.children, paneIds)
-  return paneIds
-}
-
-function collectPaneIds(children: LayoutChild[], paneIds: string[]) {
-  for (const child of children) {
-    if (child.pane) paneIds.push(child.pane.id)
-    if (child.children?.length) collectPaneIds(child.children, paneIds)
-  }
-}
-
 /**
  * Replaces the pane matching `updated.id` in the layout tree with `updated`.
  * Returns the tree unchanged if the id is not found.


### PR DESCRIPTION
## Summary
- Detect conservative agent confirmation prompts from terminal output, including ANSI-stripped split frames and streamed binary output.
- Flash panes and inactive workspace tabs when attention is needed, and request browser OS notifications when supported.
- Clear pane/workspace attention on focus, click, or workspace selection, and document the frontend-only detection limits.

## Test Plan
- [x] `git diff --check`
- [x] `make lint-frontend`
- [x] `make test-frontend`

## Notes
- `GOCACHE=/tmp/panemux-gocache-20260501120150 GOLANGCI_LINT_CACHE=/tmp/panemux-golangci-cache-20260501120150 make check` was attempted. It passed frontend build, `go vet`, `golangci-lint`, frontend typecheck, and most Go packages, then failed on sandbox-bound local environment constraints: `dscl: exit status 70` in `TestDetectLocalShell_ReturnsAbsolutePath` and `httptest` cannot bind `[::1]:0` in `internal/ws`.
