### PR TITLE
fix: reduce duplicate attention notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Use edit mode when you want to:
 - Codex permission menus such as MCP tool allow prompts are detected too.
 - When one is detected, the pane frame is highlighted.
 - If the pane belongs to an inactive workspace, that workspace tab is highlighted too.
-- Browser notifications are also shown after notification permission has been granted, and clicking one switches to the matching workspace.
+- Browser notifications are shown after notification permission has been granted only when the prompt is not currently visible to the user, and clicking one switches to the matching workspace.
+- panemux remembers the last browser-notified prompt per pane, so refreshes, reconnects, and maximize toggles do not re-notify the same prompt replay.
 - Notification permission is requested on the first browser interaction, instead of waiting for the first prompt.
 
 ### Choosing pane types

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,7 +153,17 @@ Why this hook:
 
 - decouples prompt notifications from visible xterm mounts
 - keeps inactive workspace attention behavior consistent with active panes
-- centralizes per-pane throttle and stream decoding logic
+- centralizes per-pane stream decoding, visibility gating, and last-notified dedupe
+
+The hook derives browser-notification eligibility from:
+
+- active workspace id
+- maximized pane id
+- browser activity via `document.visibilityState` and `document.hasFocus()`
+
+Each detected prompt is normalized into a stable signature. The last signature that produced a
+browser notification is persisted per pane in browser storage, so terminal replay after a refresh or
+WebSocket reconnect does not re-notify the same prompt.
 
 ### `useBrowserNotificationPermission`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -115,10 +115,25 @@ detected:
 
 - the pane frame flashes until the pane receives focus or a click
 - the containing workspace tab flashes when that workspace is not active, and clears when selected
-- the browser Notification API is used when permission has already been granted
+- the browser Notification API is used when permission has already been granted and the prompt is not currently visible to the user
 - clicking a browser notification focuses the app window and switches to the matching workspace
 - if notification permission is undecided, the browser is asked on the first pointer or key
   interaction instead of waiting for the first prompt event
+
+Browser notification eligibility is determined by the current UI state:
+
+| Browser state | Pane state | Browser notification |
+|---|---|---|
+| active | visible in the active workspace | no |
+| active | hidden in another workspace | yes |
+| active | hidden by maximize in the active workspace | yes |
+| inactive | any pane | yes |
+
+To suppress redraw noise, panemux stores the last browser-notified prompt signature per pane in
+browser storage. If the same pane replays the same prompt after a refresh, reconnect, or layout
+change, the pane and workspace attention indicators can still reappear, but the browser
+notification is not shown again. When the same pane later emits a different prompt, the stored
+signature is replaced and the new prompt can notify again.
 
 Attention detection remains frontend-only. The backend still buffers recent terminal output per
 session and replays that snapshot when a pane reconnects after a workspace switch or browser reload,

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -309,4 +309,17 @@ describe('App workspace deletion', () => {
     expect(window.Notification.requestPermission).not.toHaveBeenCalled()
     expect(window.Notification).not.toHaveBeenCalled()
   })
+
+  it('does not show a browser notification when attention is already visible', () => {
+    currentWorkspaces = { ...workspaces, active: 'dev' }
+    mockUseWorkspaceAttentionMonitor.mockImplementation(({ onAttention }: { onAttention: (paneId: string, showBrowserNotification?: boolean) => void }) => {
+      useEffect(() => {
+        onAttention('main', false)
+      }, [onAttention])
+    })
+
+    render(<App />)
+
+    expect(window.Notification).not.toHaveBeenCalled()
+  })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,7 +83,7 @@ export const App: React.FC = () => {
     })
   }, [])
 
