### PR TITLE
fix: repaint terminal after workspace switches

### DIFF
--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -486,6 +486,95 @@ describe('useTerminal', () => {
     expect(secondContainer.contains(mockTerm.element as HTMLElement)).toBe(true)
   })
 
+  it('repaints a reused terminal again after remount timing settles', () => {
+    vi.useFakeTimers()
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+    const firstContainer = makeContainer()
+    const secondContainer = makeContainer()
+
+    const first = renderHook(() => useTerminal({ sessionId: 's1', container: firstContainer }))
+    first.unmount()
+    mockFitAddon.fit.mockClear()
+    mockTerm.refresh.mockClear()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container: secondContainer }))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(1)
+
+    act(() => vi.advanceTimersByTime(50))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('repaints the attached terminal when the window regains focus', () => {
+    vi.useFakeTimers()
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+    const container = makeContainer()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    mockFitAddon.fit.mockClear()
+    mockTerm.refresh.mockClear()
+
+    act(() => window.dispatchEvent(new Event('focus')))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(1)
+
+    act(() => vi.advanceTimersByTime(50))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('repaints the attached terminal when the document becomes visible', () => {
+    vi.useFakeTimers()
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    const container = makeContainer()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    mockFitAddon.fit.mockClear()
+    mockTerm.refresh.mockClear()
+
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(1)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(1)
+
+    act(() => vi.advanceTimersByTime(50))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
+  })
+
+  it('does not repaint the attached terminal when the document becomes hidden', () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    const container = makeContainer()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    mockFitAddon.fit.mockClear()
+    mockTerm.refresh.mockClear()
+
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(mockFitAddon.fit).not.toHaveBeenCalled()
+    expect(mockTerm.refresh).not.toHaveBeenCalled()
+  })
+
   it('editMode blocks terminal input', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container, editMode: true }))

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -509,6 +509,11 @@ describe('useTerminal', () => {
 
     expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
     expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(3)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(3)
     vi.useRealTimers()
   })
 
@@ -533,6 +538,11 @@ describe('useTerminal', () => {
 
     expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
     expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(3)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(3)
     vi.useRealTimers()
   })
 
@@ -558,6 +568,11 @@ describe('useTerminal', () => {
 
     expect(mockFitAddon.fit).toHaveBeenCalledTimes(2)
     expect(mockTerm.refresh).toHaveBeenCalledTimes(2)
+
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(mockFitAddon.fit).toHaveBeenCalledTimes(3)
+    expect(mockTerm.refresh).toHaveBeenCalledTimes(3)
     vi.useRealTimers()
   })
 

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -8,6 +8,7 @@ import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 import { createAgentAttentionDetector } from '../utils/agentAttention'
 
 const ATTENTION_NOTIFY_INTERVAL_MS = 10_000
+const REMOUNT_REPAINT_DELAYS_MS = [50, 250]
 
 interface UseTerminalOptions {
   sessionId: string
@@ -21,6 +22,7 @@ interface TerminalEntry {
   fitAddon: FitAddon
   attachedContainer: HTMLElement | null
   disposeTimer: ReturnType<typeof setTimeout> | null
+  repaintTimers: Set<ReturnType<typeof setTimeout>>
   send: ((data: string | ArrayBuffer | Uint8Array) => void) | null
   editMode: boolean
 }
@@ -101,6 +103,27 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     if (entryRef.current) entryRef.current.editMode = editMode
   }, [editMode])
 
