### PR TITLE
fix: suppress replay-generated terminal input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test (Go)
         run: |
           set -o pipefail
-          go test -v ./... -race 2>&1 | go-junit-report -set-exit-code > test-results/go-junit.xml
+          go test -v ./... -race 2>&1 | go-junit-report -iocopy -out test-results/go-junit.xml -set-exit-code
 
       - name: Test (Frontend)
         run: cd frontend && npm run test:ci

--- a/.github/workflows/model-check.yml
+++ b/.github/workflows/model-check.yml
@@ -52,7 +52,7 @@ jobs:
             out_dir="$(mktemp -d)"
             log_file="$(mktemp)"
             receipt_file="$out_dir/receipt.json"
-            java -jar /tmp/alloy/org.alloytools.alloy.dist.jar exec -t none -o "$out_dir" -f "$model" | tee "$log_file"
+            java -jar /tmp/alloy/org.alloytools.alloy.dist.jar exec -t none -o "$out_dir" -f "$model" 2>&1 | tee "$log_file"
             python3 - "$model" "$log_file" "$receipt_file" <<'PY'
           import re
           import json

--- a/.github/workflows/model-check.yml
+++ b/.github/workflows/model-check.yml
@@ -1,0 +1,76 @@
+name: model-check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/models/**'
+      - '.github/workflows/model-check.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/models/**'
+      - '.github/workflows/model-check.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  alloy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Download Alloy
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/alloy
+          curl -fsSL \
+            -o /tmp/alloy/org.alloytools.alloy.dist.jar \
+            https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar
+
+      - name: Validate Alloy models
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          models=(docs/models/*.als)
+          if [ "${#models[@]}" -eq 0 ]; then
+            echo "No Alloy models found under docs/models"
+            exit 1
+          fi
+
+          for model in "${models[@]}"; do
+            echo "::group::${model}"
+            java -jar /tmp/alloy/org.alloytools.alloy.dist.jar commands "$model"
+            out_dir="$(mktemp -d)"
+            log_file="$(mktemp)"
+            java -jar /tmp/alloy/org.alloytools.alloy.dist.jar exec -t none -o "$out_dir" -f "$model" | tee "$log_file"
+            python3 - "$model" "$log_file" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          model = sys.argv[1]
+          log_path = Path(sys.argv[2])
+          result_lines = []
+          for line in log_path.read_text().splitlines():
+              if re.match(r"^\d+\.\s+check\b", line):
+                  result_lines.append(line)
+
+          if not result_lines:
+              raise SystemExit(f"{model}: no Alloy check results found")
+
+          failures = [line for line in result_lines if "UNSAT" not in line]
+          if failures:
+              joined = "\n".join(failures)
+              raise SystemExit(f"{model}: expected all checks to be UNSAT, got:\n{joined}")
+          PY
+            echo "::endgroup::"
+          done

--- a/.github/workflows/model-check.yml
+++ b/.github/workflows/model-check.yml
@@ -51,26 +51,50 @@ jobs:
             java -jar /tmp/alloy/org.alloytools.alloy.dist.jar commands "$model"
             out_dir="$(mktemp -d)"
             log_file="$(mktemp)"
+            receipt_file="$out_dir/receipt.json"
             java -jar /tmp/alloy/org.alloytools.alloy.dist.jar exec -t none -o "$out_dir" -f "$model" | tee "$log_file"
-            python3 - "$model" "$log_file" <<'PY'
+            python3 - "$model" "$log_file" "$receipt_file" <<'PY'
           import re
+          import json
           import sys
           from pathlib import Path
 
           model = sys.argv[1]
           log_path = Path(sys.argv[2])
-          result_lines = []
-          for line in log_path.read_text().splitlines():
-              if re.match(r"^\d+\.\s+check\b", line):
-                  result_lines.append(line)
+          receipt_path = Path(sys.argv[3])
+          receipt = json.loads(receipt_path.read_text())
+          expected_checks = sum(
+              1 for command in receipt.get("commands", {}).values()
+              if command.get("type") == "check"
+          )
+          if expected_checks == 0:
+              raise SystemExit(f"{model}: no Alloy check commands found in receipt")
 
-          if not result_lines:
-              raise SystemExit(f"{model}: no Alloy check results found")
+          ansi_pattern = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+          control_pattern = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
+          verdict_pattern = re.compile(r"\b(UNSAT|SAT|UNKNOWN)\b")
 
-          failures = [line for line in result_lines if "UNSAT" not in line]
-          if failures:
-              joined = "\n".join(failures)
+          unsat_lines = []
+          bad_lines = []
+          for raw_line in log_path.read_text().splitlines():
+              normalized = control_pattern.sub("", ansi_pattern.sub("", raw_line))
+              verdict = verdict_pattern.search(normalized)
+              if verdict is None:
+                  continue
+              if verdict.group(1) == "UNSAT":
+                  unsat_lines.append(normalized)
+              else:
+                  bad_lines.append(normalized)
+
+          if bad_lines:
+              joined = "\n".join(bad_lines)
               raise SystemExit(f"{model}: expected all checks to be UNSAT, got:\n{joined}")
+
+          if len(unsat_lines) != expected_checks:
+              joined = "\n".join(unsat_lines)
+              raise SystemExit(
+                  f"{model}: expected {expected_checks} UNSAT results, got {len(unsat_lines)}\n{joined}"
+              )
           PY
             echo "::endgroup::"
           done

--- a/.github/workflows/model-check.yml
+++ b/.github/workflows/model-check.yml
@@ -24,6 +24,8 @@ permissions:
 jobs:
   alloy:
     runs-on: ubuntu-latest
+    env:
+      ALLOY_JAR_SHA256: 6b8c1cb5bc93bedfc7c61435c4e1ab6e688a242dc702a394628d9a9801edb78d
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -35,6 +37,7 @@ jobs:
           curl -fsSL \
             -o /tmp/alloy/org.alloytools.alloy.dist.jar \
             https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar
+          echo "${ALLOY_JAR_SHA256}  /tmp/alloy/org.alloytools.alloy.dist.jar" | shasum -a 256 -c -
 
       - name: Validate Alloy models
         run: |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,7 +220,7 @@ The hook resets all replay fields on each WebSocket open so an interrupted repla
 connection cannot suppress stdin for the new connection.
 
 This lifecycle is also captured as an Alloy model in
-[replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als), which treats
+[replay_state.als](models/replay_state.als), which treats
 reconnect, replay frame delivery, replay-control write failure, socket close, and replay write
 completion as explicit transition events and checks the stale-suppression invariants over bounded
 traces.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ Replay state ownership in this hook:
 
 - `replayActive`: true between `replay:start` and `replay:end`
 - `replayWriteDepth`: count of replay `term.write(...)` calls whose callbacks have not fired yet
-- `replayEnded`: true once `replay:end` has been received for the current connection
+- `awaitingReplayEnd`: true after `replay:start` and false once `replay:end` has been received for the current connection
 - `disableStdin`: derived safety switch; forced on whenever replay is active or draining, forced off
   on reconnect reset and after the final replay write callback
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,15 @@ Why this split:
 - lets the frontend suppress xterm stdin only while replayed snapshot bytes are being re-applied,
   which prevents replayed terminal queries from generating fresh replies back into the PTY
 
+Replay lifecycle contract:
+
+- the backend emits replay lifecycle only around buffered snapshot delivery, never around live output
+- `replay:start` means "all following binary frames are replay bytes until `replay:end`"
+- `replay:end` means "no more replay bytes will be sent on this connection"; the frontend may still
+  be draining already-scheduled xterm writes
+- if a replay control frame write fails, the handler stops forwarding on that connection instead of
+  risking live output after an incomplete replay transition
+
 ### `internal/server`
 
 This package wires chi routes, middleware, REST handlers, WebSocket handlers, and static file serving.
@@ -190,6 +199,23 @@ When the backend labels buffered reconnect output with replay control frames, th
 sets `xterm.options.disableStdin = true` while those replay bytes are written. That keeps xterm's
 auto-generated terminal replies from being forwarded as accidental shell input during browser
 refreshes or workspace remounts.
+
+Replay state ownership in this hook:
+
+- `replayActive`: true between `replay:start` and `replay:end`
+- `replayWriteDepth`: count of replay `term.write(...)` calls whose callbacks have not fired yet
+- `replayEnded`: true once `replay:end` has been received for the current connection
+- `disableStdin`: derived safety switch; forced on whenever replay is active or draining, forced off
+  on reconnect reset and after the final replay write callback
+
+This gives the hook a three-phase replay lifecycle:
+
+1. `live`: no replay pending, stdin enabled
+2. `replay pending end`: replay frames still arriving, stdin disabled
+3. `replay draining`: end marker received, but queued xterm writes still draining, stdin disabled
+
+The hook resets all replay fields on each WebSocket open so an interrupted replay from a previous
+connection cannot suppress stdin for the new connection.
 
 Why xterm.js:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ subscribers for the same session ID while a workspace is hidden.
 Protocol split:
 
 - binary frames: raw terminal input/output
-- text frames: JSON control messages such as `resize` and `status`
+- text frames: JSON control messages such as `resize`, `status`, and replay lifecycle markers
 
 Why this split:
 
@@ -104,6 +104,8 @@ Why this split:
 - matches the low-latency needs of terminal streaming
 - works with the backend session manager's fan-out model, where one session can have multiple
   concurrent subscribers receiving the same output stream
+- lets the frontend suppress xterm stdin only while replayed snapshot bytes are being re-applied,
+  which prevents replayed terminal queries from generating fresh replies back into the PTY
 
 ### `internal/server`
 
@@ -183,6 +185,11 @@ Why this hook:
 ### `useTerminal`
 
 Owns xterm.js setup, fit behavior, byte forwarding, and resize reporting.
+
+When the backend labels buffered reconnect output with replay control frames, this hook temporarily
+sets `xterm.options.disableStdin = true` while those replay bytes are written. That keeps xterm's
+auto-generated terminal replies from being forwarded as accidental shell input during browser
+refreshes or workspace remounts.
 
 Why xterm.js:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,8 @@ Replay lifecycle contract:
   be draining already-scheduled xterm writes
 - if a replay control frame write fails, the handler stops forwarding on that connection instead of
   risking live output after an incomplete replay transition
+- if the connection dies after `replay:start` but before the frontend observes a matching `replay:end`,
+  the frontend may temporarily retain replay suppression state until the next socket open resets it
 
 ### `internal/server`
 
@@ -219,8 +221,9 @@ connection cannot suppress stdin for the new connection.
 
 This lifecycle is also captured as an Alloy model in
 [replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als), which treats
-reconnect, replay frame delivery, and replay write completion as explicit transition events and
-checks the stale-suppression invariants over bounded traces.
+reconnect, replay frame delivery, replay-control write failure, socket close, and replay write
+completion as explicit transition events and checks the stale-suppression invariants over bounded
+traces.
 
 Why xterm.js:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,15 @@ reconnect, replay frame delivery, replay-control write failure, socket close, an
 completion as explicit transition events and checks the stale-suppression invariants over bounded
 traces.
 
+State-transition verification rule:
+
+- Code that introduces or changes externally observable state transitions should have a matching
+  Alloy model under `docs/models/`.
+- Changes to transition logic should update that model in the same PR so the checked state machine
+  remains aligned with the implementation.
+- GitHub Actions runs Alloy checks only when the model files change, so model maintenance is the
+  mechanism that keeps transition verification on the critical path.
+
 Why xterm.js:
 
 - mature browser terminal emulator

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,6 +217,11 @@ This gives the hook a three-phase replay lifecycle:
 The hook resets all replay fields on each WebSocket open so an interrupted replay from a previous
 connection cannot suppress stdin for the new connection.
 
+This lifecycle is also captured as an Alloy model in
+[replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als), which treats
+reconnect, replay frame delivery, and replay write completion as explicit transition events and
+checks the stale-suppression invariants over bounded traces.
+
 Why xterm.js:
 
 - mature browser terminal emulator

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -330,7 +330,6 @@ sequenceDiagram
 
 Alloy model:
 
-- The replay state machine above is mirrored in [replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als).
 - The replay state machine above is mirrored in [replay_state.als](models/replay_state.als).
 - The model abstracts the frontend into three states: `Live`, `ReplayPendingEnd`, and `ReplayDraining`.
 - It checks these invariants:
@@ -341,7 +340,12 @@ Alloy model:
   - `SocketClose` does not falsely restore `Live` while replay is incomplete
   - `Reconnect` always resets the model to a clean `Live` state
   - stale replay suppression cannot survive in `Live`
+- Any implementation that introduces or changes observable state transitions should ship with an
+  Alloy model in `docs/models/` that captures those transitions.
+- When state-transition behavior changes, update the corresponding Alloy model in the same change.
 - To inspect counterexamples locally, open the model in Alloy and run the bundled `check` commands.
+- CI runs Alloy model checks only when files under `docs/models/` change, so transition-changing
+  code changes are expected to update the model if they need model-check coverage.
 
 When the backend session reaches EOF, the handler emits:
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -278,7 +278,7 @@ Replay state machine:
 | State | Entry condition | Allowed events | Exit condition | Frontend effect |
 |---|---|---|---|---|
 | `live` | initial steady state, or replay has fully completed | live binary output, `replay:start`, socket close, socket reconnect | `replay:start` or socket teardown | `disableStdin = false`; terminal input and xterm-generated replies may flow normally |
-| `replay_pending_end` | `replay:start` received | replay binary output, `replay:end`, socket close, socket reconnect | `replay:end` or socket teardown | `disableStdin = true`; replay bytes may still be arriving |
+| `replay_pending_end` | `replay:start` received | replay binary output, `replay:end`, `replay:end` write failure, socket close, socket reconnect | `replay:end` or socket teardown | `disableStdin = true`; replay bytes may still be arriving |
 | `replay_draining` | `replay:end` received while one or more replay writes are still in flight | replay write callback completion, socket close, socket reconnect | last replay write callback completes | `disableStdin = true`; no new replay bytes are expected, but already-scheduled writes may still cause xterm side effects |
 
 State transition rules:
@@ -288,7 +288,8 @@ State transition rules:
 3. Each replay binary frame is written while stdin remains suppressed.
 4. `replay:end` moves the terminal to `replay_draining` if replay writes are still in flight, otherwise directly back to `live`.
 5. The final replay write callback restores `live`.
-6. Any WebSocket reconnect force-resets replay state back to `live` before new frames are processed, so a partial replay cannot leave stale suppression behind.
+6. A socket close or replay-control write failure can leave the frontend in a stale replay state until the next connection opens.
+7. Any WebSocket reconnect force-resets replay state back to `live` before new frames are processed, so a partial replay cannot leave stale suppression behind.
 
 Frontend replay state diagram:
 
@@ -299,7 +300,10 @@ stateDiagram-v2
     replay_pending_end --> replay_pending_end: replay binary frame
     replay_pending_end --> replay_draining: replay:end\nand replayWriteDepth > 0
     replay_pending_end --> live: replay:end\nand replayWriteDepth == 0
+    replay_pending_end --> replay_pending_end: replay:end write failure
+    replay_pending_end --> replay_pending_end: socket close
     replay_draining --> replay_draining: replay write callback\nand replayWriteDepth > 0
+    replay_draining --> replay_draining: socket close
     replay_draining --> live: final replay write callback
     replay_pending_end --> live: socket reconnect/reset
     replay_draining --> live: socket reconnect/reset
@@ -332,6 +336,8 @@ Alloy model:
   - `Live` never leaves `disableStdin` enabled
   - replay states always keep `disableStdin` enabled
   - `ReplayDraining` is only reachable while replay writes remain queued
+  - `ReplayEndWriteFail` leaves the model in `ReplayPendingEnd` until reconnect
+  - `SocketClose` does not falsely restore `Live` while replay is incomplete
   - `Reconnect` always resets the model to a clean `Live` state
   - stale replay suppression cannot survive in `Live`
 - To inspect counterexamples locally, open the model in Alloy and run the bundled `check` commands.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -324,6 +324,18 @@ sequenceDiagram
     W->>B: binary live frame(s)
 ```
 
+Alloy model:
+
+- The replay state machine above is mirrored in [replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als).
+- The model abstracts the frontend into three states: `Live`, `ReplayPendingEnd`, and `ReplayDraining`.
+- It checks these invariants:
+  - `Live` never leaves `disableStdin` enabled
+  - replay states always keep `disableStdin` enabled
+  - `ReplayDraining` is only reachable while replay writes remain queued
+  - `Reconnect` always resets the model to a clean `Live` state
+  - stale replay suppression cannot survive in `Live`
+- To inspect counterexamples locally, open the model in Alloy and run the bundled `check` commands.
+
 When the backend session reaches EOF, the handler emits:
 
 ```json

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -273,6 +273,57 @@ Supported control messages:
 
 Resize messages with zero dimensions are ignored. Invalid JSON control frames are ignored rather than terminating the session.
 
+Replay state machine:
+
+| State | Entry condition | Allowed events | Exit condition | Frontend effect |
+|---|---|---|---|---|
+| `live` | initial steady state, or replay has fully completed | live binary output, `replay:start`, socket close, socket reconnect | `replay:start` or socket teardown | `disableStdin = false`; terminal input and xterm-generated replies may flow normally |
+| `replay_pending_end` | `replay:start` received | replay binary output, `replay:end`, socket close, socket reconnect | `replay:end` or socket teardown | `disableStdin = true`; replay bytes may still be arriving |
+| `replay_draining` | `replay:end` received while one or more replay writes are still in flight | replay write callback completion, socket close, socket reconnect | last replay write callback completes | `disableStdin = true`; no new replay bytes are expected, but already-scheduled writes may still cause xterm side effects |
+
+State transition rules:
+
+1. New connections start in `live`.
+2. `replay:start` moves the terminal to `replay_pending_end` and suppresses stdin immediately.
+3. Each replay binary frame is written while stdin remains suppressed.
+4. `replay:end` moves the terminal to `replay_draining` if replay writes are still in flight, otherwise directly back to `live`.
+5. The final replay write callback restores `live`.
+6. Any WebSocket reconnect force-resets replay state back to `live` before new frames are processed, so a partial replay cannot leave stale suppression behind.
+
+Frontend replay state diagram:
+
+```mermaid
+stateDiagram-v2
+    [*] --> live
+    live --> replay_pending_end: replay:start
+    replay_pending_end --> replay_pending_end: replay binary frame
+    replay_pending_end --> replay_draining: replay:end\nand replayWriteDepth > 0
+    replay_pending_end --> live: replay:end\nand replayWriteDepth == 0
+    replay_draining --> replay_draining: replay write callback\nand replayWriteDepth > 0
+    replay_draining --> live: final replay write callback
+    replay_pending_end --> live: socket reconnect/reset
+    replay_draining --> live: socket reconnect/reset
+```
+
+Backend replay emission order:
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant W as WebSocket handler
+    participant S as Session replay buffer
+
+    W->>B: {"type":"status","state":"connected"}
+    alt snapshot exists
+        W->>B: {"type":"replay","state":"start"}
+        S-->>W: buffered snapshot bytes
+        W->>B: binary snapshot frame
+        W->>B: {"type":"replay","state":"end"}
+    end
+    S-->>W: live output bytes
+    W->>B: binary live frame(s)
+```
+
 When the backend session reaches EOF, the handler emits:
 
 ```json

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -246,8 +246,10 @@ Connection behavior:
 
 - `404` if the session ID does not exist
 - initial text frame is a JSON status message with `type: "status"` and `state: "connected"`
-- after the connected status, the backend replays up to the recent per-session output buffer before
-  streaming live output
+- if a reconnect has buffered output, the backend sends `{"type":"replay","state":"start"}`,
+  replays up to the recent per-session output buffer as a binary frame, then sends
+  `{"type":"replay","state":"end"}` before streaming live output
+- if there is no buffered output, live output starts immediately after the connected status
 
 Frame behavior:
 
@@ -259,6 +261,14 @@ Supported control messages:
 
 ```json
 { "type": "resize", "cols": 120, "rows": 40 }
+```
+
+```json
+{ "type": "replay", "state": "start" }
+```
+
+```json
+{ "type": "replay", "state": "end" }
 ```
 
 Resize messages with zero dimensions are ignored. Invalid JSON control frames are ignored rather than terminating the session.
@@ -293,6 +303,10 @@ User types in xterm.js
   -> backend sends binary WebSocket frame
   -> xterm.js writes bytes to the terminal
 ```
+
+During replayed reconnect output, xterm stdin is suppressed until the replay end marker is fully
+applied, so terminal query responses embedded in old output are not regenerated as fresh shell
+input.
 
 ### Selection and copy behavior
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -331,6 +331,7 @@ sequenceDiagram
 Alloy model:
 
 - The replay state machine above is mirrored in [replay_state.als](/tmp/panemux-replay-input-fix/docs/models/replay_state.als).
+- The replay state machine above is mirrored in [replay_state.als](models/replay_state.als).
 - The model abstracts the frontend into three states: `Live`, `ReplayPendingEnd`, and `ReplayDraining`.
 - It checks these invariants:
   - `Live` never leaves `disableStdin` enabled

--- a/docs/models/replay_state.als
+++ b/docs/models/replay_state.als
@@ -15,7 +15,7 @@ sig Step {
   state: one ReplayState,
   event: lone Event,
   replayActive: one Flag,
-  replayEnded: one Flag,
+  awaitingReplayEnd: one Flag,
   disableStdin: one Flag,
   replayWriteDepth: one Int
 }
@@ -24,7 +24,7 @@ fact InitialState {
   first.state = Live
   no first.event
   first.replayActive = Disabled
-  first.replayEnded = Enabled
+  first.awaitingReplayEnd = Disabled
   first.disableStdin = Disabled
   first.replayWriteDepth = 0
 }
@@ -33,21 +33,21 @@ fact StateEncoding {
   all s: Step | {
     s.state = Live implies {
       s.replayActive = Disabled
-      s.replayEnded = Enabled
+      s.awaitingReplayEnd = Disabled
       s.disableStdin = Disabled
       s.replayWriteDepth = 0
     }
 
     s.state = ReplayPendingEnd implies {
       s.replayActive = Enabled
-      s.replayEnded = Disabled
+      s.awaitingReplayEnd = Enabled
       s.disableStdin = Enabled
       s.replayWriteDepth >= 0
     }
 
     s.state = ReplayDraining implies {
       s.replayActive = Disabled
-      s.replayEnded = Enabled
+      s.awaitingReplayEnd = Disabled
       s.disableStdin = Enabled
       s.replayWriteDepth > 0
     }
@@ -107,7 +107,7 @@ pred transition[cur, next: Step] {
   next.event = SocketClose implies {
     next.state = cur.state
     next.replayActive = cur.replayActive
-    next.replayEnded = cur.replayEnded
+    next.awaitingReplayEnd = cur.awaitingReplayEnd
     next.disableStdin = cur.disableStdin
     next.replayWriteDepth = cur.replayWriteDepth
   }
@@ -116,7 +116,7 @@ pred transition[cur, next: Step] {
     cur.state = ReplayPendingEnd
     next.state = ReplayPendingEnd
     next.replayActive = Enabled
-    next.replayEnded = Disabled
+    next.awaitingReplayEnd = Enabled
     next.disableStdin = Enabled
     next.replayWriteDepth = cur.replayWriteDepth
   }
@@ -143,7 +143,7 @@ assert ReconnectAlwaysResetsToLive {
     s.event = Reconnect implies {
       s.state = Live
       s.replayActive = Disabled
-      s.replayEnded = Enabled
+      s.awaitingReplayEnd = Disabled
       s.disableStdin = Disabled
       s.replayWriteDepth = 0
     }
@@ -163,7 +163,7 @@ assert ReplayEndWriteFailureLeavesReplayPendingUntilReconnect {
     s.event = ReplayEndWriteFail implies {
       s.state = ReplayPendingEnd
       s.replayActive = Enabled
-      s.replayEnded = Disabled
+      s.awaitingReplayEnd = Enabled
       s.disableStdin = Enabled
     }
 }

--- a/docs/models/replay_state.als
+++ b/docs/models/replay_state.als
@@ -8,44 +8,47 @@ one sig Live, ReplayPendingEnd, ReplayDraining extends ReplayState {}
 abstract sig Event {}
 one sig ReplayStart, ReplayBinary, ReplayEnd, WriteComplete, Reconnect extends Event {}
 
+abstract sig Flag {}
+one sig Enabled, Disabled extends Flag {}
+
 sig Step {
   state: one ReplayState,
   event: lone Event,
-  replayActive: one Bool,
-  replayEnded: one Bool,
-  disableStdin: one Bool,
+  replayActive: one Flag,
+  replayEnded: one Flag,
+  disableStdin: one Flag,
   replayWriteDepth: one Int
 }
 
 fact InitialState {
   first.state = Live
   no first.event
-  first.replayActive = False
-  first.replayEnded = True
-  first.disableStdin = False
+  first.replayActive = Disabled
+  first.replayEnded = Enabled
+  first.disableStdin = Disabled
   first.replayWriteDepth = 0
 }
 
 fact StateEncoding {
   all s: Step | {
     s.state = Live implies {
-      s.replayActive = False
-      s.replayEnded = True
-      s.disableStdin = False
+      s.replayActive = Disabled
+      s.replayEnded = Enabled
+      s.disableStdin = Disabled
       s.replayWriteDepth = 0
     }
 
     s.state = ReplayPendingEnd implies {
-      s.replayActive = True
-      s.replayEnded = False
-      s.disableStdin = True
+      s.replayActive = Enabled
+      s.replayEnded = Disabled
+      s.disableStdin = Enabled
       s.replayWriteDepth >= 0
     }
 
     s.state = ReplayDraining implies {
-      s.replayActive = False
-      s.replayEnded = True
-      s.disableStdin = True
+      s.replayActive = Disabled
+      s.replayEnded = Enabled
+      s.disableStdin = Enabled
       s.replayWriteDepth > 0
     }
   }
@@ -107,11 +110,11 @@ fact Trace {
 }
 
 assert LiveAlwaysEnablesInput {
-  all s: Step | s.state = Live implies s.disableStdin = False
+  all s: Step | s.state = Live implies s.disableStdin = Disabled
 }
 
 assert ReplayStatesAlwaysSuppressInput {
-  all s: Step | s.state in ReplayPendingEnd + ReplayDraining implies s.disableStdin = True
+  all s: Step | s.state in ReplayPendingEnd + ReplayDraining implies s.disableStdin = Enabled
 }
 
 assert DrainingRequiresQueuedWrites {
@@ -122,9 +125,9 @@ assert ReconnectAlwaysResetsToLive {
   all s: Step - first |
     s.event = Reconnect implies {
       s.state = Live
-      s.replayActive = False
-      s.replayEnded = True
-      s.disableStdin = False
+      s.replayActive = Disabled
+      s.replayEnded = Enabled
+      s.disableStdin = Disabled
       s.replayWriteDepth = 0
     }
 }
@@ -132,8 +135,8 @@ assert ReconnectAlwaysResetsToLive {
 assert NoStaleSuppressionInLive {
   all s: Step |
     s.state = Live implies {
-      s.replayActive = False
-      s.disableStdin = False
+      s.replayActive = Disabled
+      s.disableStdin = Disabled
       s.replayWriteDepth = 0
     }
 }
@@ -143,4 +146,3 @@ check ReplayStatesAlwaysSuppressInput for 8 Step, 8 Int
 check DrainingRequiresQueuedWrites for 8 Step, 8 Int
 check ReconnectAlwaysResetsToLive for 8 Step, 8 Int
 check NoStaleSuppressionInLive for 8 Step, 8 Int
-

--- a/docs/models/replay_state.als
+++ b/docs/models/replay_state.als
@@ -80,6 +80,8 @@ pred transition[cur, next: Step] {
   }
 
   next.event = WriteComplete implies {
+    cur.state in ReplayPendingEnd + ReplayDraining
+
     cur.state = ReplayPendingEnd implies {
       cur.replayWriteDepth > 0
       next.state = ReplayPendingEnd

--- a/docs/models/replay_state.als
+++ b/docs/models/replay_state.als
@@ -1,0 +1,146 @@
+module replay_state
+
+open util/ordering[Step]
+
+abstract sig ReplayState {}
+one sig Live, ReplayPendingEnd, ReplayDraining extends ReplayState {}
+
+abstract sig Event {}
+one sig ReplayStart, ReplayBinary, ReplayEnd, WriteComplete, Reconnect extends Event {}
+
+sig Step {
+  state: one ReplayState,
+  event: lone Event,
+  replayActive: one Bool,
+  replayEnded: one Bool,
+  disableStdin: one Bool,
+  replayWriteDepth: one Int
+}
+
+fact InitialState {
+  first.state = Live
+  no first.event
+  first.replayActive = False
+  first.replayEnded = True
+  first.disableStdin = False
+  first.replayWriteDepth = 0
+}
+
+fact StateEncoding {
+  all s: Step | {
+    s.state = Live implies {
+      s.replayActive = False
+      s.replayEnded = True
+      s.disableStdin = False
+      s.replayWriteDepth = 0
+    }
+
+    s.state = ReplayPendingEnd implies {
+      s.replayActive = True
+      s.replayEnded = False
+      s.disableStdin = True
+      s.replayWriteDepth >= 0
+    }
+
+    s.state = ReplayDraining implies {
+      s.replayActive = False
+      s.replayEnded = True
+      s.disableStdin = True
+      s.replayWriteDepth > 0
+    }
+  }
+}
+
+pred transition[cur, next: Step] {
+  next.event = ReplayStart implies {
+    cur.state = Live
+    next.state = ReplayPendingEnd
+    next.replayWriteDepth = 0
+  }
+
+  next.event = ReplayBinary implies {
+    cur.state = ReplayPendingEnd
+    next.state = ReplayPendingEnd
+    next.replayWriteDepth = cur.replayWriteDepth.plus[1]
+  }
+
+  next.event = ReplayEnd implies {
+    cur.state = ReplayPendingEnd
+    cur.replayWriteDepth = 0 implies {
+      next.state = Live
+      next.replayWriteDepth = 0
+    }
+    cur.replayWriteDepth > 0 implies {
+      next.state = ReplayDraining
+      next.replayWriteDepth = cur.replayWriteDepth
+    }
+  }
+
+  next.event = WriteComplete implies {
+    cur.state = ReplayPendingEnd implies {
+      cur.replayWriteDepth > 0
+      next.state = ReplayPendingEnd
+      next.replayWriteDepth = cur.replayWriteDepth.minus[1]
+    }
+
+    cur.state = ReplayDraining implies {
+      cur.replayWriteDepth > 0
+      cur.replayWriteDepth = 1 implies {
+        next.state = Live
+        next.replayWriteDepth = 0
+      }
+      cur.replayWriteDepth > 1 implies {
+        next.state = ReplayDraining
+        next.replayWriteDepth = cur.replayWriteDepth.minus[1]
+      }
+    }
+  }
+
+  next.event = Reconnect implies {
+    next.state = Live
+    next.replayWriteDepth = 0
+  }
+}
+
+fact Trace {
+  all s: Step - first | transition[prev[s], s]
+}
+
+assert LiveAlwaysEnablesInput {
+  all s: Step | s.state = Live implies s.disableStdin = False
+}
+
+assert ReplayStatesAlwaysSuppressInput {
+  all s: Step | s.state in ReplayPendingEnd + ReplayDraining implies s.disableStdin = True
+}
+
+assert DrainingRequiresQueuedWrites {
+  all s: Step | s.state = ReplayDraining implies s.replayWriteDepth > 0
+}
+
+assert ReconnectAlwaysResetsToLive {
+  all s: Step - first |
+    s.event = Reconnect implies {
+      s.state = Live
+      s.replayActive = False
+      s.replayEnded = True
+      s.disableStdin = False
+      s.replayWriteDepth = 0
+    }
+}
+
+assert NoStaleSuppressionInLive {
+  all s: Step |
+    s.state = Live implies {
+      s.replayActive = False
+      s.disableStdin = False
+      s.replayWriteDepth = 0
+    }
+}
+
+check LiveAlwaysEnablesInput for 8 Step, 8 Int
+check ReplayStatesAlwaysSuppressInput for 8 Step, 8 Int
+check DrainingRequiresQueuedWrites for 8 Step, 8 Int
+check ReconnectAlwaysResetsToLive for 8 Step, 8 Int
+check NoStaleSuppressionInLive for 8 Step, 8 Int
+

--- a/docs/models/replay_state.als
+++ b/docs/models/replay_state.als
@@ -6,7 +6,7 @@ abstract sig ReplayState {}
 one sig Live, ReplayPendingEnd, ReplayDraining extends ReplayState {}
 
 abstract sig Event {}
-one sig ReplayStart, ReplayBinary, ReplayEnd, WriteComplete, Reconnect extends Event {}
+one sig ReplayStart, ReplayBinary, ReplayEnd, WriteComplete, SocketClose, ReplayEndWriteFail, Reconnect extends Event {}
 
 abstract sig Flag {}
 one sig Enabled, Disabled extends Flag {}
@@ -103,6 +103,23 @@ pred transition[cur, next: Step] {
     next.state = Live
     next.replayWriteDepth = 0
   }
+
+  next.event = SocketClose implies {
+    next.state = cur.state
+    next.replayActive = cur.replayActive
+    next.replayEnded = cur.replayEnded
+    next.disableStdin = cur.disableStdin
+    next.replayWriteDepth = cur.replayWriteDepth
+  }
+
+  next.event = ReplayEndWriteFail implies {
+    cur.state = ReplayPendingEnd
+    next.state = ReplayPendingEnd
+    next.replayActive = Enabled
+    next.replayEnded = Disabled
+    next.disableStdin = Enabled
+    next.replayWriteDepth = cur.replayWriteDepth
+  }
 }
 
 fact Trace {
@@ -141,8 +158,28 @@ assert NoStaleSuppressionInLive {
     }
 }
 
+assert ReplayEndWriteFailureLeavesReplayPendingUntilReconnect {
+  all s: Step - first |
+    s.event = ReplayEndWriteFail implies {
+      s.state = ReplayPendingEnd
+      s.replayActive = Enabled
+      s.replayEnded = Disabled
+      s.disableStdin = Enabled
+    }
+}
+
+assert SocketCloseDoesNotFalselyRestoreLive {
+  all s: Step - first |
+    s.event = SocketClose and prev[s].state in ReplayPendingEnd + ReplayDraining implies {
+      s.state = prev[s].state
+      s.disableStdin = Enabled
+    }
+}
+
 check LiveAlwaysEnablesInput for 8 Step, 8 Int
 check ReplayStatesAlwaysSuppressInput for 8 Step, 8 Int
 check DrainingRequiresQueuedWrites for 8 Step, 8 Int
 check ReconnectAlwaysResetsToLive for 8 Step, 8 Int
 check NoStaleSuppressionInLive for 8 Step, 8 Int
+check ReplayEndWriteFailureLeavesReplayPendingUntilReconnect for 8 Step, 8 Int
+check SocketCloseDoesNotFalselyRestoreLive for 8 Step, 8 Int

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -356,6 +356,31 @@ describe('useTerminal', () => {
     expect(writesDisableState).toEqual([true, false])
   })
 
+  it('resets stale replay suppression when the socket reconnects', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const replayBuf = new TextEncoder().encode('replayed prompt').buffer
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'start' })
+      )
+    )
+    act(() => MockWebSocket.instances[0].simulateMessage(replayBuf))
+    expect(mockTerm.options.disableStdin).toBe(true)
+
+    act(() => MockWebSocket.instances[0].simulateOpen())
+    expect(mockTerm.options.disableStdin).toBe(false)
+
+    mockWrite.mockClear()
+    const liveBuf = new TextEncoder().encode('live output').buffer
+    act(() => MockWebSocket.instances[0].simulateMessage(liveBuf))
+
+    expect(mockWrite).toHaveBeenCalledWith(expect.any(Uint8Array))
+    expect(mockTerm.options.disableStdin).toBe(false)
+  })
+
   it('buffers terminal output that arrives before the container is attached', () => {
     const buf = new TextEncoder().encode('prompt before attach').buffer
     const container = makeContainer()

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -7,6 +7,7 @@ import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 const { mockWrite, mockTerm, mockFitAddon, mockTerminalCtor } = vi.hoisted(() => {
   const mockWrite = vi.fn()
   const mockTerm = {
+    options: { disableStdin: false },
     attachCustomKeyEventHandler: vi.fn(),
     element: undefined as HTMLElement | undefined,
     hasSelection: vi.fn(() => false),
@@ -19,7 +20,10 @@ const { mockWrite, mockTerm, mockFitAddon, mockTerminalCtor } = vi.hoisted(() =>
     cols: 80,
     rows: 24,
     refresh: vi.fn(),
-    write: mockWrite,
+    write: vi.fn((data: string | Uint8Array, callback?: () => void) => {
+      mockWrite(data)
+      callback?.()
+    }),
   }
   const mockFitAddon = { fit: vi.fn() }
   const mockTerminalCtor = vi.fn(function () { return mockTerm })
@@ -81,6 +85,7 @@ describe('useTerminal', () => {
       return 0
     }) as typeof window.requestAnimationFrame
     mockTerm.element = undefined
+    mockTerm.options.disableStdin = false
     mockTerm.open.mockImplementation((container: HTMLElement) => {
       const el = document.createElement('div')
       mockTerm.element = el
@@ -253,6 +258,102 @@ describe('useTerminal', () => {
     const buf = new ArrayBuffer(4)
     act(() => MockWebSocket.instances[0].simulateMessage(buf))
     expect(mockWrite).toHaveBeenCalledWith(expect.any(Uint8Array))
+  })
+
+  it('suppresses stdin while replayed output is being applied', () => {
+    const container = makeContainer()
+    const writesDisableState: boolean[] = []
+    mockTerm.write.mockImplementation((data: string | Uint8Array, callback?: () => void) => {
+      writesDisableState.push(mockTerm.options.disableStdin)
+      mockWrite(data)
+      callback?.()
+    })
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const replayBuf = new TextEncoder().encode('\u001b[>0;276;0c').buffer
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'start' })
+      )
+    )
+    expect(mockTerm.options.disableStdin).toBe(true)
+
+    act(() => MockWebSocket.instances[0].simulateMessage(replayBuf))
+    expect(writesDisableState).toEqual([true])
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'end' })
+      )
+    )
+    expect(mockTerm.options.disableStdin).toBe(false)
+  })
+
+  it('keeps replay stdin suppression across buffered remount flushes', () => {
+    const replayBuf = new TextEncoder().encode('\u001b[>0;276;0c').buffer
+    const container = makeContainer()
+    const writesDisableState: boolean[] = []
+    mockTerm.write.mockImplementation((data: string | Uint8Array, callback?: () => void) => {
+      writesDisableState.push(mockTerm.options.disableStdin)
+      mockWrite(data)
+      callback?.()
+    })
+    const { rerender } = renderHook(
+      ({ currentContainer }: { currentContainer: HTMLDivElement | null }) =>
+        useTerminal({ sessionId: 's1', container: currentContainer }),
+      { initialProps: { currentContainer: null as HTMLDivElement | null } },
+    )
+
+    act(() => MockWebSocket.instances[0].simulateOpen())
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'start' })
+      )
+    )
+    act(() => MockWebSocket.instances[0].simulateMessage(replayBuf))
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'end' })
+      )
+    )
+
+    rerender({ currentContainer: container })
+
+    expect(writesDisableState).toEqual([true])
+    expect(mockTerm.options.disableStdin).toBe(false)
+  })
+
+  it('restores stdin before applying live output after replay ends', () => {
+    const container = makeContainer()
+    const writesDisableState: boolean[] = []
+    mockTerm.write.mockImplementation((data: string | Uint8Array, callback?: () => void) => {
+      writesDisableState.push(mockTerm.options.disableStdin)
+      mockWrite(data)
+      callback?.()
+    })
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const replayBuf = new TextEncoder().encode('replayed prompt').buffer
+    const liveBuf = new TextEncoder().encode('live output').buffer
+
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'start' })
+      )
+    )
+    act(() => MockWebSocket.instances[0].simulateMessage(replayBuf))
+    act(() =>
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'replay', state: 'end' })
+      )
+    )
+    act(() => MockWebSocket.instances[0].simulateMessage(liveBuf))
+
+    expect(writesDisableState).toEqual([true, false])
   })
 
   it('buffers terminal output that arrives before the container is attached', () => {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -99,6 +99,8 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
     onMessage: handleMessage,
     onOpen: () => {
       setSessionExited(false)
+      const entry = entryRef.current
+      if (entry) resetReplayState(entry)
     },
   })
 
@@ -426,6 +428,13 @@ function writeTerminalBytes(entry: TerminalEntry, bytes: Uint8Array) {
     entry.replayWriteDepth--
     maybeRestoreTerminalInput(entry)
   })
+}
+
+function resetReplayState(entry: TerminalEntry) {
+  entry.replayActive = false
+  entry.replayWriteDepth = 0
+  entry.replayEnded = true
+  setTerminalInputSuppressed(entry, false)
 }
 
 function setTerminalInputSuppressed(entry: TerminalEntry, suppressed: boolean) {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -24,7 +24,7 @@ interface TerminalEntry {
   editMode: boolean
   replayActive: boolean
   replayWriteDepth: number
-  replayEnded: boolean
+  awaitingReplayEnd: boolean
 }
 
 interface PendingTerminalMessage {
@@ -64,11 +64,11 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
         } else if (msg.type === 'replay') {
           if (msg.state === 'start') {
             entry.replayActive = true
-            entry.replayEnded = false
+            entry.awaitingReplayEnd = true
             setTerminalInputSuppressed(entry, true)
           } else {
             entry.replayActive = false
-            entry.replayEnded = true
+            entry.awaitingReplayEnd = false
             maybeRestoreTerminalInput(entry)
           }
         } else if (msg.type === 'error') {
@@ -283,7 +283,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     editMode: false,
     replayActive: false,
     replayWriteDepth: 0,
-    replayEnded: true,
+    awaitingReplayEnd: false,
   }
 
   term.loadAddon(fitAddon)
@@ -433,7 +433,7 @@ function writeTerminalBytes(entry: TerminalEntry, bytes: Uint8Array) {
 function resetReplayState(entry: TerminalEntry) {
   entry.replayActive = false
   entry.replayWriteDepth = 0
-  entry.replayEnded = true
+  entry.awaitingReplayEnd = false
   setTerminalInputSuppressed(entry, false)
 }
 
@@ -442,7 +442,7 @@ function setTerminalInputSuppressed(entry: TerminalEntry, suppressed: boolean) {
 }
 
 function maybeRestoreTerminalInput(entry: TerminalEntry) {
-  if (!entry.replayEnded || entry.replayWriteDepth > 0) return
+  if (entry.awaitingReplayEnd || entry.replayWriteDepth > 0) return
   setTerminalInputSuppressed(entry, false)
 }
 

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -22,6 +22,9 @@ interface TerminalEntry {
   resizeTimers: Set<ReturnType<typeof setTimeout>>
   send: ((data: string | ArrayBuffer | Uint8Array) => void) | null
   editMode: boolean
+  replayActive: boolean
+  replayWriteDepth: number
+  replayEnded: boolean
 }
 
 interface PendingTerminalMessage {
@@ -43,11 +46,12 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
 
   const applyMessageToTerminal = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
     const term = termRef.current
-    if (!term) return
+    const entry = entryRef.current
+    if (!term || !entry) return
 
     if (isBinary) {
       const bytes = new Uint8Array(data as ArrayBuffer)
-      term.write(bytes)
+      writeTerminalBytes(entry, bytes)
     } else {
       try {
         const msg = JSON.parse(data as string)
@@ -56,6 +60,16 @@ export function useTerminal({ sessionId, container, editMode = false }: UseTermi
           if (msg.state === 'exited') {
             setSessionExited(true)
             term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
+          }
+        } else if (msg.type === 'replay') {
+          if (msg.state === 'start') {
+            entry.replayActive = true
+            entry.replayEnded = false
+            setTerminalInputSuppressed(entry, true)
+          } else {
+            entry.replayActive = false
+            entry.replayEnded = true
+            maybeRestoreTerminalInput(entry)
           }
         } else if (msg.type === 'error') {
           const safeMsg = msg.message.replace(/\x1b\[[0-9;?<>!]*[A-Za-z]/g, '')
@@ -265,6 +279,9 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     resizeTimers: new Set(),
     send: null,
     editMode: false,
+    replayActive: false,
+    replayWriteDepth: 0,
+    replayEnded: true,
   }
 
   term.loadAddon(fitAddon)
@@ -395,6 +412,29 @@ export function __resetTerminalEntriesForTests() {
     entry.term.dispose()
   }
   terminalEntries.clear()
+}
+
+function writeTerminalBytes(entry: TerminalEntry, bytes: Uint8Array) {
+  const replayWrite = entry.replayActive
+  if (replayWrite) {
+    entry.replayWriteDepth++
+    setTerminalInputSuppressed(entry, true)
+  }
+
+  entry.term.write(bytes, () => {
+    if (!replayWrite) return
+    entry.replayWriteDepth--
+    maybeRestoreTerminalInput(entry)
+  })
+}
+
+function setTerminalInputSuppressed(entry: TerminalEntry, suppressed: boolean) {
+  entry.term.options.disableStdin = suppressed
+}
+
+function maybeRestoreTerminalInput(entry: TerminalEntry) {
+  if (!entry.replayEnded || entry.replayWriteDepth > 0) return
+  setTerminalInputSuppressed(entry, false)
 }
 
 function isCopyShortcut(event: KeyboardEvent): boolean {

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -249,6 +249,18 @@ describe('WSControlMessageSchema', () => {
     expect(result.success).toBe(true)
   })
 
+  it('accepts replay lifecycle messages', () => {
+    expect(WSControlMessageSchema.safeParse({
+      type: 'replay',
+      state: 'start',
+    }).success).toBe(true)
+
+    expect(WSControlMessageSchema.safeParse({
+      type: 'replay',
+      state: 'end',
+    }).success).toBe(true)
+  })
+
   it('rejects unknown type', () => {
     const result = WSControlMessageSchema.safeParse({ type: 'unknown' })
     expect(result.success).toBe(false)

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -90,6 +90,7 @@ export const WSControlMessageSchema = z.discriminatedUnion('type', [
     rows: z.number().positive(),
   }),
   z.object({ type: z.literal('status'), state: z.string() }),
+  z.object({ type: z.literal('replay'), state: z.enum(['start', 'end']) }),
   z.object({ type: z.literal('error'), message: z.string().max(2000) }),
 ])
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -67,6 +67,10 @@ type ControlMessage struct {
 	Rows    uint16 `json:"rows,omitempty"`
 }
 
+type messageWriter interface {
+	WriteMessage(messageType int, data []byte) error
+}
+
 // Handler handles WebSocket connections for terminal sessions.
 type Handler struct {
 	manager *session.Manager
@@ -143,11 +147,15 @@ func (h *Handler) forwardTerminalOutput(
 	// workspace switch from showing a blank xterm when the PTY already emitted the
 	// prompt while the pane was unmounted.
 	if len(snapshot) > 0 {
-		h.sendReplay(conn, "start")
+		if !h.sendReplay(conn, "start") {
+			return
+		}
 		if err := conn.WriteMessage(websocket.BinaryMessage, snapshot); err != nil {
 			return
 		}
-		h.sendReplay(conn, "end")
+		if !h.sendReplay(conn, "end") {
+			return
+		}
 	}
 
 	for chunk := range updates {
@@ -228,13 +236,14 @@ func (h *Handler) handleControl(conn *websocket.Conn, sess session.Session, msg 
 }
 
 func (h *Handler) sendStatus(conn *websocket.Conn, state string) {
-	msg := ControlMessage{Type: "status", State: state}
-	data, _ := json.Marshal(msg)
-	_ = conn.WriteMessage(websocket.TextMessage, data)
+	_ = writeControlMessage(conn, ControlMessage{Type: "status", State: state})
 }
 
-func (h *Handler) sendReplay(conn *websocket.Conn, state string) {
-	msg := ControlMessage{Type: "replay", State: state}
+func (h *Handler) sendReplay(conn *websocket.Conn, state string) bool {
+	return writeControlMessage(conn, ControlMessage{Type: "replay", State: state})
+}
+
+func writeControlMessage(conn messageWriter, msg ControlMessage) bool {
 	data, _ := json.Marshal(msg)
-	_ = conn.WriteMessage(websocket.TextMessage, data)
+	return conn.WriteMessage(websocket.TextMessage, data) == nil
 }

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -143,9 +143,11 @@ func (h *Handler) forwardTerminalOutput(
 	// workspace switch from showing a blank xterm when the PTY already emitted the
 	// prompt while the pane was unmounted.
 	if len(snapshot) > 0 {
+		h.sendReplay(conn, "start")
 		if err := conn.WriteMessage(websocket.BinaryMessage, snapshot); err != nil {
 			return
 		}
+		h.sendReplay(conn, "end")
 	}
 
 	for chunk := range updates {
@@ -227,6 +229,12 @@ func (h *Handler) handleControl(conn *websocket.Conn, sess session.Session, msg 
 
 func (h *Handler) sendStatus(conn *websocket.Conn, state string) {
 	msg := ControlMessage{Type: "status", State: state}
+	data, _ := json.Marshal(msg)
+	_ = conn.WriteMessage(websocket.TextMessage, data)
+}
+
+func (h *Handler) sendReplay(conn *websocket.Conn, state string) {
+	msg := ControlMessage{Type: "replay", State: state}
 	data, _ := json.Marshal(msg)
 	_ = conn.WriteMessage(websocket.TextMessage, data)
 }

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -30,6 +30,31 @@ type wsMockSession struct {
 	readErr error
 }
 
+type recordedWrite struct {
+	data        []byte
+	messageType int
+}
+
+type recordingConn struct {
+	writes      []recordedWrite
+	failAtWrite int
+}
+
+func newRecordingConn() *recordingConn {
+	return &recordingConn{}
+}
+
+func (c *recordingConn) WriteMessage(messageType int, data []byte) error {
+	if c.failAtWrite > 0 && len(c.writes)+1 == c.failAtWrite {
+		return io.ErrClosedPipe
+	}
+	c.writes = append(c.writes, recordedWrite{
+		messageType: messageType,
+		data:        append([]byte(nil), data...),
+	})
+	return nil
+}
+
 func newWsMock(id string) *wsMockSession {
 	return &wsMockSession{
 		id:      id,
@@ -258,6 +283,25 @@ func TestWS_SkipsReplayFramesWhenSnapshotEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, websocket.BinaryMessage, msgType)
 	assert.Equal(t, []byte("live output"), data)
+}
+
+func TestWS_ReplayStartWriteFailureStopsBeforeReplayBody(t *testing.T) {
+	recorder := newRecordingConn()
+	recorder.failAtWrite = 2
+
+	ok := writeControlMessage(recorder, ControlMessage{Type: "replay", State: "start"})
+	require.True(t, ok)
+
+	ok = writeControlMessage(recorder, ControlMessage{Type: "replay", State: "end"})
+	require.False(t, ok)
+
+	require.Len(t, recorder.writes, 1)
+	assert.Equal(t, websocket.TextMessage, recorder.writes[0].messageType)
+
+	var replayStart ControlMessage
+	require.NoError(t, json.Unmarshal(recorder.writes[0].data, &replayStart))
+	assert.Equal(t, "replay", replayStart.Type)
+	assert.Equal(t, "start", replayStart.State)
 }
 
 func TestWS_SendsExitedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -176,7 +176,7 @@ func TestWS_SessionOutput_ReceivedAsBinary(t *testing.T) {
 	assert.Equal(t, []byte("terminal output"), data)
 }
 
-func TestWS_ReplaysBufferedOutputOnFirstConnect(t *testing.T) {
+func TestWS_ReplayFramesWrapBufferedOutput(t *testing.T) {
 	mgr := session.NewManager()
 	sess := newWsMock("s1")
 	mgr.Add(sess)
@@ -192,15 +192,72 @@ func TestWS_ReplaysBufferedOutputOnFirstConnect(t *testing.T) {
 	defer sess.Close()
 
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	msgType, _, err := conn.ReadMessage()
+	msgType, data, err := conn.ReadMessage()
 	require.NoError(t, err)
 	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var connected ControlMessage
+	require.NoError(t, json.Unmarshal(data, &connected))
+	assert.Equal(t, "status", connected.Type)
+	assert.Equal(t, "connected", connected.State)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var replayStart ControlMessage
+	require.NoError(t, json.Unmarshal(data, &replayStart))
+	assert.Equal(t, "replay", replayStart.Type)
+	assert.Equal(t, "start", replayStart.State)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.BinaryMessage, msgType)
+	assert.Equal(t, []byte("buffered prompt"), data)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var replayEnd ControlMessage
+	require.NoError(t, json.Unmarshal(data, &replayEnd))
+	assert.Equal(t, "replay", replayEnd.Type)
+	assert.Equal(t, "end", replayEnd.State)
+}
+
+func TestWS_SkipsReplayFramesWhenSnapshotEmpty(t *testing.T) {
+	mgr := session.NewManager()
+	sess := newWsMock("s1")
+	mgr.Add(sess)
+
+	srv := setupWSServer(mgr)
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv, "s1"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+	defer sess.Close()
 
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	msgType, data, err := conn.ReadMessage()
 	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var connected ControlMessage
+	require.NoError(t, json.Unmarshal(data, &connected))
+	assert.Equal(t, "status", connected.Type)
+	assert.Equal(t, "connected", connected.State)
+
+	sess.out <- []byte("live output")
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
 	assert.Equal(t, websocket.BinaryMessage, msgType)
-	assert.Equal(t, []byte("buffered prompt"), data)
+	assert.Equal(t, []byte("live output"), data)
 }
 
 func TestWS_SendsExitedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -285,7 +285,7 @@ func TestWS_SkipsReplayFramesWhenSnapshotEmpty(t *testing.T) {
 	assert.Equal(t, []byte("live output"), data)
 }
 
-func TestWS_ReplayStartWriteFailureStopsBeforeReplayBody(t *testing.T) {
+func TestWS_ReplayEndWriteFailureDetected(t *testing.T) {
 	recorder := newRecordingConn()
 	recorder.failAtWrite = 2
 


### PR DESCRIPTION
## Summary
- add explicit WebSocket replay lifecycle frames around buffered session snapshots
- suppress xterm stdin only while replayed bytes are being re-applied so replayed terminal queries do not become shell input
- cover the replay protocol and suppression behavior in frontend/backend tests and document the protocol update

## Test plan
- [x] npm test -- src/hooks/useTerminal.test.ts src/schemas/index.test.ts
- [x] make test-frontend
- [x] go test ./internal/ws
- [x] make lint-go
- [x] make test-go
