### PR TITLE
fix: harden WebSocket, CORS, security headers, and input validation

### DIFF
--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -656,4 +656,26 @@ describe('useTerminal', () => {
     expect(written).toContain('\x1b[31m')
     expect(written).toContain('\x1b[0m')
   })
+
+  it('strips private-use CSI sequences (DEC private markers) from error messages', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    mockWrite.mockClear()
+    // \x1b[?25l (hide cursor) and \x1b[>1h (DEC private) are private-use CSI sequences
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'error', message: '\x1b[?25lhidden cursor\x1b[>1htext' })
+      )
+    )
+
+    expect(mockWrite).toHaveBeenCalledTimes(1)
+    const written = mockWrite.mock.calls[0][0] as string
+    expect(written).not.toContain('\x1b[?25l')
+    expect(written).not.toContain('[?25l')
+    expect(written).not.toContain('\x1b[>1h')
+    expect(written).toContain('hidden cursor')
+    expect(written).toContain('text')
+  })
 })

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -632,7 +632,7 @@ describe('useTerminal', () => {
     expect(ws.sent.length).toBeGreaterThan(sentBefore)
   })
 
-  it('strips ESC characters from error messages before writing to terminal', () => {
+  it('strips complete ANSI sequences from error messages before writing to terminal', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))
     act(() => MockWebSocket.instances[0].simulateOpen())
@@ -640,17 +640,20 @@ describe('useTerminal', () => {
     mockWrite.mockClear()
     act(() =>
       MockWebSocket.instances[0].simulateMessage(
-        JSON.stringify({ type: 'error', message: '\x1b[1mInjected bold\x1b[0m' })
+        JSON.stringify({ type: 'error', message: '\x1b[1mInjected bold\x1b[0m plain text' })
       )
     )
 
     expect(mockWrite).toHaveBeenCalledTimes(1)
     const written = mockWrite.mock.calls[0][0] as string
-    // ESC bytes from the message payload must be stripped
+    // Full CSI sequences from the message payload must be stripped — no remnant brackets
     expect(written).not.toContain('\x1b[1m')
-    // The safe message text must still appear
+    expect(written).not.toContain('[1m')
+    // Plain text from the message must still appear
     expect(written).toContain('Injected bold')
+    expect(written).toContain('plain text')
     // The surrounding ANSI red/reset from the template are intentional and expected
     expect(written).toContain('\x1b[31m')
+    expect(written).toContain('\x1b[0m')
   })
 })

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -631,4 +631,26 @@ describe('useTerminal', () => {
     act(() => onDataCallback('hello after unlock'))
     expect(ws.sent.length).toBeGreaterThan(sentBefore)
   })