-  const notifyAttention = useCallback((paneId: string) => {
+  const notifyAttention = useCallback((paneId: string, showNotification = true) => {
     const paneMetadata = paneMetadataByID.get(paneId)
     const workspace = paneMetadata ? workspaces?.items.find((item) => item.id === paneMetadata.workspaceId) ?? null : findWorkspaceForPane(paneId)
     const pane = workspace ? findPaneById(workspace.layout, paneId) : layout ? findPaneById(layout, paneId) : null
@@ -91,6 +91,8 @@ export const App: React.FC = () => {
     const workspaceTitle = paneMetadata?.workspaceTitle ?? workspace?.title
 
     setAttentionPaneIds((current) => new Set(current).add(paneId))
+    if (!showNotification) return
+
     showBrowserNotification(
       'Agent confirmation requested',
       workspaceTitle ? `${paneTitle} in ${workspaceTitle}` : paneTitle,
@@ -101,7 +103,7 @@ export const App: React.FC = () => {
     )
   }, [findWorkspaceForPane, layout, paneMetadataByID, setActiveWorkspace, workspaces])
 
-  useWorkspaceAttentionMonitor({ workspaces, onAttention: notifyAttention })
+  useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAttention: notifyAttention })
   useBrowserNotificationPermission()
 
   const handleAddSSHHost = useCallback(async (host: SSHConfigHost) => {

--- a/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
+++ b/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
@@ -126,6 +126,37 @@ describe('useWorkspaceAttentionMonitor', () => {
     )
   })
 
+  it('does not reconnect monitor sockets when only active workspace or maximize state changes', () => {
+    const onAttention = vi.fn()
+    const { rerender } = renderHook(
+      ({ currentWorkspaces, currentMaximizedPaneId }) =>
+        useWorkspaceAttentionMonitor({
+          workspaces: currentWorkspaces,
+          maximizedPaneId: currentMaximizedPaneId,
+          onAttention,
+        }),
+      {
+        initialProps: {
+          currentWorkspaces: workspaces,
+          currentMaximizedPaneId: null as string | null,
+        },
+      },
+    )
+
+    expect(MockWebSocket.instances).toHaveLength(3)
+
+    rerender({
+      currentWorkspaces: { ...workspaces, active: 'ops' },
+      currentMaximizedPaneId: null,
+    })
+    rerender({
+      currentWorkspaces: { ...workspaces, active: 'ops' },
+      currentMaximizedPaneId: 'ops-main',
+    })
+
+    expect(MockWebSocket.instances).toHaveLength(3)
+  })
+
   it('notifies when an inactive workspace pane emits a confirmation prompt', () => {
     const onAttention = vi.fn()
     renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))

--- a/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
+++ b/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
@@ -66,22 +66,55 @@ const workspaces: WorkspacesResponse = {
 
 describe('useWorkspaceAttentionMonitor', () => {
   let originalWebSocket: typeof WebSocket
+  let originalLocalStorage: Storage | undefined
+  let hasFocusSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
     originalWebSocket = window.WebSocket
+    originalLocalStorage = window.localStorage
     MockWebSocket.instances = []
     window.WebSocket = MockWebSocket as unknown as typeof WebSocket
-    vi.useFakeTimers()
+    const storageData = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storageData.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          storageData.set(key, value)
+        },
+        removeItem: (key: string) => {
+          storageData.delete(key)
+        },
+        clear: () => {
+          storageData.clear()
+        },
+        key: (index: number) => [...storageData.keys()][index] ?? null,
+        get length() {
+          return storageData.size
+        },
+      } satisfies Storage,
+    })
+    window.localStorage.clear()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true)
   })
 
   afterEach(() => {
     window.WebSocket = originalWebSocket
-    vi.useRealTimers()
+    if (originalLocalStorage) {
+      Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: originalLocalStorage,
+      })
+    }
     vi.restoreAllMocks()
   })
 
   it('subscribes to every pane across all workspaces', () => {
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention: vi.fn() }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention: vi.fn() }))
 
     expect(MockWebSocket.instances).toHaveLength(3)
     expect(MockWebSocket.instances.map((instance) => instance.url)).toEqual(
@@ -95,7 +128,7 @@ describe('useWorkspaceAttentionMonitor', () => {
 
   it('notifies when an inactive workspace pane emits a confirmation prompt', () => {
     const onAttention = vi.fn()
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
 
     act(() => MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))?.simulateOpen())
     act(() =>
@@ -104,25 +137,165 @@ describe('useWorkspaceAttentionMonitor', () => {
         ?.simulateMessage(new TextEncoder().encode('Agent is waiting for confirmation: proceed?').buffer),
     )
 
-    expect(onAttention).toHaveBeenCalledWith('ops-main')
+    expect(onAttention).toHaveBeenCalledWith('ops-main', true)
   })
 
-  it('deduplicates repeated redraws from the same pane', () => {
+  it('does not notify for a visible pane while the browser is active', () => {
     const onAttention = vi.fn()
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
     const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/main'))
 
     act(() => socket?.simulateOpen())
     const prompt = new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer
     act(() => socket?.simulateMessage(prompt))
+
+    expect(onAttention).toHaveBeenCalledWith('main', false)
+  })
+
+  it('notifies for the active workspace when the browser is inactive', () => {
+    hasFocusSpy.mockReturnValue(false)
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/main'))
+
+    act(() => socket?.simulateOpen())
+    act(() =>
+      socket?.simulateMessage(new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer),
+    )
+
+    expect(onAttention).toHaveBeenCalledWith('main', true)
+  })
+
+  it('notifies for a non-maximized pane hidden by maximize while the browser is active', () => {
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: 'main', onAttention }))
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/side'))
+
+    act(() => socket?.simulateOpen())
+    act(() =>
+      socket?.simulateMessage(new TextEncoder().encode('Agent is waiting for confirmation: proceed?').buffer),
+    )
+
+    expect(onAttention).toHaveBeenCalledWith('side', true)
+  })
+
+  it('deduplicates repeated redraws from the same pane across reconnects', () => {
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+
+    act(() => socket?.simulateOpen())
+    const prompt = new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer
+    act(() => socket?.simulateMessage(prompt))
+    act(() => socket?.simulateMessage(prompt))
+    act(() => socket?.simulateOpen())
     act(() => socket?.simulateMessage(prompt))
 
-    expect(onAttention).toHaveBeenCalledTimes(1)
+    expect(onAttention).toHaveBeenCalledTimes(3)
+    expect(onAttention).toHaveBeenNthCalledWith(1, 'ops-main', true)
+    expect(onAttention).toHaveBeenNthCalledWith(2, 'ops-main', false)
+    expect(onAttention).toHaveBeenNthCalledWith(3, 'ops-main', false)
+  })
+
+  it('deduplicates the last notified prompt after a remount', () => {
+    const onAttention = vi.fn()
+    const { unmount } = renderHook(() =>
+      useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }),
+    )
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+    const prompt = new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer
+
+    act(() => socket?.simulateOpen())
+    act(() => socket?.simulateMessage(prompt))
+    unmount()
+    MockWebSocket.instances = []
+
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const remountedSocket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+    act(() => remountedSocket?.simulateOpen())
+    act(() => remountedSocket?.simulateMessage(prompt))
+
+    expect(onAttention).toHaveBeenCalledTimes(2)
+    expect(onAttention).toHaveBeenNthCalledWith(1, 'ops-main', true)
+    expect(onAttention).toHaveBeenNthCalledWith(2, 'ops-main', false)
+  })
+
+  it('notifies again when the same pane receives a different prompt', () => {
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+
+    act(() => socket?.simulateOpen())
+    act(() =>
+      socket?.simulateMessage(new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer),
+    )
+    act(() =>
+      socket?.simulateMessage(new TextEncoder().encode('Allow the github MCP server to run tool "list_pull_requests"?\n1. Allow\n2. Allow for this session\n3. Always allow\n4. Cancel\nenter to submit | esc to cancel').buffer),
+    )
+
+    expect(onAttention).toHaveBeenCalledTimes(2)
+  })
+
+  it('notifies for the same prompt text when it appears in a different pane', () => {
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const prompt = new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer
+    const mainSocket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/main'))
+    const opsSocket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+
+    hasFocusSpy.mockReturnValue(false)
+    act(() => mainSocket?.simulateOpen())
+    act(() => mainSocket?.simulateMessage(prompt))
+    hasFocusSpy.mockReturnValue(true)
+    act(() => opsSocket?.simulateOpen())
+    act(() => opsSocket?.simulateMessage(prompt))
+
+    expect(onAttention).toHaveBeenCalledTimes(2)
+    expect(onAttention).toHaveBeenNthCalledWith(1, 'main', true)
+    expect(onAttention).toHaveBeenNthCalledWith(2, 'ops-main', true)
+  })
+
+  it('falls back to in-memory dedupe when localStorage is unavailable', () => {
+    const failingStorage = {
+      getItem() {
+        throw new Error('storage unavailable')
+      },
+      setItem() {
+        throw new Error('storage unavailable')
+      },
+      removeItem() {
+        throw new Error('storage unavailable')
+      },
+      clear() {
+        throw new Error('storage unavailable')
+      },
+      key() {
+        return null
+      },
+      length: 0,
+    } as Storage
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: failingStorage,
+    })
+
+    const onAttention = vi.fn()
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
+    const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/ops-main'))
+    const prompt = new TextEncoder().encode('Codex needs confirmation before continuing. Approve?').buffer
+
+    act(() => socket?.simulateOpen())
+    act(() => socket?.simulateMessage(prompt))
+    act(() => socket?.simulateMessage(prompt))
+
+    expect(onAttention).toHaveBeenCalledTimes(2)
+    expect(onAttention).toHaveBeenNthCalledWith(1, 'ops-main', true)
+    expect(onAttention).toHaveBeenNthCalledWith(2, 'ops-main', false)
   })
 
   it('ignores text control frames because only terminal output bytes should trigger attention', () => {
     const onAttention = vi.fn()
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention }))
     const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/main'))
 
     act(() => socket?.simulateOpen())