+  useEffect(() => {
+    const repaintCurrentTerminal = () => {
+      const entry = entryRef.current
+      if (entry) refreshTerminal(entry, setDims)
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        repaintCurrentTerminal()
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    window.addEventListener('focus', repaintCurrentTerminal)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      window.removeEventListener('focus', repaintCurrentTerminal)
+    }
+  }, [])
+
   // Initialize terminal
   useEffect(() => {
     if (!container || initializedRef.current) return
@@ -126,10 +149,12 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
       const currentEntry = entryRef.current
       if (!currentEntry) return
 
+      clearScheduledRepaints(currentEntry)
       currentEntry.attachedContainer = null
       currentEntry.send = null
       currentEntry.disposeTimer = setTimeout(() => {
         if (currentEntry.attachedContainer) return
+        clearScheduledRepaints(currentEntry)
         currentEntry.term.dispose()
         terminalEntries.delete(sessionId)
       }, 0)
@@ -153,10 +178,8 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     const entry = entryRef.current
     if (!entry) return
 
-    entry.fitAddon.fit()
-    entry.term.refresh(0, entry.term.rows - 1)
+    repaintTerminal(entry, setDims)
     const { cols, rows } = entry.term
-    setDims({ cols, rows })
     if (connected) {
       send(JSON.stringify({ type: 'resize', cols, rows }))
     }
@@ -207,6 +230,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     fitAddon,
     attachedContainer: null,
     disposeTimer: null,
+    repaintTimers: new Set(),
     send: null,
     editMode: false,
   }
@@ -262,17 +286,43 @@ function refreshTerminal(
   entry: TerminalEntry,
   setDims: (dims: { cols: number; rows: number }) => void,
 ) {
-  requestAnimationFrame(() => {
-    entry.fitAddon.fit()
+  clearScheduledRepaints(entry)
+  requestAnimationFrame(() => repaintTerminal(entry, setDims))
+
+  for (const delay of REMOUNT_REPAINT_DELAYS_MS) {
+    const timer = setTimeout(() => {
+      entry.repaintTimers.delete(timer)
+      requestAnimationFrame(() => repaintTerminal(entry, setDims))
+    }, delay)
+    entry.repaintTimers.add(timer)
+  }
+}
+
+function repaintTerminal(
+  entry: TerminalEntry,
+  setDims: (dims: { cols: number; rows: number }) => void,
+) {
+  if (!entry.attachedContainer) return
+
+  entry.fitAddon.fit()
+  if (entry.term.rows > 0) {
     entry.term.refresh(0, entry.term.rows - 1)
-    const { cols, rows } = entry.term
-    setDims({ cols, rows })
-  })
+  }
+  const { cols, rows } = entry.term
+  setDims({ cols, rows })
+}
+
+function clearScheduledRepaints(entry: TerminalEntry) {
+  for (const timer of entry.repaintTimers) {
+    clearTimeout(timer)
+  }
+  entry.repaintTimers.clear()
 }
 
 export function __resetTerminalEntriesForTests() {
   for (const entry of terminalEntries.values()) {
     if (entry.disposeTimer) clearTimeout(entry.disposeTimer)
+    clearScheduledRepaints(entry)
     entry.term.dispose()
   }
   terminalEntries.clear()

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -8,7 +8,7 @@ import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 import { createAgentAttentionDetector } from '../utils/agentAttention'
 
 const ATTENTION_NOTIFY_INTERVAL_MS = 10_000
-const REMOUNT_REPAINT_DELAYS_MS = [50, 250]
+const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 
 interface UseTerminalOptions {
   sessionId: string
@@ -104,6 +104,8 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
   }, [editMode])
 
   useEffect(() => {
+    // Browser focus and tab visibility changes can affect every attached pane's layout,
+    // so each mounted terminal repaints its own attached instance when the page returns.
     const repaintCurrentTerminal = () => {
       const entry = entryRef.current
       if (entry) refreshTerminal(entry, setDims)
@@ -289,7 +291,7 @@ function refreshTerminal(
   clearScheduledRepaints(entry)
   requestAnimationFrame(() => repaintTerminal(entry, setDims))
 
-  for (const delay of REMOUNT_REPAINT_DELAYS_MS) {
+  for (const delay of REPAINT_SETTLE_DELAYS_MS) {
     const timer = setTimeout(() => {
       entry.repaintTimers.delete(timer)
       requestAnimationFrame(() => repaintTerminal(entry, setDims))


### PR DESCRIPTION
## Summary

Fixes terminal text disappearing after switching away from a workspace and returning by forcing xterm to repaint when the terminal is remounted, when the browser window regains focus, and when the document becomes visible again.

## Root cause

The terminal instance can be reused after a workspace switch while its canvas/viewport has not repainted yet. A later layout resize triggered xterm fit/refresh, which made the existing buffer visible again.

## Changes

- Schedule immediate and short delayed terminal fit/refresh passes after remount.
- Repaint each mounted, attached terminal pane on `window.focus` and visible `visibilitychange`.
- Clear pending repaint timers on detach, disposal, and test reset.
- Add regression coverage for remount, focus, visible document, and hidden document behavior.

## Test plan

- [x] `cd frontend && npm run test -- src/hooks/useTerminal.test.ts`
- [x] `make check`

## Residual risk

Automated coverage exercises the repaint triggers, but this was not manually verified in a real browser workspace-switch session.