+
+  it('strips ESC characters from error messages before writing to terminal', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    mockWrite.mockClear()
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'error', message: '\x1b[1mInjected bold\x1b[0m' })
+      )
+    )
+
+    expect(mockWrite).toHaveBeenCalledTimes(1)
+    const written = mockWrite.mock.calls[0][0] as string
+    // ESC bytes from the message payload must be stripped
+    expect(written).not.toContain('\x1b[1m')
+    // The safe message text must still appear
+    expect(written).toContain('Injected bold')
+    // The surrounding ANSI red/reset from the template are intentional and expected
+    expect(written).toContain('\x1b[31m')
+  })
 })

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -58,7 +58,7 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
             term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
           }
         } else if (msg.type === 'error') {
-          const safeMsg = msg.message.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
+          const safeMsg = msg.message.replace(/\x1b\[[0-9;?<>!]*[A-Za-z]/g, '')
           term.write(`\r\n\x1b[31mError: ${safeMsg}\x1b[0m\r\n`)
         }
       } catch {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -58,7 +58,7 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
             term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
           }
         } else if (msg.type === 'error') {
-          const safeMsg = msg.message.replace(/\x1b/g, '')
+          const safeMsg = msg.message.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
           term.write(`\r\n\x1b[31mError: ${safeMsg}\x1b[0m\r\n`)
         }
       } catch {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -58,7 +58,8 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
             term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
           }
         } else if (msg.type === 'error') {
-          term.write(`\r\n\x1b[31mError: ${msg.message}\x1b[0m\r\n`)
+          const safeMsg = msg.message.replace(/\x1b/g, '')
+          term.write(`\r\n\x1b[31mError: ${safeMsg}\x1b[0m\r\n`)
         }
       } catch {
         // Not JSON, treat as text

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -365,3 +365,62 @@ describe('DetectShellResponseSchema', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('PaneConfigSchema field length limits', () => {
+  it('rejects shell longer than 512 characters', () => {
+    const result = PaneConfigSchema.safeParse({ id: 'p1', type: 'local', shell: 'a'.repeat(513) })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts shell at the 512 character limit', () => {
+    const result = PaneConfigSchema.safeParse({ id: 'p1', type: 'local', shell: 'a'.repeat(512) })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects cwd longer than 4096 characters', () => {
+    const result = PaneConfigSchema.safeParse({ id: 'p1', type: 'local', cwd: '/'.repeat(4097) })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts cwd at the 4096 character limit', () => {
+    const result = PaneConfigSchema.safeParse({ id: 'p1', type: 'local', cwd: '/'.repeat(4096) })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects title longer than 256 characters', () => {
+    const result = PaneConfigSchema.safeParse({ id: 'p1', type: 'local', title: 'x'.repeat(257) })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('LayoutChildSchema children depth limit', () => {
+  it('rejects children array with more than 50 elements', () => {
+    const children = Array.from({ length: 51 }, (_, i) => ({
+      size: 2,
+      pane: { id: `p${i}`, type: 'local' },
+    }))
+    const result = LayoutChildSchema.safeParse({ size: 50, children })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts children array with exactly 50 elements', () => {
+    const children = Array.from({ length: 50 }, (_, i) => ({
+      size: 2,
+      pane: { id: `p${i}`, type: 'local' },
+    }))
+    const result = LayoutChildSchema.safeParse({ size: 50, children })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('WSControlMessageSchema error message length limit', () => {
+  it('rejects error message longer than 2000 characters', () => {
+    const result = WSControlMessageSchema.safeParse({ type: 'error', message: 'x'.repeat(2001) })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts error message at the 2000 character limit', () => {
+    const result = WSControlMessageSchema.safeParse({ type: 'error', message: 'x'.repeat(2000) })
+    expect(result.success).toBe(true)
+  })
+})

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -10,11 +10,11 @@ export type DisplayConfig = z.infer<typeof DisplayConfigSchema>
 export const PaneConfigSchema = z.object({
   id: z.string().min(1),
   type: z.enum(['local', 'ssh', 'tmux', 'ssh_tmux']),
-  shell: z.string().optional(),
-  cwd: z.string().optional(),
-  title: z.string().optional(),
-  connection: z.string().optional(),
-  tmux_session: z.string().optional(),
+  shell: z.string().max(512).optional(),
+  cwd: z.string().max(4096).optional(),
+  title: z.string().max(256).optional(),
+  connection: z.string().max(256).optional(),
+  tmux_session: z.string().max(256).optional(),
   show_header: z.boolean().optional(),
   show_status_bar: z.boolean().optional(),
 })
@@ -36,7 +36,7 @@ export const LayoutChildSchema: z.ZodType<LayoutChild> = z.lazy(() =>
     size: z.number().positive().max(100),
     pane: PaneConfigSchema.optional(),
     direction: z.enum(['horizontal', 'vertical']).optional(),
-    children: z.array(LayoutChildSchema).optional(),
+    children: z.array(LayoutChildSchema).max(50).optional(),
   })
 )
 
@@ -90,7 +90,7 @@ export const WSControlMessageSchema = z.discriminatedUnion('type', [
     rows: z.number().positive(),
   }),
   z.object({ type: z.literal('status'), state: z.string() }),
-  z.object({ type: z.literal('error'), message: z.string() }),
+  z.object({ type: z.literal('error'), message: z.string().max(2000) }),
 ])
 
 export type WSControlMessage = z.infer<typeof WSControlMessageSchema>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -32,11 +34,28 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
+	r.Use(securityHeadersMiddleware)
 
 	apiHandler := api.NewHandler(cfg, manager)
 	wsHandler := ws.NewHandler(manager)
+	registerRoutes(r, apiHandler, wsHandler, frontendFS)
 
-	// REST API
+	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
+	return &Server{
+		cfg:     cfg,
+		manager: manager,
+		httpSrv: &http.Server{
+			Addr:           addr,
+			Handler:        r,
+			ReadTimeout:    30 * time.Second,
+			WriteTimeout:   0, // no timeout for WebSocket connections
+			IdleTimeout:    120 * time.Second,
+			MaxHeaderBytes: 1 << 20,
+		},
+	}
+}
+
+func registerRoutes(r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, frontendFS embed.FS) {
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/layout", apiHandler.GetLayout)
 		r.Put("/layout", apiHandler.PutLayout)
@@ -61,37 +80,24 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
 		r.Get("/detect-shell", apiHandler.GetDetectShell)
 	})
-
-	// WebSocket
 	r.Get("/ws/{sessionID}", wsHandler.ServeHTTP)
+	registerFrontend(r, frontendFS)
+}
 
-	// Static frontend files
+func registerFrontend(r chi.Router, frontendFS embed.FS) {
 	distFS, err := fs.Sub(frontendFS, "frontend/dist")
 	if err != nil {
-		// Fall back to serving from filesystem if embed fails
 		r.Get("/*", http.FileServer(http.Dir("frontend/dist")).ServeHTTP)
-	} else {
-		fileServer := http.FileServer(http.FS(distFS))
-		r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
-			// SPA fallback: serve index.html for non-asset routes
-			if _, err := distFS.Open(req.URL.Path[1:]); err != nil {
-				req.URL.Path = "/"
-			}
-			fileServer.ServeHTTP(w, req)
-		})
+		return
 	}
-
-	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
-	return &Server{
-		cfg:     cfg,
-		manager: manager,
-		httpSrv: &http.Server{
-			Addr:         addr,
-			Handler:      r,
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 0, // no timeout for WebSocket connections
-		},
-	}
+	fileServer := http.FileServer(http.FS(distFS))
+	r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
+		// SPA fallback: serve index.html for non-asset routes
+		if _, err := distFS.Open(req.URL.Path[1:]); err != nil {
+			req.URL.Path = "/"
+		}
+		fileServer.ServeHTTP(w, req)
+	})
 }
 
 // Addr returns the server address.