@@ -132,7 +305,7 @@ describe('useWorkspaceAttentionMonitor', () => {
   })
 
   it('closes a socket when it errors', () => {
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention: vi.fn() }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention: vi.fn() }))
     const socket = MockWebSocket.instances.find((instance) => instance.url.endsWith('/main'))
     const closeSpy = vi.spyOn(socket!, 'close')
 
@@ -142,14 +315,14 @@ describe('useWorkspaceAttentionMonitor', () => {
   })
 
   it('does nothing when there are no workspaces to monitor', () => {
-    renderHook(() => useWorkspaceAttentionMonitor({ workspaces: null, onAttention: vi.fn() }))
+    renderHook(() => useWorkspaceAttentionMonitor({ workspaces: null, maximizedPaneId: null, onAttention: vi.fn() }))
 
     expect(MockWebSocket.instances).toHaveLength(0)
   })
 
   it('closes all sockets on unmount', () => {
     const closeSpy = vi.spyOn(MockWebSocket.prototype, 'close')
-    const { unmount } = renderHook(() => useWorkspaceAttentionMonitor({ workspaces, onAttention: vi.fn() }))
+    const { unmount } = renderHook(() => useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId: null, onAttention: vi.fn() }))
 
     unmount()
 

--- a/frontend/src/hooks/useWorkspaceAttentionMonitor.ts
+++ b/frontend/src/hooks/useWorkspaceAttentionMonitor.ts
@@ -1,30 +1,37 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { createAgentAttentionDetector } from '../utils/agentAttention'
+import { getLastNotifiedAttentionSignature, setLastNotifiedAttentionSignature } from '../utils/attentionNotificationState'
 import type { LayoutNode, WorkspacesResponse } from '../schemas'
