### PR TITLE
feat: expand approval prompt notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ Use edit mode when you want to:
 ### Notifications and attention prompts
 
 - panemux watches terminal output for agent confirmation prompts such as approval or proceed requests.
+- Codex permission menus such as MCP tool allow prompts are detected too.
 - When one is detected, the pane frame is highlighted.
 - If the pane belongs to an inactive workspace, that workspace tab is highlighted too.
-- Browser notifications are also shown after notification permission has been granted.
+- Browser notifications are also shown after notification permission has been granted, and clicking one switches to the matching workspace.
 - Notification permission is requested on the first browser interaction, instead of waiting for the first prompt.
 
 ### Choosing pane types
@@ -188,7 +189,7 @@ workspaces:
 
 Older config files with a top-level `layout:` are still accepted. When the config is next saved, panemux migrates that layout into a `default` workspace and writes the `workspaces:` format.
 
-If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add and tab-position controls; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab can be renamed inline and has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace and changing `tab_position` are persisted so the same workspace and tab placement are restored after restart. Agent confirmation prompts can mark inactive workspace tabs and trigger browser notifications after notification permission has been granted.
+If there is only one workspace, the workspace tab bar is hidden during normal use. Enable edit mode to show the workspace add and tab-position controls; newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. In edit mode, each visible workspace tab can be renamed inline and has a delete button that asks for confirmation before removing the workspace. The last remaining workspace cannot be deleted. Switching the active workspace and changing `tab_position` are persisted so the same workspace and tab placement are restored after restart. Agent confirmation prompts, including Codex MCP allow menus, can mark inactive workspace tabs and trigger browser notifications after notification permission has been granted. Clicking the notification switches to the relevant workspace.
 
 ### Pane types
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -108,13 +108,15 @@ Persistence behavior:
 ## Agent Attention Notifications
 
 The frontend watches terminal output for conservative agent confirmation prompts such as approval,
-permission, or proceed requests. Detection runs in the frontend and keeps a lightweight background
-WebSocket subscription for every pane across every workspace, so hidden workspaces are still watched
-even while their xterm instances are unmounted. When a prompt is detected:
+permission, proceed requests, and Codex MCP allow menus. Detection runs in the frontend and keeps a
+lightweight background WebSocket subscription for every pane across every workspace, so hidden
+workspaces are still watched even while their xterm instances are unmounted. When a prompt is
+detected:
 
 - the pane frame flashes until the pane receives focus or a click
 - the containing workspace tab flashes when that workspace is not active, and clears when selected
 - the browser Notification API is used when permission has already been granted
+- clicking a browser notification focuses the app window and switches to the matching workspace
 - if notification permission is undecided, the browser is asked on the first pointer or key
   interaction instead of waiting for the first prompt event
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -37,6 +37,7 @@ let currentWorkspaces = workspaces
 const mockDeleteWorkspace = vi.fn()
 const mockRenameWorkspace = vi.fn()
 const mockSetWorkspaceTabPosition = vi.fn()
+const mockSetActiveWorkspace = vi.fn()
 const mockUseWorkspaceAttentionMonitor = vi.hoisted(() => vi.fn())
 const mockUseBrowserNotificationPermission = vi.hoisted(() => vi.fn())
 