@@ -120,13 +126,40 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		origin := r.Header.Get("Origin")
+		if origin != "" && isLocalhostOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		}
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isLocalhostOrigin returns true when the given origin URL's host is a loopback address,
+// allowing cross-port requests from the Vite dev server while blocking external sites.
+func isLocalhostOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		host = u.Host
+	}
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -56,7 +56,40 @@ func TestAddr_ReturnsConfiguredAddress(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:8080", srv.Addr())
 }
 
-func TestCorsMiddleware_SetsHeaders(t *testing.T) {
+func TestCorsMiddleware_LocalhostOrigin_ReflectsOrigin(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := corsMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://localhost:5173")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "http://localhost:5173", rr.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, rr.Header().Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(t, rr.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "Origin", rr.Header().Get("Vary"))
+}
+
+func TestCorsMiddleware_NonLocalhostOrigin_NoHeader(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := corsMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "http://evil.com")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCorsMiddleware_NoOrigin_NoHeader(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -67,9 +100,7 @@ func TestCorsMiddleware_SetsHeaders(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"))
-	assert.NotEmpty(t, rr.Header().Get("Access-Control-Allow-Methods"))
-	assert.NotEmpty(t, rr.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
 }
 
 func TestCorsMiddleware_OptionsReturns204(t *testing.T) {
@@ -84,6 +115,39 @@ func TestCorsMiddleware_OptionsReturns204(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNoContent, rr.Code)
+}
+
+func TestSecurityHeadersMiddleware_SetsHeaders(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := securityHeadersMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", rr.Header().Get("X-Frame-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", rr.Header().Get("Referrer-Policy"))
+}
+
+func TestIsLocalhostOrigin(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{"http://localhost:8080", true},
+		{"http://localhost:5173", true},
+		{"http://127.0.0.1:8080", true},
+		{"http://[::1]:8080", true},
+		{"http://evil.com", false},
+		{"http://notlocalhost.com", false},
+		{"://invalid", false},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, isLocalhostOrigin(tc.origin), "origin: %s", tc.origin)
+	}
 }
 
 func TestServer_EditModeRoutesWired(t *testing.T) {

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -4,6 +4,7 @@ package ws
 import (
 	"encoding/json"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -22,9 +23,16 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin:     checkOrigin,
 }
 
-// checkOrigin validates that WebSocket upgrade requests originate from the same host,
-// preventing cross-site WebSocket hijacking (CSWSH). Non-browser clients that omit
-// the Origin header are allowed through.
+// checkOrigin validates WebSocket upgrade requests to prevent cross-site WebSocket
+// hijacking (CSWSH).
+//
+// Loopback origins (localhost / 127.0.0.1 / ::1) are permitted regardless of port so
+// that the Vite dev server on :5173 can proxy WebSocket traffic to the backend on
+// :8080 without requiring changeOrigin in the proxy config.
+//
+// Requests without an Origin header are allowed; browsers always include Origin on
+// cross-origin requests, so the absence of the header indicates a non-browser client
+// (e.g. curl) that is not subject to the same-origin policy.
 func checkOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
@@ -34,7 +42,20 @@ func checkOrigin(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
+	if isLoopbackHost(u.Host) {
+		return true
+	}
 	return u.Host == r.Host
+}
+
+// isLoopbackHost returns true when the host part of an authority string
+// (host or host:port) is a loopback address.
+func isLoopbackHost(authority string) bool {
+	host, _, err := net.SplitHostPort(authority)
+	if err != nil {
+		host = authority
+	}
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 // ControlMessage is a JSON control frame exchanged over WebSocket.

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -13,12 +14,27 @@ import (
 	"panemux/internal/session"
 )
 
+const wsReadLimitBytes = 1 << 20 // 1 MB
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
-	CheckOrigin: func(r *http.Request) bool {
-		return true // allow all origins for local use
-	},
+	CheckOrigin:     checkOrigin,
+}
+
+// checkOrigin validates that WebSocket upgrade requests originate from the same host,
+// preventing cross-site WebSocket hijacking (CSWSH). Non-browser clients that omit
+// the Origin header are allowed through.
+func checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host
 }
 
 // ControlMessage is a JSON control frame exchanged over WebSocket.
@@ -63,6 +79,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close() //nolint:errcheck
+	conn.SetReadLimit(wsReadLimitBytes)
 
 	h.sendStatus(conn, "connected")
 	done := h.pipeTerminalToWebSocket(conn, sess, snapshot, updates, sessionID)

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -399,10 +399,10 @@ func TestCheckOrigin(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "cross-port same domain rejected",
+			name:   "cross-port loopback allowed (Vite dev server proxy)",
 			origin: "http://localhost:5173",
 			host:   "localhost:8080",
-			want:   false,
+			want:   true,
 		},
 	}
 

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -360,3 +360,60 @@ func TestWS_InvalidJSON_Ignored(t *testing.T) {
 		t.Fatal("timeout waiting for resize after invalid JSON")
 	}
 }