-
-const ATTENTION_NOTIFY_INTERVAL_MS = 10_000
 
 interface UseWorkspaceAttentionMonitorOptions {
   workspaces: WorkspacesResponse | null
-  onAttention: (paneId: string) => void
+  maximizedPaneId: string | null
+  onAttention: (paneId: string, showBrowserNotification?: boolean) => void
 }
 
 interface PaneMonitorState {
   detector: ReturnType<typeof createAgentAttentionDetector>
   decoder: TextDecoder
-  lastAttentionAt: number | null
 }
 
-export function useWorkspaceAttentionMonitor({ workspaces, onAttention }: UseWorkspaceAttentionMonitorOptions) {
+export function useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAttention }: UseWorkspaceAttentionMonitorOptions) {
   const monitorStatesRef = useRef<Map<string, PaneMonitorState>>(new Map())
 
-  const paneIds = useMemo(() => {
-    if (!workspaces) return []
+  const paneMetadataById = useMemo(() => {
+    const metadata = new Map<string, { workspaceId: string }>()
+    if (!workspaces) return metadata
 
-    return workspaces.items.flatMap((workspace) => collectPaneIDs(workspace.layout))
+    for (const workspace of workspaces.items) {
+      for (const paneId of collectPaneIDs(workspace.layout)) {
+        metadata.set(paneId, { workspaceId: workspace.id })
+      }
+    }
+
+    return metadata
   }, [workspaces])
 
   useEffect(() => {
+    const paneIds = [...paneMetadataById.keys()]
     if (paneIds.length === 0) return
 
     const sockets = paneIds.map((paneId) => {
@@ -33,7 +40,6 @@ export function useWorkspaceAttentionMonitor({ workspaces, onAttention }: UseWor
       ws.binaryType = 'arraybuffer'
 
       ws.onopen = () => {
-        state.lastAttentionAt = null
         state.detector.reset()
         state.decoder = new TextDecoder()
       }
@@ -41,9 +47,22 @@ export function useWorkspaceAttentionMonitor({ workspaces, onAttention }: UseWor
       ws.onmessage = (event) => {
         if (typeof event.data === 'string') return
         const text = state.decoder.decode(new Uint8Array(event.data as ArrayBuffer), { stream: true })
-        if (shouldNotifyAttention(state, text)) {
-          onAttention(paneId)
+        const attentionMatch = state.detector.feed(text)
+        if (!attentionMatch) return
+
+        const shouldNotifyBrowser = shouldNotifyBrowserAttention({
+          paneId,
+          paneWorkspaceId: paneMetadataById.get(paneId)?.workspaceId ?? null,
+          activeWorkspaceId: workspaces?.active ?? null,
+          maximizedPaneId,
+          browserIsActive: isBrowserActive(),
+          signature: attentionMatch.signature,
+        })
+
+        if (shouldNotifyBrowser) {
+          setLastNotifiedAttentionSignature(paneId, attentionMatch.signature)
         }
+        onAttention(paneId, shouldNotifyBrowser)
       }
 
       ws.onerror = () => {
@@ -60,7 +79,7 @@ export function useWorkspaceAttentionMonitor({ workspaces, onAttention }: UseWor
         socket.close()
       }
     }
-  }, [onAttention, paneIds])
+  }, [maximizedPaneId, onAttention, paneMetadataById, workspaces])
 }
 
 function buildWebSocketURL(paneId: string): string {
@@ -91,20 +110,34 @@ function getOrCreatePaneMonitorState(states: Map<string, PaneMonitorState>, pane
   const created: PaneMonitorState = {
     detector: createAgentAttentionDetector(),
     decoder: new TextDecoder(),
-    lastAttentionAt: null,
   }
   states.set(paneId, created)
   return created
 }
 
-function shouldNotifyAttention(state: PaneMonitorState, text: string): boolean {
-  if (!state.detector.feed(text)) return false
+function shouldNotifyBrowserAttention({
+  paneId,
+  paneWorkspaceId,
+  activeWorkspaceId,
+  maximizedPaneId,
+  browserIsActive,
+  signature,
+}: {
+  paneId: string
+  paneWorkspaceId: string | null
+  activeWorkspaceId: string | null
+  maximizedPaneId: string | null
+  browserIsActive: boolean
+  signature: string
+}): boolean {
+  if (getLastNotifiedAttentionSignature(paneId) === signature) return false
+  if (!browserIsActive) return true
+  if (!paneWorkspaceId || paneWorkspaceId !== activeWorkspaceId) return true
+  if (!maximizedPaneId) return false
 
-  const now = Date.now()
-  if (state.lastAttentionAt !== null && now - state.lastAttentionAt < ATTENTION_NOTIFY_INTERVAL_MS) {
-    return false
-  }
+  return paneId !== maximizedPaneId
+}
 
-  state.lastAttentionAt = now
-  return true
+function isBrowserActive(): boolean {
+  return document.visibilityState === 'visible' && document.hasFocus()
 }

--- a/frontend/src/hooks/useWorkspaceAttentionMonitor.ts
+++ b/frontend/src/hooks/useWorkspaceAttentionMonitor.ts
@@ -16,6 +16,16 @@ interface PaneMonitorState {
 
 export function useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAttention }: UseWorkspaceAttentionMonitorOptions) {
   const monitorStatesRef = useRef<Map<string, PaneMonitorState>>(new Map())
+  const activeWorkspaceIdRef = useRef<string | null>(workspaces?.active ?? null)
+  const maximizedPaneIdRef = useRef<string | null>(maximizedPaneId)
+
+  useEffect(() => {
+    activeWorkspaceIdRef.current = workspaces?.active ?? null
+  }, [workspaces?.active])
+
+  useEffect(() => {
+    maximizedPaneIdRef.current = maximizedPaneId
+  }, [maximizedPaneId])
 
   const paneMetadataById = useMemo(() => {
     const metadata = new Map<string, { workspaceId: string }>()
@@ -28,7 +38,7 @@ export function useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAt
     }
 
     return metadata
-  }, [workspaces])
+  }, [workspaces?.items])
 
   useEffect(() => {
     const paneIds = [...paneMetadataById.keys()]
@@ -53,8 +63,8 @@ export function useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAt
         const shouldNotifyBrowser = shouldNotifyBrowserAttention({
           paneId,
           paneWorkspaceId: paneMetadataById.get(paneId)?.workspaceId ?? null,
-          activeWorkspaceId: workspaces?.active ?? null,
-          maximizedPaneId,
+          activeWorkspaceId: activeWorkspaceIdRef.current,
+          maximizedPaneId: maximizedPaneIdRef.current,
           browserIsActive: isBrowserActive(),
           signature: attentionMatch.signature,
         })
@@ -79,7 +89,7 @@ export function useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAt
         socket.close()
       }
     }
-  }, [maximizedPaneId, onAttention, paneMetadataById, workspaces])
+  }, [onAttention, paneMetadataById])
 }
 
 function buildWebSocketURL(paneId: string): string {

--- a/frontend/src/utils/agentAttention.test.ts
+++ b/frontend/src/utils/agentAttention.test.ts
@@ -5,26 +5,34 @@ describe('createAgentAttentionDetector', () => {
   it('detects an agent confirmation prompt in terminal output', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toBe(true)
+    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toMatchObject({
+      signature: 'codex needs confirmation before continuing. approve',
+    })
   })
 
   it('detects prompts split across terminal frames after stripping ANSI escapes', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('\x1b[33mAgent is waiting for conf')).toBe(false)
-    expect(detector.feed('irmation\x1b[0m: proceed?')).toBe(true)
+    expect(detector.feed('\x1b[33mAgent is waiting for conf')).toBeNull()
+    expect(detector.feed('irmation\x1b[0m: proceed?')).toMatchObject({
+      signature: 'agent is waiting for confirmation: proceed',
+    })
   })
 
   it('detects agent confirmation prompts split across terminal lines', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('Codex is waiting for your\napproval before it can proceed.')).toBe(true)