@@ -50,7 +51,7 @@ vi.mock('./hooks/useLayout', () => ({
     splitPane: vi.fn(),
     closePane: vi.fn(),
     swapPanes: vi.fn(),
-    setActiveWorkspace: vi.fn(),
+    setActiveWorkspace: mockSetActiveWorkspace,
     addWorkspace: vi.fn(),
     deleteWorkspace: mockDeleteWorkspace,
     renameWorkspace: mockRenameWorkspace,
@@ -87,12 +88,20 @@ vi.mock('./hooks/usePaneSettings', () => ({
 
 describe('App workspace deletion', () => {
   let originalNotification: typeof Notification | undefined
+  let notificationInstance: { onclick: (() => void) | null; close: ReturnType<typeof vi.fn> } | null
 
   beforeEach(() => {
     originalNotification = window.Notification
     mockUseWorkspaceAttentionMonitor.mockImplementation(() => {})
     mockUseBrowserNotificationPermission.mockImplementation(() => {})
-    vi.stubGlobal('Notification', vi.fn() as unknown as typeof Notification)
+    notificationInstance = null
+    vi.stubGlobal('Notification', vi.fn(function MockNotification(this: Notification) {
+      notificationInstance = {
+        onclick: null,
+        close: vi.fn(),
+      }
+      return notificationInstance as unknown as Notification
+    }) as unknown as typeof Notification)
     Object.defineProperty(window.Notification, 'permission', {
       configurable: true,
       value: 'granted',
@@ -107,6 +116,7 @@ describe('App workspace deletion', () => {
     mockDeleteWorkspace.mockClear()
     mockRenameWorkspace.mockClear()
     mockSetWorkspaceTabPosition.mockClear()
+    mockSetActiveWorkspace.mockClear()
     mockTerminalPane.mockClear()
     mockUseWorkspaceAttentionMonitor.mockReset()
     mockUseBrowserNotificationPermission.mockReset()
@@ -228,6 +238,24 @@ describe('App workspace deletion', () => {
     expect(window.Notification).toHaveBeenCalledWith('Agent confirmation requested', {
       body: 'main in Dev',
     })
+  })
+
+  it('switches to the relevant workspace when the browser notification is clicked', () => {
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {})
+
+    mockUseWorkspaceAttentionMonitor.mockImplementation(({ onAttention }: { onAttention: (paneId: string) => void }) => {
+      useEffect(() => {
+        onAttention('main')
+      }, [onAttention])
+    })
+
+    render(<App />)
+    notificationInstance?.onclick?.()
+
+    expect(focusSpy).toHaveBeenCalled()
+    expect(mockSetActiveWorkspace).toHaveBeenCalledWith('dev')
+    expect(notificationInstance?.close).toHaveBeenCalled()
   })
 
   it('does not mark the active workspace tab when attention comes from the active workspace', () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -243,6 +243,7 @@ describe('App workspace deletion', () => {
   it('switches to the relevant workspace when the browser notification is clicked', () => {
     currentWorkspaces = { ...workspaces, active: 'ops' }
     const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => {})
+    mockSetActiveWorkspace.mockResolvedValue(undefined)
 
     mockUseWorkspaceAttentionMonitor.mockImplementation(({ onAttention }: { onAttention: (paneId: string) => void }) => {
       useEffect(() => {
@@ -256,6 +257,26 @@ describe('App workspace deletion', () => {
     expect(focusSpy).toHaveBeenCalled()
     expect(mockSetActiveWorkspace).toHaveBeenCalledWith('dev')
     expect(notificationInstance?.close).toHaveBeenCalled()
+  })
+
+  it('logs workspace switch failures from notification clicks', async () => {
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    const switchError = new Error('switch failed')
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(window, 'focus').mockImplementation(() => {})
+    mockSetActiveWorkspace.mockRejectedValueOnce(switchError)
+
+    mockUseWorkspaceAttentionMonitor.mockImplementation(({ onAttention }: { onAttention: (paneId: string) => void }) => {
+      useEffect(() => {
+        onAttention('main')
+      }, [onAttention])
+    })
+
+    render(<App />)
+    notificationInstance?.onclick?.()
+    await Promise.resolve()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(switchError)
   })
 
   it('does not mark the active workspace tab when attention comes from the active workspace', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -96,7 +96,7 @@ export const App: React.FC = () => {
       workspaceTitle ? `${paneTitle} in ${workspaceTitle}` : paneTitle,
       workspace ? () => {
         window.focus()
-        void setActiveWorkspace(workspace.id)
+        setActiveWorkspace(workspace.id).catch(console.error)
       } : undefined,
     )
   }, [findWorkspaceForPane, layout, paneMetadataByID, setActiveWorkspace, workspaces])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,8 +94,12 @@ export const App: React.FC = () => {
     showBrowserNotification(
       'Agent confirmation requested',
       workspaceTitle ? `${paneTitle} in ${workspaceTitle}` : paneTitle,
+      workspace ? () => {
+        window.focus()
+        void setActiveWorkspace(workspace.id)
+      } : undefined,
     )
-  }, [findWorkspaceForPane, layout, paneMetadataByID, workspaces])
+  }, [findWorkspaceForPane, layout, paneMetadataByID, setActiveWorkspace, workspaces])
 
   useWorkspaceAttentionMonitor({ workspaces, onAttention: notifyAttention })
   useBrowserNotificationPermission()
@@ -227,12 +231,18 @@ export const App: React.FC = () => {
   )
 }
 
-function showBrowserNotification(title: string, body: string) {
+function showBrowserNotification(title: string, body: string, onClick?: () => void) {
   if (!('Notification' in window)) return
 
   if (Notification.permission !== 'granted') return
 
-  new Notification(title, { body })
+  const notification = new Notification(title, { body })
+  if (onClick) {
+    notification.onclick = () => {
+      onClick()
+      notification.close()
+    }
+  }
 }
 
 function collectPaneMetadata(

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -104,6 +104,69 @@ describe('createAgentAttentionDetector', () => {
     ).toBe(true)
   })
 
+  it('detects Codex MCP approval menus with allow options', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Field 1/1',
+          'Allow the maestro MCP server to run tool "query_docs"?',
+          '',
+          'question: Ignore this if not relevant.',
+          '',
+          '› 1. Allow                   Run the tool and continue.',
+          '  2. Allow for this session  Run the tool and remember this choice for this session.',
+          '  3. Always allow            Run the tool and remember this choice for future tool calls.',
+          '  4. Cancel                  Cancel this tool call',
+          'enter to submit | esc to cancel',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects Codex MCP approval menus for other servers and tools', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Field 1/1',
+          'Allow the github MCP server to run tool "list_pull_requests"?',
+          '',
+          'question: Ignore this if not relevant.',
+          '',
+          '› 1. Allow                   Run the tool and continue.',
+          '  2. Allow for this session  Run the tool and remember this choice for this session.',
+          '  3. Always allow            Run the tool and remember this choice for future tool calls.',
+          '  4. Cancel                  Cancel this tool call',
+          'enter to submit | esc to cancel',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
+  it('detects non-MCP allow menus with the same Codex approval structure', () => {
+    const detector = createAgentAttentionDetector()
+
+    expect(
+      detector.feed(
+        [
+          'Field 1/1',
+          'Allow access to workspace "production"?',
+          '',
+          'question: Ignore this if not relevant.',
+          '',
+          '› 1. Allow                   Run the tool and continue.',
+          '  2. Allow for this session  Run the tool and remember this choice for this session.',
+          '  3. Always allow            Run the tool and remember this choice for future tool calls.',
+          '  4. Cancel                  Cancel this tool call',
+          'enter to submit | esc to cancel',
+        ].join('\n'),
+      ),
+    ).toBe(true)
+  })
+
   it('does not match ordinary terminal output', () => {
     const detector = createAgentAttentionDetector()
 

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -4,6 +4,7 @@ const ATTENTION_PATTERNS = [
   /\b(codex|claude|agent)\b[\s\S]{0,160}\b(confirm|confirmation|approve|approval|permission|allow|proceed)\b/i,
   /\bYes,\s*proceed\s*\(y\)[\s\S]{0,160}\bNo,\s*and\s*tell\s+(Codex|Claude|agent)\s+what\s+to\s+do\s+differently\s*\(esc\)/i,
   /Do you want to proceed\?[\s\S]{0,120}\b1\.\s*Yes\b[\s\S]{0,80}\b2\.\s*No\b[\s\S]{0,160}Esc to cancel\s*·\s*Tab to amend\s*·\s*ctrl\+e to explain/i,
+  /Allow [^\n]+\?[\s\S]{0,240}\b1\.\s*Allow\b[\s\S]{0,160}\b2\.\s*Allow for this session\b[\s\S]{0,160}\b3\.\s*Always allow\b[\s\S]{0,160}\b4\.\s*Cancel\b[\s\S]{0,120}enter to submit\s*\|\s*esc to cancel/i,
   /(確認|承認|許可)[\s\S]{0,120}(必要|してください|しますか|待ち)/,
 ]
 


### PR DESCRIPTION
## Summary
- expand approval prompt detection beyond specific MCP server and tool names
- switch to the relevant workspace when a browser attention notification is clicked
- document the broader approval prompt detection and notification click behavior

## Test Plan
- [x] make lint-frontend
- [x] make test-frontend