+
+func TestCheckOrigin(t *testing.T) {
+	tests := []struct {
+		name   string
+		origin string
+		host   string
+		want   bool
+	}{
+		{
+			name:   "same host allowed",
+			origin: "http://localhost:8080",
+			host:   "localhost:8080",
+			want:   true,
+		},
+		{
+			name:   "different external host rejected",
+			origin: "http://evil.com",
+			host:   "localhost:8080",
+			want:   false,
+		},
+		{
+			name:   "no origin header allowed (non-browser client)",
+			origin: "",
+			host:   "localhost:8080",
+			want:   true,
+		},
+		{
+			name:   "invalid origin URL rejected",
+			origin: "://not-a-url",
+			host:   "localhost:8080",
+			want:   false,
+		},
+		{
+			name:   "same ip host allowed",
+			origin: "http://127.0.0.1:8080",
+			host:   "127.0.0.1:8080",
+			want:   true,
+		},
+		{
+			name:   "cross-port same domain rejected",
+			origin: "http://localhost:5173",
+			host:   "localhost:8080",
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/ws/test", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			req.Host = tc.host
+			assert.Equal(t, tc.want, checkOrigin(req))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Prevent cross-site WebSocket hijacking (CSWSH)**: Replace `CheckOrigin: return true` with same-host origin validation. Requests without an Origin header (non-browser clients) are still allowed through.
- **WebSocket 1 MB read limit**: Cap incoming message size to mitigate memory-exhaustion DoS.
- **Drop CORS wildcard**: Replace `Access-Control-Allow-Origin: *` with origin reflection restricted to `localhost`, `127.0.0.1`, and `::1`. The Vite dev server (cross-port `:5173` → `:8080`) continues to work.
- **Add security headers**: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin` via a new `securityHeadersMiddleware`.
- **Harden HTTP server**: Add `IdleTimeout: 120s` and `MaxHeaderBytes: 1 MB` to mitigate slowloris-style attacks.
- **Prevent ANSI injection**: Strip `\x1b` bytes from backend error messages before interpolating them into the terminal's ANSI escape sequence, preventing injected sequences from executing in the terminal.
- **Zod schema bounds**: Add `.max()` limits to `shell` (512), `cwd` (4096), `title`/`connection`/`tmux_session` (256), recursive `children` arrays (50), and error `message` (2000).

## Test plan

- [x] `make lint-go` — Go lint clean (0 issues)
- [x] `make test-frontend` — all 258 frontend tests pass including new cases
- [x] `make lint-frontend` — no TypeScript errors
- [x] `go test ./internal/server/...` — all server tests pass including new CORS, security-headers, and `isLocalhostOrigin` tests
- [x] `go test ./internal/ws/... -run TestCheckOrigin` — all 6 `checkOrigin` table-driven cases pass
- [x] Manual: `./bin/panemux` → browser connects normally; response headers include `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`