+    expect(detector.feed('Codex is waiting for your\napproval before it can proceed.')).toMatchObject({
+      signature: 'codex is waiting for your approval before it can proceed',
+    })
   })
 
   it('detects Japanese approval prompts split across terminal lines', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('操作の承認\nが必要です')).toBe(true)
+    expect(detector.feed('操作の承認\nが必要です')).toMatchObject({
+      signature: '承認 が必要',
+    })
   })
 
   it('detects Codex approval menus with yes and no options', () => {
@@ -32,7 +40,9 @@ describe('createAgentAttentionDetector', () => {
 
     expect(
       detector.feed(' 1. Yes, proceed (y)\n 2. No, and tell Codex what to do differently (esc)'),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'yes, proceed (y) 2. no, and tell codex what to do differently (esc)',
+    })
   })
 
   it('detects Claude approval menus with yes and no options', () => {
@@ -40,7 +50,9 @@ describe('createAgentAttentionDetector', () => {
 
     expect(
       detector.feed(' 1. Yes, proceed (y)\n 2. No, and tell Claude what to do differently (esc)'),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'yes, proceed (y) 2. no, and tell claude what to do differently (esc)',
+    })
   })
 
   it('detects Codex edit approval menus with a do-not-ask-again option', () => {
@@ -56,7 +68,9 @@ describe('createAgentAttentionDetector', () => {
           '  3. No, and tell Codex what to do differently (esc)',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: "yes, proceed (y) 2. yes, and don't ask again for these files (a) 3. no, and tell codex what to do differently (esc)",
+    })
   })
 
   it('detects Codex command approval menus with scoped do-not-ask-again options', () => {
@@ -76,7 +90,9 @@ describe('createAgentAttentionDetector', () => {
           '  3. No, and tell Codex what to do differently (esc)',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: "yes, proceed (y) 2. yes, and don't ask again for commands that start with `gh pr comment` (p) 3. no, and tell codex what to do differently (esc)",
+    })
   })
 
   it('detects Claude bash command approval menus', () => {
@@ -101,7 +117,9 @@ describe('createAgentAttentionDetector', () => {
           'Esc to cancel · Tab to amend · ctrl+e to explain',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'do you want to proceed? ❯ 1. yes 2. no esc to cancel · tab to amend · ctrl+e to explain',
+    })
   })
 
   it('detects Codex MCP approval menus with allow options', () => {
@@ -122,7 +140,9 @@ describe('createAgentAttentionDetector', () => {
           'enter to submit | esc to cancel',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'allow the maestro mcp server to run tool "query_docs"? question: ignore this if not relevant. › 1. allow run the tool and continue. 2. allow for this session run the tool and remember this choice for this session. 3. always allow run the tool and remember this choice for future tool calls. 4. cancel cancel this tool call enter to submit | esc to cancel',
+    })
   })
 
   it('detects Codex MCP approval menus for other servers and tools', () => {
@@ -143,7 +163,9 @@ describe('createAgentAttentionDetector', () => {
           'enter to submit | esc to cancel',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'allow the github mcp server to run tool "list_pull_requests"? question: ignore this if not relevant. › 1. allow run the tool and continue. 2. allow for this session run the tool and remember this choice for this session. 3. always allow run the tool and remember this choice for future tool calls. 4. cancel cancel this tool call enter to submit | esc to cancel',
+    })
   })
 
   it('detects non-MCP allow menus with the same Codex approval structure', () => {
@@ -164,26 +186,40 @@ describe('createAgentAttentionDetector', () => {
           'enter to submit | esc to cancel',
         ].join('\n'),
       ),
-    ).toBe(true)
+    ).toMatchObject({
+      signature: 'allow access to workspace "production"? question: ignore this if not relevant. › 1. allow run the tool and continue. 2. allow for this session run the tool and remember this choice for this session. 3. always allow run the tool and remember this choice for future tool calls. 4. cancel cancel this tool call enter to submit | esc to cancel',
+    })
   })
 
   it('does not match ordinary terminal output', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('npm test finished successfully')).toBe(false)
