### PR TITLE
fix: replay terminal output after workspace switches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
       - name: Test (Frontend)
         run: cd frontend && npm run test:ci
 
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps chromium
+
+      - name: Test (E2E)
+        run: make test-e2e
+
       - name: Coverage (Go)
         run: make coverage-go
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 frontend/node_modules/
 frontend/dist/
 frontend/coverage/
+playwright-report/
 coverage.out
 *.yaml
 !config.example.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ make fmt        # apply go fmt -s to all Go files
 ```sh
 make lint       # includes go fmt check; fails if any Go file is unformatted
 make test
+make test-e2e   # Playwright browser regression checks for real renderer issues
 make check
 ```
 
@@ -137,7 +138,7 @@ Example: `Config.sshConfigPath` (empty = use `sshconfig.DefaultPath()`, non-empt
 
 ### Quality gate
 - `make check` (lint + test + coverage) must pass before `make build`.
-- Test commands: `make test-go` / `make test-frontend` / `make test`
+- Test commands: `make test-go` / `make test-frontend` / `make test-e2e` / `make test`
 - Coverage commands: `make coverage-go` / `make coverage-frontend`
 - Lint commands: `make lint-go` / `make lint-frontend` / `make lint`
 - **Go lint includes `gofmt`, `go vet`, and `golangci-lint run ./...`** (v2, config in `.golangci.yml`). The lint binary auto-installs via `make install-deps` / `make install-deps-ci`.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci \
-        test test-go test-frontend \
+        test test-go test-frontend test-e2e \
         fmt fmt-go fmt-check-go \
         lint lint-go lint-go-deps lint-frontend \
         coverage coverage-go coverage-frontend \
@@ -26,6 +26,9 @@ test-go:
 
 test-frontend:
 	cd frontend && npm test
+
+test-e2e:
+	cd frontend && npm run test:e2e
 
 # ── Coverage (≥ 80 %) ─────────────────────────────────────────────────────────
 #

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Individual commands:
 ```sh
 go test ./... -v -race           # Go tests
 cd frontend && npm test          # Frontend tests
+make test-e2e                    # Playwright E2E for browser-only rendering regressions
 make coverage-go                 # Go coverage (≥ 80 % required)
 cd frontend && npm run coverage  # Frontend coverage (≥ 80 % required)
 go vet ./...                     # Go lint

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -117,9 +117,11 @@ for detection are also written to the terminal buffer. When a prompt is detected
   browser may prompt before showing OS-level notifications
 
 Attention detection is frontend-only and only runs while the pane is rendered in the browser app.
-Inactive workspace panes are not watched by a separate background reader, because each WebSocket
-connection consumes directly from the session stream. It does not persist missed prompts across
-workspace switches, browser reloads, or closed browser windows.
+Inactive workspace panes are not watched by a separate background reader. Instead, the backend
+buffers recent terminal output per session and replays that snapshot when a pane reconnects after a
+workspace switch or browser reload. Attention detection itself still does not run while the pane is
+hidden, so prompts that appear and disappear entirely while a workspace is inactive are not
+retrospectively notified.
 
 ## REST API
 
@@ -227,6 +229,8 @@ Connection behavior:
 
 - `404` if the session ID does not exist
 - initial text frame is a JSON status message with `type: "status"` and `state: "connected"`
+- after the connected status, the backend replays up to the recent per-session output buffer before
+  streaming live output
 
 Frame behavior:
 

--- a/frontend/e2e/run-panemux-e2e.sh
+++ b/frontend/e2e/run-panemux-e2e.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+export GOCACHE="${TMPDIR:-/tmp}/panemux-playwright-gocache"
+mkdir -p "$GOCACHE"
+
+make build-frontend >/dev/null
+exec go run . --config frontend/e2e/workspace-switch.yml --port 4173

--- a/frontend/e2e/workspace-switch.spec.ts
+++ b/frontend/e2e/workspace-switch.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test, type Page } from '@playwright/test'
+
+test('renders terminal output when switching to a previously hidden workspace', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('tab', { name: 'Default' })).toHaveAttribute('aria-selected', 'true')
+  await expect.poll(async () => await visibleTerminalText(page), {
+    message: 'default workspace terminal should render an initial prompt',
+  }).toMatch(/\S/)
+
+  await page.getByRole('tab', { name: 'Workspace 2' }).click()
+
+  await expect(page.getByRole('tab', { name: 'Workspace 2' })).toHaveAttribute('aria-selected', 'true')
+  await expect.poll(async () => await visibleTerminalText(page), {
+    message: 'workspace switch should not leave the terminal blank',
+  }).toMatch(/\S/)
+})
+
+async function visibleTerminalText(page: Page) {
+  const text = await page.locator('.xterm-rows').first().textContent()
+  return text ?? ''
+}

--- a/frontend/e2e/workspace-switch.yml
+++ b/frontend/e2e/workspace-switch.yml
@@ -2,7 +2,7 @@ server:
     host: 127.0.0.1
     port: 4173
 workspaces:
-    active: workspace-2
+    active: default
     tab_position: top
     items:
         - id: default

--- a/frontend/e2e/workspace-switch.yml
+++ b/frontend/e2e/workspace-switch.yml
@@ -1,0 +1,34 @@
+server:
+    host: 127.0.0.1
+    port: 4173
+workspaces:
+    active: workspace-2
+    tab_position: top
+    items:
+        - id: default
+          title: Default
+          layout:
+            direction: horizontal
+            children:
+                - pane:
+                    id: default-main
+                    type: local
+                    shell: /bin/bash
+                    cwd: /tmp
+                    title: Default Shell
+                  size: 100
+        - id: workspace-2
+          title: Workspace 2
+          layout:
+            direction: horizontal
+            children:
+                - pane:
+                    id: workspace-2-main
+                    type: local
+                    shell: /bin/bash
+                    cwd: /tmp
+                    title: Workspace 2 Shell
+                  size: 100
+display:
+    show_header: true
+    show_status_bar: true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
@@ -16,6 +16,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.0",
@@ -588,6 +589,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2479,6 +2496,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
-    "@playwright/test": "^1.55.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "vitest run --reporter=default --reporter=junit --outputFile=../test-results/vitest.xml",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
@@ -21,9 +22,11 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
+    "@playwright/test": "^1.55.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^5.2.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'sh ./e2e/run-panemux-e2e.sh',
+    url: 'http://127.0.0.1:4173',
+    cwd: '.',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -207,6 +207,44 @@ describe('useTerminal', () => {
     expect(sentResizes.length).toBeGreaterThan(0)
   })
 
+  it('waits for a non-zero terminal size before sending the initial resize', () => {
+    vi.useFakeTimers()
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    }) as typeof window.requestAnimationFrame
+    const container = makeContainer()
+    let fitCalls = 0
+    mockTerm.cols = 0
+    mockTerm.rows = 0
+    mockFitAddon.fit.mockImplementation(() => {
+      fitCalls++
+      if (fitCalls >= 3) {
+        mockTerm.cols = 80
+        mockTerm.rows = 24
+      }
+    })
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const initialResizeFrames = MockWebSocket.instances[0].sent.filter(
+      (d) => typeof d === 'string' && (d as string).includes('"type":"resize"')
+    )
+    expect(initialResizeFrames).toHaveLength(0)
+
+    act(() => vi.advanceTimersByTime(50))
+
+    const resizeFrames = MockWebSocket.instances[0].sent.filter(
+      (d) => typeof d === 'string' && (d as string).includes('"type":"resize"')
+    )
+    expect(resizeFrames).toHaveLength(1)
+    expect(resizeFrames[0]).toContain('"cols":80')
+    expect(resizeFrames[0]).toContain('"rows":24')
+    vi.useRealTimers()
+  })
+
   it('writes binary data directly to terminal', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))
@@ -214,6 +252,25 @@ describe('useTerminal', () => {
 
     const buf = new ArrayBuffer(4)
     act(() => MockWebSocket.instances[0].simulateMessage(buf))
+    expect(mockWrite).toHaveBeenCalledWith(expect.any(Uint8Array))
+  })
+
+  it('buffers terminal output that arrives before the container is attached', () => {
+    const buf = new TextEncoder().encode('prompt before attach').buffer
+    const container = makeContainer()
+    const { rerender } = renderHook(
+      ({ currentContainer }: { currentContainer: HTMLDivElement | null }) =>
+        useTerminal({ sessionId: 's1', container: currentContainer }),
+      { initialProps: { currentContainer: null as HTMLDivElement | null } },
+    )
+
+    act(() => MockWebSocket.instances[0].simulateOpen())
+    act(() => MockWebSocket.instances[0].simulateMessage(buf))
+
+    expect(mockWrite).not.toHaveBeenCalledWith(expect.any(Uint8Array))
+
+    rerender({ currentContainer: container })
+
     expect(mockWrite).toHaveBeenCalledWith(expect.any(Uint8Array))
   })
 

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -84,6 +84,9 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
 
   const handleMessage = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
     if (!canApplyMessage(entryRef.current, termRef.current)) {
+      // A pane can reconnect before React has reattached the reused xterm DOM node
+      // during a workspace switch. Keep those bytes so the initial prompt is not
+      // lost between the WebSocket open and the eventual attach.
       pendingMessagesRef.current.push({ data, isBinary })
       return
     }
@@ -142,6 +145,9 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     const entry = entryRef.current
     if (!connected || !entry) return
 
+    // On reconnect the container may still be measuring as 0x0. Delay the
+    // initial resize until xterm reports non-zero cols/rows, otherwise the
+    // backend drops the resize and some shells never redraw their prompt.
     scheduleConnectedResize(entry, setDims, send)
   }, [connected, send, sessionId])
 
@@ -164,6 +170,8 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     fitAddonRef.current = entry.fitAddon
 
     attachTerminal(entry, container)
+    // Flush anything buffered while the pane was logically mounted but the xterm
+    // element had not yet been attached back into this container.
     flushPendingMessages(pendingMessagesRef.current, applyMessageToTerminal)
     refreshTerminal(entry, setDims)
 

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -23,8 +23,14 @@ interface TerminalEntry {
   attachedContainer: HTMLElement | null
   disposeTimer: ReturnType<typeof setTimeout> | null
   repaintTimers: Set<ReturnType<typeof setTimeout>>
+  resizeTimers: Set<ReturnType<typeof setTimeout>>
   send: ((data: string | ArrayBuffer | Uint8Array) => void) | null
   editMode: boolean
+}
+
+interface PendingTerminalMessage {
+  data: ArrayBuffer | string
+  isBinary: boolean
 }
 
 const terminalEntries = new Map<string, TerminalEntry>()
@@ -38,15 +44,17 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
   const attentionDetectorRef = useRef(createAgentAttentionDetector())
   const outputDecoderRef = useRef(new TextDecoder())
   const lastAttentionAtRef = useRef<number | null>(null)
+  const pendingMessagesRef = useRef<PendingTerminalMessage[]>([])
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null)
   const [sessionExited, setSessionExited] = useState(false)
 
-  const handleMessage = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
-    if (!termRef.current) return
+  const applyMessageToTerminal = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
+    const term = termRef.current
+    if (!term) return
 
     if (isBinary) {
       const bytes = new Uint8Array(data as ArrayBuffer)
-      termRef.current.write(bytes)
+      term.write(bytes)
       const text = outputDecoderRef.current.decode(bytes, { stream: true })
       if (shouldNotifyAttention(attentionDetectorRef.current.feed(text), lastAttentionAtRef)) {
         onAttention?.(sessionId)
@@ -58,21 +66,30 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
           console.log(`Session ${sessionId} status:`, msg.state)
           if (msg.state === 'exited') {
             setSessionExited(true)
-            termRef.current.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
+            term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
           }
         } else if (msg.type === 'error') {
-          termRef.current.write(`\r\n\x1b[31mError: ${msg.message}\x1b[0m\r\n`)
+          term.write(`\r\n\x1b[31mError: ${msg.message}\x1b[0m\r\n`)
         }
       } catch {
         // Not JSON, treat as text
         const text = data as string
-        termRef.current.write(text)
+        term.write(text)
         if (shouldNotifyAttention(attentionDetectorRef.current.feed(text), lastAttentionAtRef)) {
           onAttention?.(sessionId)
         }
       }
     }
   }, [onAttention, sessionId])
+
+  const handleMessage = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
+    if (!canApplyMessage(entryRef.current, termRef.current)) {
+      pendingMessagesRef.current.push({ data, isBinary })
+      return
+    }
+
+    applyMessageToTerminal(data, isBinary)
+  }, [applyMessageToTerminal])
 
   const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/${sessionId}`
   const { send, connected, reconnect } = useWebSocket(wsUrl, {
@@ -82,11 +99,6 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
       attentionDetectorRef.current.reset()
       outputDecoderRef.current = new TextDecoder()
       setSessionExited(false)
-      if (fitAddonRef.current && termRef.current) {
-        fitAddonRef.current.fit()
-        const { cols, rows } = termRef.current
-        sendRef.current?.(JSON.stringify({ type: 'resize', cols, rows }))
-      }
     },
   })
 
@@ -126,6 +138,13 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     }
   }, [])
 
+  useEffect(() => {
+    const entry = entryRef.current
+    if (!connected || !entry) return
+
+    scheduleConnectedResize(entry, setDims, send)
+  }, [connected, send, sessionId])
+
   // Initialize terminal
   useEffect(() => {
     if (!container || initializedRef.current) return
@@ -145,6 +164,7 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
     fitAddonRef.current = entry.fitAddon
 
     attachTerminal(entry, container)
+    flushPendingMessages(pendingMessagesRef.current, applyMessageToTerminal)
     refreshTerminal(entry, setDims)
 
     return () => {
@@ -152,11 +172,13 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
       if (!currentEntry) return
 
       clearScheduledRepaints(currentEntry)
+      clearScheduledResizes(currentEntry)
       currentEntry.attachedContainer = null
       currentEntry.send = null
       currentEntry.disposeTimer = setTimeout(() => {
         if (currentEntry.attachedContainer) return
         clearScheduledRepaints(currentEntry)
+        clearScheduledResizes(currentEntry)
         currentEntry.term.dispose()
         terminalEntries.delete(sessionId)
       }, 0)
@@ -182,12 +204,28 @@ export function useTerminal({ sessionId, container, editMode = false, onAttentio
 
     repaintTerminal(entry, setDims)
     const { cols, rows } = entry.term
-    if (connected) {
+    if (connected && cols > 0 && rows > 0) {
       send(JSON.stringify({ type: 'resize', cols, rows }))
     }
   }, [send, connected])
 
   return { handleResize, connected, dims, sessionExited, restartSession }
+}
+
+function flushPendingMessages(
+  pendingMessages: PendingTerminalMessage[],
+  applyMessageToTerminal: (data: ArrayBuffer | string, isBinary: boolean) => void,
+) {
+  if (pendingMessages.length === 0) return
+
+  for (const { data, isBinary } of pendingMessages) {
+    applyMessageToTerminal(data, isBinary)
+  }
+  pendingMessages.length = 0
+}
+
+function canApplyMessage(entry: TerminalEntry | null, term: Terminal | null): boolean {
+  return Boolean(entry?.attachedContainer && term?.element)
 }
 
 function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
@@ -233,6 +271,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     attachedContainer: null,
     disposeTimer: null,
     repaintTimers: new Set(),
+    resizeTimers: new Set(),
     send: null,
     editMode: false,
   }
@@ -314,6 +353,35 @@ function repaintTerminal(
   setDims({ cols, rows })
 }
 
+function scheduleConnectedResize(
+  entry: TerminalEntry,
+  setDims: (dims: { cols: number; rows: number }) => void,
+  send: (data: string | ArrayBuffer | Uint8Array) => void,
+) {
+  clearScheduledResizes(entry)
+
+  const attemptResize = () => {
+    if (!entry.attachedContainer) return
+
+    repaintTerminal(entry, setDims)
+    const { cols, rows } = entry.term
+    if (cols > 0 && rows > 0) {
+      clearScheduledResizes(entry)
+      send(JSON.stringify({ type: 'resize', cols, rows }))
+    }
+  }
+
+  requestAnimationFrame(attemptResize)
+
+  for (const delay of REPAINT_SETTLE_DELAYS_MS) {
+    const timer = setTimeout(() => {
+      entry.resizeTimers.delete(timer)
+      requestAnimationFrame(attemptResize)
+    }, delay)
+    entry.resizeTimers.add(timer)
+  }
+}
+
 function clearScheduledRepaints(entry: TerminalEntry) {
   for (const timer of entry.repaintTimers) {
     clearTimeout(timer)
@@ -321,10 +389,18 @@ function clearScheduledRepaints(entry: TerminalEntry) {
   entry.repaintTimers.clear()
 }
 
+function clearScheduledResizes(entry: TerminalEntry) {
+  for (const timer of entry.resizeTimers) {
+    clearTimeout(timer)
+  }
+  entry.resizeTimers.clear()
+}
+
 export function __resetTerminalEntriesForTests() {
   for (const entry of terminalEntries.values()) {
     if (entry.disposeTimer) clearTimeout(entry.disposeTimer)
     clearScheduledRepaints(entry)
+    clearScheduledResizes(entry)
     entry.term.dispose()
   }
   terminalEntries.clear()

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    exclude: ['e2e/**'],
     coverage: {
       provider: 'v8',
       // Measure only hooks and schemas — UI components and entry points

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -3,6 +3,7 @@ package session
 import (
 	"fmt"
 	"io"
+	"log"
 	"sync"
 )
 
@@ -134,6 +135,7 @@ func (m *managedSession) pump() {
 				m.closeSubscribers()
 				return
 			}
+			log.Printf("session %s read error: %v", m.session.ID(), err)
 			m.closeSubscribers()
 			return
 		}
@@ -142,16 +144,20 @@ func (m *managedSession) pump() {
 
 func (m *managedSession) publish(chunk []byte) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	m.history = append(m.history, chunk...)
 	if len(m.history) > sessionReplayLimitBytes {
 		m.history = append([]byte(nil), m.history[len(m.history)-sessionReplayLimitBytes:]...)
 	}
 
 	for _, subscriber := range m.subscribers {
-		subscriber <- append([]byte(nil), chunk...)
+		select {
+		case subscriber <- append([]byte(nil), chunk...):
+		default:
+			// A slow client must not block session pumping or subscription cleanup.
+			// The recent replay buffer remains the source of truth for reconnects.
+		}
 	}
+	m.mu.Unlock()
 }
 
 func (m *managedSession) subscribe() ([]byte, <-chan []byte, func()) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -2,35 +2,74 @@ package session
 
 import (
 	"fmt"
+	"io"
 	"sync"
 )
 
+const sessionReplayLimitBytes = 256 * 1024
+
 // Manager manages the lifecycle of all terminal sessions.
 type Manager struct {
-	sessions map[string]Session
+	sessions map[string]*managedSession
 	mu       sync.RWMutex
+}
+
+// managedSession keeps the session handle and replay state together so
+// subscription lifecycle changes stay under one owner.
+//
+//nolint:govet // fieldalignment: clarity is preferred over splitting this tiny state holder.
+type managedSession struct {
+	session        Session
+	history        []byte
+	subscribers    map[int]chan []byte
+	nextSubscriber int
+	closed         bool
+	mu             sync.Mutex
 }
 
 // NewManager creates a new session manager.
 func NewManager() *Manager {
 	return &Manager{
-		sessions: make(map[string]Session),
+		sessions: make(map[string]*managedSession),
 	}
 }
 
-// Add registers a session with the manager.
+// Add registers a session with the manager and starts buffering its output.
 func (m *Manager) Add(s Session) {
+	entry := &managedSession{
+		session:     s,
+		subscribers: make(map[int]chan []byte),
+	}
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.sessions[s.ID()] = s
+	m.sessions[s.ID()] = entry
+	m.mu.Unlock()
+
+	go entry.pump()
 }
 
 // Get retrieves a session by ID.
 func (m *Manager) Get(id string) (Session, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	s, ok := m.sessions[id]
-	return s, ok
+	entry, ok := m.sessions[id]
+	if !ok {
+		return nil, false
+	}
+	return entry.session, true
+}
+
+// Subscribe returns buffered output plus a live stream for the session.
+func (m *Manager) Subscribe(id string) ([]byte, <-chan []byte, func(), bool) {
+	m.mu.RLock()
+	entry, ok := m.sessions[id]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, nil, nil, false
+	}
+
+	snapshot, stream, unsubscribe := entry.subscribe()
+	return snapshot, stream, unsubscribe, true
 }
 
 // List returns all current sessions.
@@ -38,8 +77,8 @@ func (m *Manager) List() []Session {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	list := make([]Session, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		list = append(list, s)
+	for _, entry := range m.sessions {
+		list = append(list, entry.session)
 	}
 	return list
 }
@@ -47,7 +86,7 @@ func (m *Manager) List() []Session {
 // Remove closes and removes a session.
 func (m *Manager) Remove(id string) error {
 	m.mu.Lock()
-	s, ok := m.sessions[id]
+	entry, ok := m.sessions[id]
 	if ok {
 		delete(m.sessions, id)
 	}
@@ -56,20 +95,95 @@ func (m *Manager) Remove(id string) error {
 	if !ok {
 		return fmt.Errorf("session %s not found", id)
 	}
-	return s.Close()
+	return entry.session.Close()
 }
 
 // CloseAll closes all sessions.
 func (m *Manager) CloseAll() {
 	m.mu.Lock()
 	sessions := make([]Session, 0, len(m.sessions))
-	for _, s := range m.sessions {
-		sessions = append(sessions, s)
+	for _, entry := range m.sessions {
+		sessions = append(sessions, entry.session)
 	}
-	m.sessions = make(map[string]Session)
+	m.sessions = make(map[string]*managedSession)
 	m.mu.Unlock()
 
 	for _, s := range sessions {
 		s.Close()
+	}
+}
+
+func (m *managedSession) pump() {
+	buf := make([]byte, 4096)
+	for {
+		n, err := m.session.Read(buf)
+		if n > 0 {
+			chunk := append([]byte(nil), buf[:n]...)
+			m.publish(chunk)
+		}
+		if err != nil {
+			if err == io.EOF {
+				m.closeSubscribers()
+				return
+			}
+			m.closeSubscribers()
+			return
+		}
+	}
+}
+
+func (m *managedSession) publish(chunk []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.history = append(m.history, chunk...)
+	if len(m.history) > sessionReplayLimitBytes {
+		m.history = append([]byte(nil), m.history[len(m.history)-sessionReplayLimitBytes:]...)
+	}
+
+	for _, subscriber := range m.subscribers {
+		subscriber <- append([]byte(nil), chunk...)
+	}
+}
+
+func (m *managedSession) subscribe() ([]byte, <-chan []byte, func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snapshot := append([]byte(nil), m.history...)
+	ch := make(chan []byte, 64)
+	if m.closed {
+		close(ch)
+		return snapshot, ch, func() {}
+	}
+
+	subscriptionID := m.nextSubscriber
+	m.nextSubscriber++
+	m.subscribers[subscriptionID] = ch
+
+	unsubscribe := func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		subscriber, ok := m.subscribers[subscriptionID]
+		if !ok {
+			return
+		}
+		delete(m.subscribers, subscriptionID)
+		close(subscriber)
+	}
+
+	return snapshot, ch, unsubscribe
+}
+
+func (m *managedSession) closeSubscribers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	m.closed = true
+	for id, subscriber := range m.subscribers {
+		delete(m.subscribers, id)
+		close(subscriber)
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -35,6 +35,11 @@ func NewManager() *Manager {
 }
 
 // Add registers a session with the manager and starts buffering its output.
+//
+// The replay buffer exists because workspace switches unmount hidden panes in the
+// browser, which closes their WebSocket readers while the PTY keeps producing
+// bytes. Without a backend-side buffer, a pane that reconnects later only sees
+// fresh output and appears blank until the shell redraws.
 func (m *Manager) Add(s Session) {
 	entry := &managedSession{
 		session:     s,
@@ -60,6 +65,9 @@ func (m *Manager) Get(id string) (Session, bool) {
 }
 
 // Subscribe returns buffered output plus a live stream for the session.
+//
+// Callers are expected to send the snapshot before consuming the live stream so a
+// reconnected terminal reconstructs its recent screen contents immediately.
 func (m *Manager) Subscribe(id string) ([]byte, <-chan []byte, func(), bool) {
 	m.mu.RLock()
 	entry, ok := m.sessions[id]

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -147,3 +147,34 @@ func TestManager_Subscribe_ClosedSessionReturnsSnapshotAndClosedStream(t *testin
 		}
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestManagedSession_SubscribeStillWorksWhilePublishWaitsOnSlowSubscriber(t *testing.T) {
+	slowSubscriber := make(chan []byte, 1)
+	slowSubscriber <- []byte("already full")
+
+	entry := &managedSession{
+		subscribers: map[int]chan []byte{
+			0: slowSubscriber,
+		},
+	}
+
+	go entry.publish([]byte("next chunk"))
+
+	done := make(chan struct{})
+	go func() {
+		_, updates, unsubscribe := entry.subscribe()
+		unsubscribe()
+		select {
+		case _, ok := <-updates:
+			require.False(t, ok)
+		default:
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("subscribe blocked behind a slow subscriber")
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,4 +77,73 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+}
+
+func TestManager_Subscribe_ReplaysBufferedOutputAndStreamsNewOutput(t *testing.T) {
+	m := NewManager()
+	s := newMock("sess1")
+	m.Add(s)
+
+	_, err := s.Write([]byte("before"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		snapshot, updates, unsubscribe, ok := m.Subscribe("sess1")
+		if !ok {
+			return false
+		}
+		defer unsubscribe()
+
+		if string(snapshot) != "before" {
+			return false
+		}
+
+		_, err = s.Write([]byte("after"))
+		require.NoError(t, err)
+
+		select {
+		case got := <-updates:
+			return string(got) == "after"
+		case <-time.After(100 * time.Millisecond):
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestManager_Subscribe_ClosedSessionReturnsSnapshotAndClosedStream(t *testing.T) {
+	m := NewManager()
+	s := newMock("sess1")
+	m.Add(s)
+
+	_, err := s.Write([]byte("before close"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		snapshot, _, unsubscribe, ok := m.Subscribe("sess1")
+		if !ok {
+			return false
+		}
+		defer unsubscribe()
+		return string(snapshot) == "before close"
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, s.Close())
+
+	require.Eventually(t, func() bool {
+		snapshot, updates, unsubscribe, ok := m.Subscribe("sess1")
+		if !ok {
+			return false
+		}
+		defer unsubscribe()
+
+		if string(snapshot) != "before close" {
+			return false
+		}
+
+		select {
+		case _, stillOpen := <-updates:
+			return !stillOpen
+		case <-time.After(100 * time.Millisecond):
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -101,6 +101,9 @@ func (h *Handler) forwardTerminalOutput(
 	updates <-chan []byte,
 	sessionID string,
 ) {
+	// Replay the buffered bytes before streaming new output. This is what keeps a
+	// workspace switch from showing a blank xterm when the PTY already emitted the
+	// prompt while the pane was unmounted.
 	if len(snapshot) > 0 {
 		if err := conn.WriteMessage(websocket.BinaryMessage, snapshot); err != nil {
 			return

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -3,7 +3,6 @@ package ws
 
 import (
 	"encoding/json"
-	"io"
 	"log"
 	"net/http"
 	"time"
@@ -50,6 +49,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	snapshot, updates, unsubscribe, ok := h.manager.Subscribe(sessionID)
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	defer unsubscribe()
+
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		//nolint:gosec // G706: sessionID is a config-defined identifier
@@ -59,7 +65,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close() //nolint:errcheck
 
 	h.sendStatus(conn, "connected")
-	done := h.pipeTerminalToWebSocket(conn, sess, sessionID)
+	done := h.pipeTerminalToWebSocket(conn, sess, snapshot, updates, sessionID)
 	h.pipeWebSocketToTerminal(conn, sess, sessionID)
 	waitForTerminalPipe(done)
 }
@@ -76,12 +82,14 @@ func (h *Handler) sessionForRequest(w http.ResponseWriter, sessionID string) ses
 func (h *Handler) pipeTerminalToWebSocket(
 	conn *websocket.Conn,
 	sess session.Session,
+	snapshot []byte,
+	updates <-chan []byte,
 	sessionID string,
 ) <-chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		h.forwardTerminalOutput(conn, sess, sessionID)
+		h.forwardTerminalOutput(conn, sess, snapshot, updates, sessionID)
 	}()
 	return done
 }
@@ -89,24 +97,33 @@ func (h *Handler) pipeTerminalToWebSocket(
 func (h *Handler) forwardTerminalOutput(
 	conn *websocket.Conn,
 	sess session.Session,
+	snapshot []byte,
+	updates <-chan []byte,
 	sessionID string,
 ) {
-	buf := make([]byte, 4096)
-	for {
-		n, err := sess.Read(buf)
-		if n > 0 {
-			if writeErr := conn.WriteMessage(websocket.BinaryMessage, buf[:n]); writeErr != nil {
-				return
-			}
-		}
-		if err != nil {
-			if err != io.EOF {
-				//nolint:gosec // G706: sessionID is a config-defined identifier
-				log.Printf("session %s read error: %v", sessionID, err)
-			}
-			h.sendStatus(conn, "exited")
+	if len(snapshot) > 0 {
+		if err := conn.WriteMessage(websocket.BinaryMessage, snapshot); err != nil {
 			return
 		}
+	}
+
+	for chunk := range updates {
+		if len(chunk) == 0 {
+			continue
+		}
+		if writeErr := conn.WriteMessage(websocket.BinaryMessage, chunk); writeErr != nil {
+			return
+		}
+	}
+
+	if sess.State() == session.StateExited {
+		h.sendStatus(conn, "exited")
+		return
+	}
+
+	if sess.State() != session.StateConnected {
+		//nolint:gosec // G706: sessionID is a config-defined identifier
+		log.Printf("session %s stream closed in state %s", sessionID, sess.State())
 	}
 }
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -119,15 +119,12 @@ func (h *Handler) forwardTerminalOutput(
 		}
 	}
 
-	if sess.State() == session.StateExited {
-		h.sendStatus(conn, "exited")
-		return
-	}
-
 	if sess.State() != session.StateConnected {
 		//nolint:gosec // G706: sessionID is a config-defined identifier
 		log.Printf("session %s stream closed in state %s", sessionID, sess.State())
 	}
+
+	h.sendStatus(conn, "exited")
 }
 
 func (h *Handler) pipeWebSocketToTerminal(

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -170,6 +170,33 @@ func TestWS_SessionOutput_ReceivedAsBinary(t *testing.T) {
 	assert.Equal(t, []byte("terminal output"), data)
 }
 
+func TestWS_ReplaysBufferedOutputOnFirstConnect(t *testing.T) {
+	mgr := session.NewManager()
+	sess := newWsMock("s1")
+	mgr.Add(sess)
+	sess.out <- []byte("buffered prompt")
+	time.Sleep(50 * time.Millisecond)
+
+	srv := setupWSServer(mgr)
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv, "s1"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	defer sess.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, _, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.BinaryMessage, msgType)
+	assert.Equal(t, []byte("buffered prompt"), data)
+}
+
 func TestWS_ResizeMessage_ResizesSession(t *testing.T) {
 	mgr := session.NewManager()
 	sess := newWsMock("s1")

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -18,13 +18,16 @@ import (
 )
 
 // wsMockSession implements session.Session for WebSocket handler tests.
+//
+//nolint:govet // fieldalignment: test-only mock fields are grouped for readability.
 type wsMockSession struct {
 	id      string
+	state   session.State // configurable; defaults to StateConnected
+	closed  bool
 	out     chan []byte // data sent to WS client (session output)
 	in      chan []byte // data received from WS client (session input)
 	resizes chan [2]uint16
-	state   session.State // configurable; defaults to StateConnected
-	closed  bool
+	readErr error
 }
 
 func newWsMock(id string) *wsMockSession {
@@ -45,6 +48,9 @@ func (m *wsMockSession) State() session.State { return m.state }
 func (m *wsMockSession) Read(p []byte) (int, error) {
 	data, ok := <-m.out
 	if !ok {
+		if m.readErr != nil {
+			return 0, m.readErr
+		}
 		return 0, io.EOF
 	}
 	n := copy(p, data)
@@ -195,6 +201,41 @@ func TestWS_ReplaysBufferedOutputOnFirstConnect(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, websocket.BinaryMessage, msgType)
 	assert.Equal(t, []byte("buffered prompt"), data)
+}
+
+func TestWS_SendsExitedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {
+	mgr := session.NewManager()
+	sess := newWsMock("s1")
+	sess.state = session.StateDisconnected
+	sess.readErr = io.ErrUnexpectedEOF
+	mgr.Add(sess)
+	close(sess.out)
+	time.Sleep(50 * time.Millisecond)
+
+	srv := setupWSServer(mgr)
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv, "s1"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err := conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var connected ControlMessage
+	require.NoError(t, json.Unmarshal(data, &connected))
+	assert.Equal(t, "connected", connected.State)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var exited ControlMessage
+	require.NoError(t, json.Unmarshal(data, &exited))
+	assert.Equal(t, "exited", exited.State)
 }
 
 func TestWS_ResizeMessage_ResizesSession(t *testing.T) {


### PR DESCRIPTION
## Summary

- replay the most recent terminal output when a pane reconnects after a workspace switch or reload
- delay the initial frontend resize until xterm has a non-zero size and buffer messages until the terminal is attached
- add a Playwright E2E regression that verifies a previously hidden workspace does not render a blank terminal when first selected
- document the new reconnect and replay behavior for inactive workspace panes

## Root cause

Inactive workspace panes were unmounted, so their WebSocket readers disappeared while the backend PTY kept producing output. When the pane reconnected, the backend only sent a `connected` status and then streamed new bytes, which left panes blank until some later interaction caused fresh shell output to appear.

## Impact

Workspace switches now restore the recent terminal contents immediately instead of showing an empty pane. The frontend also avoids dropping early output or sending a `0x0` resize during reconnect, and CI now keeps a real-browser regression for this class of bug.

## Test plan

- [x] `make test-frontend`
- [x] `make test-go`
- [x] `make test-e2e`
- [x] `make lint-frontend`
- [x] `make lint-go`