+    expect(detector.feed('npm test finished successfully')).toBeNull()
   })
 
   it('does not match generic non-agent confirmation prompts', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('Need to install the following packages: vite. Proceed? [y/N]')).toBe(false)
-    expect(detector.feed('Allow Homebrew to make changes?')).toBe(false)
+    expect(detector.feed('Need to install the following packages: vite. Proceed? [y/N]')).toBeNull()
+    expect(detector.feed('Allow Homebrew to make changes?')).toBeNull()
   })
 
   it('does not keep matching stale prompt text after it has emitted', () => {
     const detector = createAgentAttentionDetector()
 
-    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toBe(true)
-    expect(detector.feed('\nnormal command output after the prompt')).toBe(false)
+    expect(detector.feed('Codex needs confirmation before continuing. Approve?')).toMatchObject({
+      signature: 'codex needs confirmation before continuing. approve',
+    })
+    expect(detector.feed('\nnormal command output after the prompt')).toBeNull()
+  })
+
+  it('normalizes whitespace so repeated redraws produce the same signature', () => {
+    const detector = createAgentAttentionDetector()
+
+    const firstMatch = detector.feed('Codex needs confirmation before continuing.\n\nApprove?')
+    const secondMatch = detector.feed('Codex needs confirmation before continuing.   Approve?')
+
+    expect(firstMatch?.signature).toBe('codex needs confirmation before continuing. approve')
+    expect(secondMatch?.signature).toBe('codex needs confirmation before continuing. approve')
   })
 })

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -51,7 +51,7 @@ function normalizeAttentionText(value: string): string {
   return stripAnsi(value)
     .replace(/\s+/g, ' ')
     .trim()
-    .toLocaleLowerCase()
+    .toLowerCase()
 }
 
 function stripAnsi(value: string): string {

--- a/frontend/src/utils/agentAttention.ts
+++ b/frontend/src/utils/agentAttention.ts
@@ -8,8 +8,12 @@ const ATTENTION_PATTERNS = [
   /(確認|承認|許可)[\s\S]{0,120}(必要|してください|しますか|待ち)/,
 ]
 
+export interface AgentAttentionMatch {
+  signature: string
+}
+
 export interface AgentAttentionDetector {
-  feed: (chunk: string) => boolean
+  feed: (chunk: string) => AgentAttentionMatch | null
   reset: () => void
 }
 
@@ -19,16 +23,35 @@ export function createAgentAttentionDetector(): AgentAttentionDetector {
   return {
     feed(chunk: string) {
       tail = (tail + stripAnsi(chunk)).slice(-MAX_TAIL_LENGTH)
-      const matched = ATTENTION_PATTERNS.some((pattern) => pattern.test(tail))
-      if (matched) {
+      const match = findAttentionMatch(tail)
+      if (match) {
         tail = ''
+        return {
+          signature: normalizeAttentionText(match),
+        }
       }
-      return matched
+      return null
     },
     reset() {
       tail = ''
     },
   }
+}
+
+function findAttentionMatch(value: string): string | null {
+  for (const pattern of ATTENTION_PATTERNS) {
+    const match = value.match(pattern)
+    if (match) return match[0]
+  }
+
+  return null
+}
+
+function normalizeAttentionText(value: string): string {
+  return stripAnsi(value)
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLocaleLowerCase()
 }
 
 function stripAnsi(value: string): string {

--- a/frontend/src/utils/attentionNotificationState.ts
+++ b/frontend/src/utils/attentionNotificationState.ts
@@ -1,0 +1,56 @@
+const LAST_NOTIFIED_SIGNATURES_KEY = 'panemux:last-notified-attention-signatures'
+
+let inMemoryFallback = new Map<string, string>()
+
+export function getLastNotifiedAttentionSignature(paneId: string): string | null {
+  return readSignatureMap().get(paneId) ?? null
+}
+
+export function setLastNotifiedAttentionSignature(paneId: string, signature: string) {
+  const signatures = readSignatureMap()
+  signatures.set(paneId, signature)
+  writeSignatureMap(signatures)
+}
+
+function readSignatureMap(): Map<string, string> {
+  const storage = getStorage()
+  if (!storage) return new Map(inMemoryFallback)
+
+  try {
+    const raw = storage.getItem(LAST_NOTIFIED_SIGNATURES_KEY)
+    if (!raw) return new Map()
+
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object') return new Map()
+
+    return new Map(
+      Object.entries(parsed).filter((entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'),
+    )
+  } catch {
+    return new Map(inMemoryFallback)
+  }
+}
+
+function writeSignatureMap(signatures: Map<string, string>) {
+  const storage = getStorage()
+  if (!storage) {
+    inMemoryFallback = new Map(signatures)
+    return
+  }
+
+  const value = JSON.stringify(Object.fromEntries(signatures))
+
+  try {
+    storage.setItem(LAST_NOTIFIED_SIGNATURES_KEY, value)
+  } catch {
+    inMemoryFallback = new Map(signatures)
+  }
+}
+
+function getStorage(): Storage | null {
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- suppress browser attention notifications for prompts that are already visible to the user
- dedupe replayed browser notifications per pane across refreshes, reconnects, and maximize changes
- document the notification rules and expand factor-based frontend test coverage

## Test Plan
- [x] make test-frontend
- [x] make coverage-frontend
- [x] make lint-frontend
- [x] cd frontend && npx playwright test e2e/workspace-switch.spec.ts
