### PR TITLE
feat: add directory browser for pane working directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,11 @@ Sessions are started at server startup from the YAML config (`main.go: startSess
 
 ## Development Rules
 
+### Path sanitization
+- Do not record real local or remote directory paths from a developer machine or environment in tests, fixtures, docs, screenshots, PR bodies, review replies, or commit history.
+- Replace environment-specific paths with clearly fake placeholders such as `/workspace/user/project`, `/tmp/sample-project`, or `/remote/home/demo`.
+- If a real path is used temporarily for investigation, remove it before committing and rewrite the branch history if that path already landed in a published commit on the PR branch.
+
 ### TDD
 - Always **write tests first**, confirm they fail, then implement.
 - Go: all tests must pass (`make test-go`) before moving on.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Common uses:
 - A pane with `connection: my-host` can use either a named `ssh_connections` entry or a `Host my-host` entry from `~/.ssh/config`.
 - `tmux` and `ssh_tmux` panes automatically create the target tmux session if it does not already exist.
 - Set `cwd` on `local`, `ssh`, or `ssh_tmux` panes when you want the shell to start in a specific directory.
+- In the pane settings dialog, `Working Directory` can be chosen from a browsable directory tree for both local and SSH-backed panes. Hidden directories are available through a toggle.
 
 ---
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -98,6 +98,8 @@ Host-key verification uses `known_hosts_file` if configured, or `~/.ssh/known_ho
 
 `cwd` is validated against `validRemotePath` before use: absolute paths only, no shell metacharacters (`;|&$` + "`" + `'"<>(){}[]!`), no control characters. See *Security Design* in `architecture.md`.
 
+Pane settings in the frontend expose a directory browser for `cwd`. Local and local tmux panes browse the local filesystem; `ssh` and `ssh_tmux` panes browse the selected SSH connection's remote filesystem. The browser lists directories only and hides dot-directories by default unless the user enables the hidden-directory toggle.
+
 Persistence behavior:
 
 - layout and workspace changes are persisted immediately when a save path is available

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -88,6 +88,7 @@ vi.mock('./hooks/usePaneSettings', () => ({
     saveSettings: vi.fn(),
     addSSHConfigHost: vi.fn(),
     detectShell: vi.fn(),
+    browseDirectories: vi.fn(),
   }),
 }))
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,7 @@ export const App: React.FC = () => {
   const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
   const [attentionPaneIds, setAttentionPaneIds] = useState<Set<string>>(() => new Set())
-  const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell } =
+  const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell, browseDirectories } =
     usePaneSettings(layout, updateSizes)
 
   const [isAddSSHHostOpen, setIsAddSSHHostOpen] = useState(false)
@@ -338,6 +338,7 @@ export const App: React.FC = () => {
           onClose={closeSettings}
           onAddSSHHost={() => setIsAddSSHHostOpen(true)}
           onDetectShell={detectShell}
+          onBrowseDirectories={browseDirectories}
         />
         <AddSSHHostDialog
           isOpen={isAddSSHHostOpen}

--- a/frontend/src/components/PaneSettingsDialog.test.tsx
+++ b/frontend/src/components/PaneSettingsDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { PaneSettingsDialog } from './PaneSettingsDialog'
 
 const defaultProps = {
@@ -12,6 +12,10 @@ const defaultProps = {
   onClose: vi.fn(),
   onAddSSHHost: vi.fn(),
   onDetectShell: vi.fn().mockResolvedValue('/bin/zsh'),
+  onBrowseDirectories: vi.fn().mockResolvedValue({
+    path: '/workspace/user',
+    entries: [{ name: 'projects', path: '/workspace/user/projects', has_children: true }],
+  }),
 }
 
 describe('PaneSettingsDialog', () => {
@@ -70,5 +74,120 @@ describe('PaneSettingsDialog', () => {
       maxHeight: 'calc(100vh - 32px)',
       overflowY: 'auto',
     })
+  })
+
+  it('loads directories when Browse is clicked and updates cwd when one is selected', async () => {
+    const onBrowseDirectories = vi.fn().mockResolvedValue({
+      path: '/workspace/user',
+      entries: [{ name: 'projects', path: '/workspace/user/projects', has_children: false }],
+    })
+    render(<PaneSettingsDialog {...defaultProps} onBrowseDirectories={onBrowseDirectories} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }))
+
+    await waitFor(() => expect(onBrowseDirectories).toHaveBeenCalled())
+    expect(screen.getByRole('dialog', { name: 'Directory browser' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '/workspace/user/projects' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Choose Directory' }))
+
+    expect(screen.getByLabelText('Working Directory')).toHaveValue('/workspace/user/projects')
+  })
+
+  it('opens the browser dialog even when the current directory has no child directories', async () => {
+    const onBrowseDirectories = vi.fn().mockResolvedValue({
+      path: '/tmp/sample-project',
+      entries: [],
+    })
+    render(
+      <PaneSettingsDialog
+        {...defaultProps}
+        pane={{ id: 'main', type: 'local', title: 'Main', shell: '/bin/zsh', cwd: '/tmp/sample-project' }}
+        onBrowseDirectories={onBrowseDirectories}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }))
+
+    expect(screen.getByRole('dialog', { name: 'Directory browser' })).toBeInTheDocument()
+    await screen.findByText('No directories found.')
+  })
+
+  it('disables Browse for SSH panes until a connection is selected', () => {
+    render(<PaneSettingsDialog
+      {...defaultProps}
+      pane={{ id: 'remote', type: 'ssh', title: 'Remote' }}
+      sshConnectionNames={['prod']}
+    />)
+
+    expect(screen.getByRole('button', { name: 'Browse' })).toBeDisabled()
+    expect(screen.getByText('Select an SSH connection to browse remote directories.')).toBeInTheDocument()
+  })
+
+  it('shows hidden directories after toggling the visibility option', async () => {
+    const onBrowseDirectories = vi.fn()
+      .mockResolvedValueOnce({
+        path: '/workspace/user',
+        entries: [{ name: 'visible', path: '/workspace/user/visible', has_children: false }],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace/user',
+        entries: [{ name: '.config', path: '/workspace/user/.config', has_children: true }],
+      })
+    render(<PaneSettingsDialog {...defaultProps} onBrowseDirectories={onBrowseDirectories} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }))
+    await screen.findByText('visible')
+
+    fireEvent.click(screen.getByLabelText('Show hidden directories'))
+
+    await screen.findByText('.config')
+    expect(onBrowseDirectories).toHaveBeenLastCalledWith('local', undefined, '/workspace/user', true)
+  })
+
+  it('can navigate to the parent directory from the browser dialog', async () => {
+    const onBrowseDirectories = vi.fn()
+      .mockResolvedValueOnce({
+        path: '/workspace/user/projects',
+        entries: [{ name: 'app', path: '/workspace/user/projects/app', has_children: false }],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace/user',
+        entries: [{ name: 'projects', path: '/workspace/user/projects', has_children: true }],
+      })
+
+    render(
+      <PaneSettingsDialog
+        {...defaultProps}
+        pane={{ id: 'main', type: 'local', title: 'Main', shell: '/bin/zsh', cwd: '/workspace/user/projects' }}
+        onBrowseDirectories={onBrowseDirectories}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }))
+    await screen.findByText('app')
+    fireEvent.click(screen.getByRole('button', { name: 'Go to parent directory' }))
+
+    await screen.findByText('projects')
+    expect(onBrowseDirectories).toHaveBeenLastCalledWith('local', undefined, '/workspace/user', false)
+  })
+
+  it('selects and expands a directory row on single click', async () => {
+    const onBrowseDirectories = vi.fn()
+      .mockResolvedValueOnce({
+        path: '/workspace/user',
+        entries: [{ name: 'projects', path: '/workspace/user/projects', has_children: true }],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace/user/projects',
+        entries: [{ name: 'sample-app', path: '/workspace/user/projects/sample-app', has_children: false }],
+      })
+    render(<PaneSettingsDialog {...defaultProps} onBrowseDirectories={onBrowseDirectories} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Browse' }))
+    await screen.findByText('projects')
+
+    fireEvent.click(screen.getByRole('button', { name: '/workspace/user/projects' }))
+
+    await screen.findByText('sample-app')
   })
 })

--- a/frontend/src/components/PaneSettingsDialog.tsx
+++ b/frontend/src/components/PaneSettingsDialog.tsx
@@ -91,6 +91,18 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   const [isBrowsingDirectories, setIsBrowsingDirectories] = useState(false)
   const [showHiddenDirectories, setShowHiddenDirectories] = useState(false)
 
+  function resetDirectoryBrowser() {
+    setShowDirectoryBrowser(false)
+    setDirectoryResponses({})
+    setExpandedDirectories({})
+    setBrowserPath('')
+    setBrowserInputPath('')
+    setBrowserSelection('')
+    setBrowseError(null)
+    setIsBrowsingDirectories(false)
+    setShowHiddenDirectories(false)
+  }
+
   useEffect(() => {
     if (pane) {
       setType(pane.type)
@@ -129,18 +141,6 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   const needsTmux = type === 'tmux' || type === 'ssh_tmux'
   const needsShell = type === 'local' || type === 'ssh' || type === 'ssh_tmux'
   const canBrowseDirectories = !needsConnection || connection !== ''
-
-  function resetDirectoryBrowser() {
-    setShowDirectoryBrowser(false)
-    setDirectoryResponses({})
-    setExpandedDirectories({})
-    setBrowserPath('')
-    setBrowserInputPath('')
-    setBrowserSelection('')
-    setBrowseError(null)
-    setIsBrowsingDirectories(false)
-    setShowHiddenDirectories(false)
-  }
 
   const handleDetectShell = async () => {
     setIsDetecting(true)

--- a/frontend/src/components/PaneSettingsDialog.tsx
+++ b/frontend/src/components/PaneSettingsDialog.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import type { PaneConfig } from '../types'
+import React, { useEffect, useState } from 'react'
+import type { DirectoryBrowserResponse, PaneConfig } from '../types'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
 interface PaneSettingsDialogProps {
@@ -12,6 +12,12 @@ interface PaneSettingsDialogProps {
   onClose: () => void
   onAddSSHHost: () => void
   onDetectShell: (type: PaneConfig['type'], connection?: string) => Promise<string>
+  onBrowseDirectories: (
+    type: PaneConfig['type'],
+    connection?: string,
+    path?: string,
+    showHidden?: boolean,
+  ) => Promise<DirectoryBrowserResponse>
 }
 
 const PANE_TYPES: Array<{ value: PaneConfig['type']; label: string }> = [
@@ -45,6 +51,16 @@ const fieldStyle: React.CSSProperties = {
   marginBottom: '12px',
 }
 
+const explorerButtonStyle: React.CSSProperties = {
+  padding: 0,
+  backgroundColor: 'transparent',
+  color: '#d4d4d4',
+  border: 'none',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '12px',
+  cursor: 'pointer',
+}
+
 export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   isOpen,
   pane,
@@ -55,6 +71,7 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   onClose,
   onAddSSHHost,
   onDetectShell,
+  onBrowseDirectories,
 }) => {
   const [type, setType] = useState<PaneConfig['type']>('local')
   const [shell, setShell] = useState('')
@@ -64,6 +81,15 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   const [title, setTitle] = useState('')
   const [validationError, setValidationError] = useState<string | null>(null)
   const [isDetecting, setIsDetecting] = useState(false)
+  const [showDirectoryBrowser, setShowDirectoryBrowser] = useState(false)
+  const [directoryResponses, setDirectoryResponses] = useState<Record<string, DirectoryBrowserResponse>>({})
+  const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({})
+  const [browserPath, setBrowserPath] = useState('')
+  const [browserInputPath, setBrowserInputPath] = useState('')
+  const [browserSelection, setBrowserSelection] = useState('')
+  const [browseError, setBrowseError] = useState<string | null>(null)
+  const [isBrowsingDirectories, setIsBrowsingDirectories] = useState(false)
+  const [showHiddenDirectories, setShowHiddenDirectories] = useState(false)
 
   useEffect(() => {
     if (pane) {
@@ -75,7 +101,7 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
       setCwd(pane.cwd ?? '')
       setTitle(pane.title ?? '')
       setValidationError(null)
-      // Auto-detect shell for local panes when shell is not set
+      resetDirectoryBrowser()
       if (pane.type === 'local' && !existingShell) {
         onDetectShell('local').then(setShell).catch(() => {})
       }
@@ -85,17 +111,36 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
   useEffect(() => {
     if (!isOpen || !pane || isSaving) return
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+      if (event.key === 'Escape') {
+        if (showDirectoryBrowser) {
+          setShowDirectoryBrowser(false)
+          return
+        }
+        onClose()
+      }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, isSaving, onClose, pane])
+  }, [isOpen, isSaving, onClose, pane, showDirectoryBrowser])
 
   if (!isOpen || !pane) return null
 
   const needsConnection = type === 'ssh' || type === 'ssh_tmux'
   const needsTmux = type === 'tmux' || type === 'ssh_tmux'
   const needsShell = type === 'local' || type === 'ssh' || type === 'ssh_tmux'
+  const canBrowseDirectories = !needsConnection || connection !== ''
+
+  function resetDirectoryBrowser() {
+    setShowDirectoryBrowser(false)
+    setDirectoryResponses({})
+    setExpandedDirectories({})
+    setBrowserPath('')
+    setBrowserInputPath('')
+    setBrowserSelection('')
+    setBrowseError(null)
+    setIsBrowsingDirectories(false)
+    setShowHiddenDirectories(false)
+  }
 
   const handleDetectShell = async () => {
     setIsDetecting(true)
@@ -107,6 +152,178 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
     } finally {
       setIsDetecting(false)
     }
+  }
+
+  const browseDirectory = async (path: string) => {
+    setIsBrowsingDirectories(true)
+    setBrowseError(null)
+    try {
+      const response = await onBrowseDirectories(
+        type,
+        needsConnection ? connection || undefined : undefined,
+        path,
+        showHiddenDirectories,
+      )
+      setDirectoryResponses({ [response.path]: response })
+      setExpandedDirectories({ [response.path]: true })
+      setBrowserPath(response.path)
+      setBrowserInputPath(response.path)
+      setBrowserSelection(response.path)
+      return response
+    } catch (err) {
+      setBrowseError(err instanceof Error ? err.message : 'Failed to browse directories')
+      return null
+    } finally {
+      setIsBrowsingDirectories(false)
+    }
+  }
+
+  const openDirectoryBrowser = async () => {
+    setShowDirectoryBrowser(true)
+    await browseDirectory(cwd)
+  }
+
+  const toggleDirectory = async (path: string, hasChildren: boolean) => {
+    if (!hasChildren) return
+    if (!expandedDirectories[path]) {
+      setIsBrowsingDirectories(true)
+      setBrowseError(null)
+      try {
+        const response = await onBrowseDirectories(
+          type,
+          needsConnection ? connection || undefined : undefined,
+          path,
+          showHiddenDirectories,
+        )
+        setDirectoryResponses((current) => ({ ...current, [response.path]: response }))
+      } catch (err) {
+        setBrowseError(err instanceof Error ? err.message : 'Failed to browse directories')
+        setIsBrowsingDirectories(false)
+        return
+      } finally {
+        setIsBrowsingDirectories(false)
+      }
+    }
+    setExpandedDirectories((current) => ({ ...current, [path]: !current[path] }))
+  }
+
+  const handleToggleHiddenDirectories = async (nextValue: boolean) => {
+    setShowHiddenDirectories(nextValue)
+    if (!showDirectoryBrowser) return
+    setIsBrowsingDirectories(true)
+    setBrowseError(null)
+    try {
+      const response = await onBrowseDirectories(
+        type,
+        needsConnection ? connection || undefined : undefined,
+        browserPath,
+        nextValue,
+      )
+      setDirectoryResponses({ [response.path]: response })
+      setExpandedDirectories({ [response.path]: true })
+      setBrowserPath(response.path)
+      setBrowserInputPath(response.path)
+      if (browserSelection === '' || browserSelection === browserPath) {
+        setBrowserSelection(response.path)
+      }
+    } catch (err) {
+      setBrowseError(err instanceof Error ? err.message : 'Failed to browse directories')
+    } finally {
+      setIsBrowsingDirectories(false)
+    }
+  }
+
+  const applyDirectorySelection = () => {
+    setCwd(browserSelection)
+    setShowDirectoryBrowser(false)
+  }
+
+  const handleGoToParent = async () => {
+    const parent = parentDirectory(browserPath)
+    if (parent === browserPath) return
+    await browseDirectory(parent)
+  }
+
+  const renderDirectoryEntries = (path: string, depth = 0): React.ReactNode => {
+    const response = directoryResponses[path]
+    if (!response) return null
+
+    return response.entries.map((entry) => {
+      const isSelected = browserSelection === entry.path
+      return (
+        <div key={entry.path}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              paddingLeft: `${depth * 14}px`,
+              borderRadius: '4px',
+              backgroundColor: isSelected ? '#04395e' : 'transparent',
+            }}
+          >
+            <button
+              type="button"
+              aria-label={`toggle ${entry.path}`}
+              onClick={(event) => {
+                event.stopPropagation()
+                void toggleDirectory(entry.path, entry.has_children)
+              }}
+              disabled={!entry.has_children}
+              style={{
+                ...explorerButtonStyle,
+                width: '24px',
+                height: '24px',
+                fontSize: '15px',
+                lineHeight: '24px',
+                color: entry.has_children ? '#e5e7eb' : '#666666',
+                cursor: entry.has_children ? 'pointer' : 'default',
+              }}
+            >
+              {entry.has_children ? (expandedDirectories[entry.path] ? '▾' : '▸') : ''}
+            </button>
+            <button
+              type="button"
+              aria-label={entry.path}
+              onClick={() => {
+                setBrowserSelection(entry.path)
+                if (entry.has_children) {
+                  void toggleDirectory(entry.path, entry.has_children)
+                }
+              }}
+              onDoubleClick={() => {
+                setBrowserSelection(entry.path)
+                setCwd(entry.path)
+                setShowDirectoryBrowser(false)
+              }}
+              style={{
+                ...explorerButtonStyle,
+                flex: 1,
+                minHeight: '28px',
+                padding: '4px 6px',
+                textAlign: 'left',
+                color: isSelected ? '#ffffff' : '#d4d4d4',
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  display: 'inline-block',
+                  width: '16px',
+                  marginRight: '6px',
+                  color: '#d7ba7d',
+                  fontSize: '14px',
+                  textAlign: 'center',
+                }}
+              >
+                ●
+              </span>
+              {entry.name}
+            </button>
+          </div>
+          {expandedDirectories[entry.path] ? renderDirectoryEntries(entry.path, depth + 1) : null}
+        </div>
+      )
+    })
   }
 
   const handleSave = async () => {
@@ -183,6 +400,7 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
               const newType = e.target.value as PaneConfig['type']
               setType(newType)
               setValidationError(null)
+              resetDirectoryBrowser()
               if (newType === 'local' && !shell) {
                 onDetectShell(newType).then(setShell).catch(() => {})
               }
@@ -207,20 +425,10 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
                 style={{ ...inputStyle, flex: 1 }}
               />
               <button
+                type="button"
                 onClick={handleDetectShell}
                 disabled={isDetecting || (needsConnection && !connection)}
-                style={{
-                  padding: '5px 10px',
-                  backgroundColor: 'transparent',
-                  color: '#888',
-                  border: '1px solid #555',
-                  borderRadius: '3px',
-                  fontFamily: TERMINAL_FONT_FAMILY,
-                  fontSize: '13px',
-                  cursor: 'pointer',
-                  whiteSpace: 'nowrap',
-                  opacity: (isDetecting || (needsConnection && !connection)) ? 0.5 : 1,
-                }}
+                style={actionButtonStyle(isDetecting || (needsConnection && !connection))}
               >
                 {isDetecting ? '…' : 'Detect'}
               </button>
@@ -234,7 +442,11 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
             <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
               <select
                 value={connection}
-                onChange={(e) => { setConnection(e.target.value); setValidationError(null) }}
+                onChange={(e) => {
+                  setConnection(e.target.value)
+                  setValidationError(null)
+                  resetDirectoryBrowser()
+                }}
                 style={{ ...inputStyle, flex: 1 }}
               >
                 <option value="">— select connection —</option>
@@ -243,18 +455,9 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
                 ))}
               </select>
               <button
+                type="button"
                 onClick={onAddSSHHost}
-                style={{
-                  padding: '5px 10px',
-                  backgroundColor: 'transparent',
-                  color: '#888',
-                  border: '1px solid #555',
-                  borderRadius: '3px',
-                  fontFamily: TERMINAL_FONT_FAMILY,
-                  fontSize: '13px',
-                  cursor: 'pointer',
-                  whiteSpace: 'nowrap',
-                }}
+                style={actionButtonStyle(false)}
               >
                 + Add
               </button>
@@ -271,7 +474,10 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
             <input
               type="text"
               value={tmuxSession}
-              onChange={(e) => { setTmuxSession(e.target.value); setValidationError(null) }}
+              onChange={(e) => {
+                setTmuxSession(e.target.value)
+                setValidationError(null)
+              }}
               placeholder="session-name"
               style={inputStyle}
             />
@@ -279,14 +485,33 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
         )}
 
         <div style={fieldStyle}>
-          <label style={labelStyle}>Working Directory</label>
-          <input
-            type="text"
-            value={cwd}
-            onChange={(e) => setCwd(e.target.value)}
-            placeholder="~/projects/myapp"
-            style={inputStyle}
-          />
+          <label htmlFor="pane-working-directory" style={labelStyle}>Working Directory</label>
+          <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+            <input
+              id="pane-working-directory"
+              aria-label="Working Directory"
+              type="text"
+              value={cwd}
+              onChange={(e) => setCwd(e.target.value)}
+              placeholder="~/projects/myapp"
+              style={{ ...inputStyle, flex: 1 }}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                void openDirectoryBrowser()
+              }}
+              disabled={!canBrowseDirectories || isBrowsingDirectories}
+              style={actionButtonStyle(!canBrowseDirectories || isBrowsingDirectories)}
+            >
+              Browse
+            </button>
+          </div>
+          {needsConnection && !connection && (
+            <div style={{ fontSize: '11px', color: '#888', marginTop: '4px' }}>
+              Select an SSH connection to browse remote directories.
+            </div>
+          )}
         </div>
 
         <div style={fieldStyle}>
@@ -308,23 +533,18 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
 
         <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
           <button
+            type="button"
             onClick={onClose}
             disabled={isSaving}
-            style={{
-              padding: '5px 14px',
-              backgroundColor: 'transparent',
-              color: '#888',
-              border: '1px solid #555',
-              borderRadius: '3px',
-              fontFamily: TERMINAL_FONT_FAMILY,
-              fontSize: '13px',
-              cursor: 'pointer',
-            }}
+            style={secondaryButtonStyle}
           >
             Cancel
           </button>
           <button
-            onClick={handleSave}
+            type="button"
+            onClick={() => {
+              void handleSave()
+            }}
             disabled={isSaving || (needsConnection && !connection)}
             style={{
               padding: '5px 14px',
@@ -342,6 +562,196 @@ export const PaneSettingsDialog: React.FC<PaneSettingsDialogProps> = ({
           </button>
         </div>
       </div>
+
+      {showDirectoryBrowser && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Directory browser"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.45)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1100,
+          }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setShowDirectoryBrowser(false)
+          }}
+        >
+          <div
+            style={{
+              width: '560px',
+              maxWidth: 'calc(100vw - 32px)',
+              maxHeight: 'calc(100vh - 48px)',
+              display: 'flex',
+              flexDirection: 'column',
+              backgroundColor: '#1e1e1e',
+              border: '1px solid #3f3f46',
+              borderRadius: '8px',
+              boxShadow: '0 20px 60px rgba(0, 0, 0, 0.45)',
+              overflow: 'hidden',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div style={{ padding: '14px 16px', borderBottom: '1px solid #333', fontSize: '13px', fontWeight: 600 }}>
+              Select Working Directory
+            </div>
+
+            <div style={{ padding: '12px 16px', borderBottom: '1px solid #333' }}>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '10px' }}>
+                <button
+                  type="button"
+                  aria-label="Go to parent directory"
+                  onClick={() => {
+                    void handleGoToParent()
+                  }}
+                  disabled={isBrowsingDirectories || parentDirectory(browserPath) === browserPath}
+                  style={secondaryButtonStyle}
+                >
+                  ↑ Up
+                </button>
+                <button
+                  type="button"
+                  aria-label="Reload current directory"
+                  onClick={() => {
+                    void browseDirectory(browserPath)
+                  }}
+                  disabled={isBrowsingDirectories}
+                  style={secondaryButtonStyle}
+                >
+                  Reload
+                </button>
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    marginLeft: 'auto',
+                    fontSize: '11px',
+                    color: '#aaaaaa',
+                  }}
+                >
+                  <input
+                    aria-label="Show hidden directories"
+                    type="checkbox"
+                    checked={showHiddenDirectories}
+                    onChange={(e) => {
+                      void handleToggleHiddenDirectories(e.target.checked)
+                    }}
+                  />
+                  Show hidden directories
+                </label>
+              </div>
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <input
+                  aria-label="Directory browser path"
+                  type="text"
+                  value={browserInputPath}
+                  onChange={(e) => setBrowserInputPath(e.target.value)}
+                  style={{ ...inputStyle, flex: 1 }}
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    void browseDirectory(browserInputPath)
+                  }}
+                  disabled={isBrowsingDirectories}
+                  style={secondaryButtonStyle}
+                >
+                  Go
+                </button>
+              </div>
+            </div>
+
+            <div style={{ padding: '10px 16px', fontSize: '11px', color: '#9ca3af', borderBottom: '1px solid #333' }}>
+              Current folder: {browserPath}
+            </div>
+
+            <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px 12px' }}>
+              {isBrowsingDirectories && (
+                <div style={{ fontSize: '12px', color: '#888', padding: '8px 4px' }}>Loading directories…</div>
+              )}
+              {browseError && (
+                <div style={{ fontSize: '12px', color: '#f44747', padding: '8px 4px' }}>{browseError}</div>
+              )}
+              {!isBrowsingDirectories && !browseError && directoryResponses[browserPath]?.entries.length === 0 && (
+                <div style={{ fontSize: '12px', color: '#888', padding: '8px 4px' }}>No directories found.</div>
+              )}
+              {renderDirectoryEntries(browserPath)}
+            </div>
+
+            <div style={{ padding: '12px 16px', borderTop: '1px solid #333', backgroundColor: '#181818' }}>
+              <div style={{ fontSize: '11px', color: '#9ca3af', marginBottom: '10px' }}>
+                Selected: {browserSelection}
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                <button
+                  type="button"
+                  onClick={() => setShowDirectoryBrowser(false)}
+                  style={secondaryButtonStyle}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={applyDirectorySelection}
+                  disabled={!browserSelection}
+                  style={{
+                    padding: '5px 14px',
+                    backgroundColor: '#0e639c',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: '3px',
+                    fontFamily: TERMINAL_FONT_FAMILY,
+                    fontSize: '13px',
+                    cursor: 'pointer',
+                    opacity: browserSelection ? 1 : 0.5,
+                  }}
+                >
+                  Choose Directory
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
+}
+
+function parentDirectory(path: string): string {
+  if (!path || path === '/') return '/'
+  const normalized = path.endsWith('/') && path !== '/' ? path.slice(0, -1) : path
+  const lastSlash = normalized.lastIndexOf('/')
+  if (lastSlash <= 0) return '/'
+  return normalized.slice(0, lastSlash)
+}
+
+function actionButtonStyle(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '5px 10px',
+    backgroundColor: 'transparent',
+    color: '#888',
+    border: '1px solid #555',
+    borderRadius: '3px',
+    fontFamily: TERMINAL_FONT_FAMILY,
+    fontSize: '13px',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    opacity: disabled ? 0.5 : 1,
+  }
+}
+
+const secondaryButtonStyle: React.CSSProperties = {
+  padding: '5px 14px',
+  backgroundColor: 'transparent',
+  color: '#c5c5c5',
+  border: '1px solid #555',
+  borderRadius: '3px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '13px',
+  cursor: 'pointer',
 }

--- a/frontend/src/hooks/usePaneSettings.test.ts
+++ b/frontend/src/hooks/usePaneSettings.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePaneSettings } from './usePaneSettings'
-import type { LayoutNode, PaneConfig, SSHConfigHost } from '../schemas'
+import type { DirectoryBrowserResponse, LayoutNode, PaneConfig, SSHConfigHost } from '../schemas'
 
 const mockLayout: LayoutNode = {
   direction: 'horizontal',
@@ -268,6 +268,74 @@ describe('usePaneSettings', () => {
           await result.current.detectShell('local')
         })
       ).rejects.toThrow('cannot detect')
+    })
+  })
+
+  describe('browseDirectories', () => {
+    it('calls local directory API without a connection', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            path: '/workspace/user',
+            entries: [{ name: 'projects', path: '/workspace/user/projects', has_children: true }],
+          }),
+        })
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+      await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
+
+      let browserResponse: DirectoryBrowserResponse | undefined
+      await act(async () => {
+        browserResponse = await result.current.browseDirectories('local', undefined, '/workspace/user', false)
+      })
+
+      expect(browserResponse?.path).toBe('/workspace/user')
+      expect(fetchMock).toHaveBeenCalledWith('/api/directories?path=%2Fworkspace%2Fuser&show_hidden=false')
+    })
+
+    it('calls remote directory API with the selected connection', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({
+            path: '/home/ubuntu',
+            entries: [{ name: 'app', path: '/home/ubuntu/app', has_children: false }],
+          }),
+        })
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+      await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
+
+      await act(async () => {
+        await result.current.browseDirectories('ssh', 'prod', '/home/ubuntu', true)
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/directories?path=%2Fhome%2Fubuntu&show_hidden=true&connection=prod')
+    })
+
+    it('throws when directory browsing fails', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ names: [] }) })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 422,
+          json: () => Promise.resolve({ error: 'invalid path' }),
+        })
+
+      vi.stubGlobal('fetch', fetchMock)
+      const { result } = renderHook(() => usePaneSettings(mockLayout, vi.fn()))
+      await waitFor(() => expect(result.current.sshConnectionNames).toEqual([]))
+
+      await expect(
+        act(async () => {
+          await result.current.browseDirectories('local', undefined, '/missing', false)
+        }),
+      ).rejects.toThrow('invalid path')
     })
   })
 })

--- a/frontend/src/hooks/usePaneSettings.ts
+++ b/frontend/src/hooks/usePaneSettings.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { SSHConnectionsResponseSchema, DetectShellResponseSchema } from '../schemas'
+import { SSHConnectionsResponseSchema, DetectShellResponseSchema, DirectoryBrowserResponseSchema } from '../schemas'
 import type { LayoutNode, PaneConfig, SSHConfigHost } from '../schemas'
 import { replacePaneInTree } from '../utils/layoutTree'
 
@@ -95,5 +95,28 @@ export function usePaneSettings(
     [],
   )
 
-  return { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell }
+  const browseDirectories = useCallback(
+    async (
+      type: PaneConfig['type'],
+      connection?: string,
+      path = '',
+      showHidden = false,
+    ) => {
+      const params = new URLSearchParams()
+      if (path) params.set('path', path)
+      params.set('show_hidden', String(showHidden))
+      if ((type === 'ssh' || type === 'ssh_tmux') && connection) {
+        params.set('connection', connection)
+      }
+      const r = await fetch(`/api/directories?${params.toString()}`)
+      if (!r.ok) {
+        const body = await r.json().catch(() => ({}))
+        throw new Error((body as { error?: string }).error ?? `HTTP ${r.status}`)
+      }
+      return DirectoryBrowserResponseSchema.parse(await r.json())
+    },
+    [],
+  )
+
+  return { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell, browseDirectories }
 }

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -11,6 +11,8 @@ import {
   DetectShellResponseSchema,
   WorkspaceTabPositionRequestSchema,
   WorkspacesResponseSchema,
+  DirectoryEntrySchema,
+  DirectoryBrowserResponseSchema,
 } from './index'
 
 describe('DisplayConfigSchema', () => {
@@ -219,6 +221,50 @@ describe('SessionInfoSchema', () => {
       state: 'unknown',
     })
     expect(result.success).toBe(false)
+  })
+})
+
+describe('DirectoryEntrySchema', () => {
+  it('accepts a valid directory entry', () => {
+    const result = DirectoryEntrySchema.safeParse({
+      name: 'src',
+      path: '/workspace/user/src',
+      has_children: true,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty names and missing flags', () => {
+    expect(DirectoryEntrySchema.safeParse({
+      name: '',
+      path: '/tmp',
+      has_children: true,
+    }).success).toBe(false)
+    expect(DirectoryEntrySchema.safeParse({
+      name: 'tmp',
+      path: '/tmp',
+    }).success).toBe(false)
+  })
+})
+
+describe('DirectoryBrowserResponseSchema', () => {
+  it('accepts a directory browser response', () => {
+    const result = DirectoryBrowserResponseSchema.safeParse({
+      path: '/workspace/user',
+      entries: [
+        { name: 'projects', path: '/workspace/user/projects', has_children: true },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid entries', () => {
+    expect(DirectoryBrowserResponseSchema.safeParse({
+      path: '/workspace/user',
+      entries: [
+        { name: '', path: '/workspace/user/projects', has_children: true },
+      ],
+    }).success).toBe(false)
   })
 })
 

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -131,3 +131,18 @@ export const DetectShellResponseSchema = z.object({
 })
 
 export type DetectShellResponse = z.infer<typeof DetectShellResponseSchema>
+
+export const DirectoryEntrySchema = z.object({
+  name: z.string().min(1),
+  path: z.string().min(1),
+  has_children: z.boolean(),
+})
+
+export type DirectoryEntry = z.infer<typeof DirectoryEntrySchema>
+
+export const DirectoryBrowserResponseSchema = z.object({
+  path: z.string().min(1),
+  entries: z.array(DirectoryEntrySchema),
+})
+
+export type DirectoryBrowserResponse = z.infer<typeof DirectoryBrowserResponseSchema>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,4 +11,6 @@ export type {
   SessionInfo,
   WSControlMessage,
   SSHConnectionsResponse,
+  DirectoryEntry,
+  DirectoryBrowserResponse,
 } from '../schemas'

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -21,6 +22,8 @@ import (
 	"panemux/internal/session"
 	"panemux/internal/sshconfig"
 )
+
+var readDir = os.ReadDir
 
 // Handler provides REST API endpoints.
 type Handler struct {
@@ -777,7 +780,7 @@ func listLocalDirectories(path string, showHidden bool) (directoryBrowserRespons
 		return directoryBrowserResponse{}, errors.New("path is not a directory")
 	}
 
-	entries, err := os.ReadDir(resolvedPath)
+	entries, err := readDir(resolvedPath)
 	if err != nil {
 		return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", err)
 	}
@@ -796,6 +799,9 @@ func listLocalDirectories(path string, showHidden bool) (directoryBrowserRespons
 		childPath := filepath.Join(resolvedPath, entry.Name())
 		hasChildren, childErr := localDirectoryHasChildren(childPath)
 		if childErr != nil {
+			if errors.Is(childErr, fs.ErrPermission) {
+				continue
+			}
 			return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", childErr)
 		}
 		resp.Entries = append(resp.Entries, directoryEntryResponse{
@@ -858,7 +864,7 @@ func resolveLocalDirectoryBrowsePath(path string) (string, error) {
 }
 
 func localDirectoryHasChildren(path string) (bool, error) {
-	entries, err := os.ReadDir(path)
+	entries, err := readDir(path)
 	if err != nil {
 		return false, fmt.Errorf("read dir %s: %w", path, err)
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -23,14 +24,16 @@ import (
 
 // Handler provides REST API endpoints.
 type Handler struct {
-	cfg                 *config.Config
-	manager             *session.Manager
-	createSession       func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
-	detectLocalShellFn  func() (string, error)
-	detectRemoteShellFn func(cfg session.SSHConfig) (string, error)
-	sshConfigPath       string
-	codeBinaryPath      string // empty = auto-detect; overridden in tests
-	gitBinaryPath       string // empty = auto-detect; overridden in tests
+	cfg                     *config.Config
+	manager                 *session.Manager
+	createSession           func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
+	detectLocalShellFn      func() (string, error)
+	detectRemoteShellFn     func(cfg session.SSHConfig) (string, error)
+	listLocalDirectoriesFn  func(path string, showHidden bool) (directoryBrowserResponse, error)
+	listRemoteDirectoriesFn func(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error)
+	sshConfigPath           string
+	codeBinaryPath          string // empty = auto-detect; overridden in tests
+	gitBinaryPath           string // empty = auto-detect; overridden in tests
 }
 
 type sshConnectionsResponse struct {
@@ -69,6 +72,17 @@ type workspaceTabPositionRequest struct {
 	TabPosition string `json:"tab_position"`
 }
 
+type directoryEntryResponse struct {
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	HasChildren bool   `json:"has_children"`
+}
+
+type directoryBrowserResponse struct {
+	Path    string                   `json:"path"`
+	Entries []directoryEntryResponse `json:"entries"`
+}
+
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
@@ -77,6 +91,8 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
 	h.detectRemoteShellFn = session.DetectRemoteShell
+	h.listLocalDirectoriesFn = listLocalDirectories
+	h.listRemoteDirectoriesFn = listRemoteDirectories
 	return h
 }
 
@@ -623,6 +639,44 @@ func (h *Handler) GetDetectShell(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, detectShellResponse{Shell: shell})
 }
 
+// GetDirectories returns a directory listing for the local or remote filesystem.
+func (h *Handler) GetDirectories(w http.ResponseWriter, r *http.Request) {
+	showHidden := false
+	showHiddenParam := r.URL.Query().Get("show_hidden")
+	if showHiddenParam != "" {
+		parsed, err := strconv.ParseBool(showHiddenParam)
+		if err != nil {
+			http.Error(w, "invalid show_hidden value", http.StatusBadRequest)
+			return
+		}
+		showHidden = parsed
+	}
+
+	path := r.URL.Query().Get("path")
+	connection := r.URL.Query().Get("connection")
+
+	var (
+		resp directoryBrowserResponse
+		err  error
+	)
+	if connection == "" {
+		resp, err = h.listLocalDirectoriesFn(path, showHidden)
+	} else {
+		cfg, cfgErr := session.ResolveSSHConfig(connection, h.cfg.SSHConnections, h.sshConfigPath)
+		if cfgErr != nil {
+			http.Error(w, cfgErr.Error(), http.StatusNotFound)
+			return
+		}
+		resp, err = h.listRemoteDirectoriesFn(cfg, path, showHidden)
+	}
+	if err != nil {
+		writeValidationError(w, err.Error())
+		return
+	}
+
+	writeJSON(w, resp)
+}
+
 type gitInfoResponse struct {
 	Branch string `json:"branch,omitempty"`
 	Repo   string `json:"repo,omitempty"`
@@ -706,4 +760,112 @@ func writeValidationError(w http.ResponseWriter, msg string) {
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+func listLocalDirectories(path string, showHidden bool) (directoryBrowserResponse, error) {
+	resolvedPath, err := resolveLocalDirectoryBrowsePath(path)
+	if err != nil {
+		return directoryBrowserResponse{}, err
+	}
+
+	//nolint:gosec // G703: resolvedPath is validated and normalized for local browsing only
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return directoryBrowserResponse{}, errors.New("directory path does not exist")
+	}
+	if !info.IsDir() {
+		return directoryBrowserResponse{}, errors.New("path is not a directory")
+	}
+
+	entries, err := os.ReadDir(resolvedPath)
+	if err != nil {
+		return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", err)
+	}
+
+	resp := directoryBrowserResponse{
+		Path:    resolvedPath,
+		Entries: []directoryEntryResponse{},
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if !showHidden && strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		childPath := filepath.Join(resolvedPath, entry.Name())
+		hasChildren, childErr := localDirectoryHasChildren(childPath)
+		if childErr != nil {
+			return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", childErr)
+		}
+		resp.Entries = append(resp.Entries, directoryEntryResponse{
+			Name:        entry.Name(),
+			Path:        childPath,
+			HasChildren: hasChildren,
+		})
+	}
+	sort.Slice(resp.Entries, func(i, j int) bool {
+		return strings.ToLower(resp.Entries[i].Name) < strings.ToLower(resp.Entries[j].Name)
+	})
+	return resp, nil
+}
+
+func listRemoteDirectories(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error) {
+	entries, resolvedPath, err := session.ListRemoteDirectories(cfg, path, showHidden)
+	if err != nil {
+		return directoryBrowserResponse{}, fmt.Errorf("listing remote directories: %w", err)
+	}
+	resp := directoryBrowserResponse{
+		Path:    resolvedPath,
+		Entries: make([]directoryEntryResponse, 0, len(entries)),
+	}
+	for _, entry := range entries {
+		resp.Entries = append(resp.Entries, directoryEntryResponse{
+			Name:        entry.Name,
+			Path:        entry.Path,
+			HasChildren: entry.HasChildren,
+		})
+	}
+	return resp, nil
+}
+
+func resolveLocalDirectoryBrowsePath(path string) (string, error) {
+	if path == "" || path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("getting home directory: %w", err)
+		}
+		return filepath.Clean(home), nil
+	}
+
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("getting home directory: %w", err)
+		}
+		return filepath.Clean(filepath.Join(home, path[2:])), nil
+	}
+
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving absolute path: %w", err)
+	}
+	return filepath.Clean(absPath), nil
+}
+
+func localDirectoryHasChildren(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("read dir %s: %w", path, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -771,17 +771,21 @@ func listLocalDirectories(path string, showHidden bool) (directoryBrowserRespons
 		return directoryBrowserResponse{}, err
 	}
 
-	//nolint:gosec // G703: resolvedPath is validated and normalized for local browsing only
-	info, err := os.Stat(resolvedPath)
-	if err != nil {
-		return directoryBrowserResponse{}, errors.New("directory path does not exist")
-	}
-	if !info.IsDir() {
-		return directoryBrowserResponse{}, errors.New("path is not a directory")
-	}
-
 	entries, err := readDir(resolvedPath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return directoryBrowserResponse{}, errors.New("directory path does not exist")
+		}
+		if errors.Is(err, fs.ErrPermission) {
+			return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", err)
+		}
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, fs.ErrInvalid) {
+			return directoryBrowserResponse{}, errors.New("path is not a directory")
+		}
+		if errors.As(err, &pathErr) && pathErr.Op == "readdir" {
+			return directoryBrowserResponse{}, errors.New("path is not a directory")
+		}
 		return directoryBrowserResponse{}, fmt.Errorf("reading directory: %w", err)
 	}
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -23,8 +23,6 @@ import (
 	"panemux/internal/sshconfig"
 )
 
-var readDir = os.ReadDir
-
 // Handler provides REST API endpoints.
 type Handler struct {
 	cfg                     *config.Config
@@ -34,6 +32,7 @@ type Handler struct {
 	detectRemoteShellFn     func(cfg session.SSHConfig) (string, error)
 	listLocalDirectoriesFn  func(path string, showHidden bool) (directoryBrowserResponse, error)
 	listRemoteDirectoriesFn func(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error)
+	readDirFn               func(name string) ([]os.DirEntry, error)
 	sshConfigPath           string
 	codeBinaryPath          string // empty = auto-detect; overridden in tests
 	gitBinaryPath           string // empty = auto-detect; overridden in tests
@@ -94,7 +93,8 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
 	h.detectRemoteShellFn = session.DetectRemoteShell
-	h.listLocalDirectoriesFn = listLocalDirectories
+	h.readDirFn = os.ReadDir
+	h.listLocalDirectoriesFn = h.listLocalDirectories
 	h.listRemoteDirectoriesFn = listRemoteDirectories
 	return h
 }
@@ -765,13 +765,13 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func listLocalDirectories(path string, showHidden bool) (directoryBrowserResponse, error) {
+func (h *Handler) listLocalDirectories(path string, showHidden bool) (directoryBrowserResponse, error) {
 	resolvedPath, err := resolveLocalDirectoryBrowsePath(path)
 	if err != nil {
 		return directoryBrowserResponse{}, err
 	}
 
-	entries, err := readDir(resolvedPath)
+	entries, err := h.readDirFn(resolvedPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return directoryBrowserResponse{}, errors.New("directory path does not exist")
@@ -783,6 +783,7 @@ func listLocalDirectories(path string, showHidden bool) (directoryBrowserRespons
 		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, fs.ErrInvalid) {
 			return directoryBrowserResponse{}, errors.New("path is not a directory")
 		}
+		// readDir on a plain file commonly reports a PathError with Op "readdir".
 		if errors.As(err, &pathErr) && pathErr.Op == "readdir" {
 			return directoryBrowserResponse{}, errors.New("path is not a directory")
 		}
@@ -801,7 +802,7 @@ func listLocalDirectories(path string, showHidden bool) (directoryBrowserRespons
 			continue
 		}
 		childPath := filepath.Join(resolvedPath, entry.Name())
-		hasChildren, childErr := localDirectoryHasChildren(childPath)
+		hasChildren, childErr := h.localDirectoryHasChildren(childPath)
 		if childErr != nil {
 			if errors.Is(childErr, fs.ErrPermission) {
 				continue
@@ -867,8 +868,8 @@ func resolveLocalDirectoryBrowsePath(path string) (string, error) {
 	return filepath.Clean(absPath), nil
 }
 
-func localDirectoryHasChildren(path string) (bool, error) {
-	entries, err := readDir(path)
+func (h *Handler) localDirectoryHasChildren(path string) (bool, error) {
+	entries, err := h.readDirFn(path)
 	if err != nil {
 		return false, fmt.Errorf("read dir %s: %w", path, err)
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -68,6 +68,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Get("/api/ssh-config/hosts", h.GetSSHConfigHosts)
 	r.Post("/api/ssh-config/hosts", h.PostSSHConfigHost)
 	r.Get("/api/detect-shell", h.GetDetectShell)
+	r.Get("/api/directories", h.GetDirectories)
 	return r
 }
 
@@ -1445,4 +1446,103 @@ func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
 	var resp gitInfoResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.False(t, resp.IsGit)
+}
+
+func TestGetDirectories_LocalPathReturnsDirectories(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "visible"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0600))
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?path="+dir+"&show_hidden=false", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp directoryBrowserResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "visible", resp.Entries[0].Name)
+	assert.Equal(t, filepath.Join(dir, "visible"), resp.Entries[0].Path)
+}
+
+func TestGetDirectories_ShowHiddenIncludesHiddenDirectories(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?path="+dir+"&show_hidden=true", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp directoryBrowserResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, ".hidden", resp.Entries[0].Name)
+}
+
+func TestGetDirectories_NoVisibleChildDirectoriesReturnsEmptyArray(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0600))
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?path="+dir+"&show_hidden=false", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"path":"`+dir+`","entries":[]}`, rec.Body.String())
+}
+
+func TestGetDirectories_UsesRemoteConnectionWhenProvided(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.listRemoteDirectoriesFn = func(
+		cfg session.SSHConfig,
+		path string,
+		showHidden bool,
+	) (directoryBrowserResponse, error) {
+		assert.Equal(t, "remote.example.com", cfg.Host)
+		assert.Equal(t, "/home/ubuntu", path)
+		assert.True(t, showHidden)
+		return directoryBrowserResponse{
+			Path: "/home/ubuntu",
+			Entries: []directoryEntryResponse{
+				{Name: "app", Path: "/home/ubuntu/app", HasChildren: true},
+			},
+		}, nil
+	}
+	h.cfg.SSHConnections = map[string]config.SSHConnection{
+		"prod": {Host: "remote.example.com", User: "ubuntu", Port: 22},
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?connection=prod&path=/home/ubuntu&show_hidden=true", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp directoryBrowserResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "app", resp.Entries[0].Name)
+}
+
+func TestGetDirectories_InvalidLocalPathReturns422(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?path=/definitely/missing/path", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1545,4 +1546,38 @@ func TestGetDirectories_InvalidLocalPathReturns422(t *testing.T) {
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestGetDirectories_SkipsUnreadableChildDirectories(t *testing.T) {
+	dir := t.TempDir()
+	readableDir := filepath.Join(dir, "readable")
+	unreadableDir := filepath.Join(dir, "restricted")
+	require.NoError(t, os.Mkdir(readableDir, 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(readableDir, "nested"), 0755))
+	require.NoError(t, os.Mkdir(unreadableDir, 0755))
+
+	originalReadDir := readDir
+	readDir = func(name string) ([]os.DirEntry, error) {
+		if name == unreadableDir {
+			return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrPermission}
+		}
+		return originalReadDir(name)
+	}
+	t.Cleanup(func() {
+		readDir = originalReadDir
+	})
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories?path="+dir+"&show_hidden=false", nil)
+	r.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp directoryBrowserResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, "readable", resp.Entries[0].Name)
+	assert.True(t, resp.Entries[0].HasChildren)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1556,18 +1556,18 @@ func TestGetDirectories_SkipsUnreadableChildDirectories(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(readableDir, "nested"), 0755))
 	require.NoError(t, os.Mkdir(unreadableDir, 0755))
 
-	originalReadDir := readDir
-	readDir = func(name string) ([]os.DirEntry, error) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	originalReadDir := h.readDirFn
+	h.readDirFn = func(name string) ([]os.DirEntry, error) {
 		if name == unreadableDir {
 			return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrPermission}
 		}
 		return originalReadDir(name)
 	}
 	t.Cleanup(func() {
-		readDir = originalReadDir
+		h.readDirFn = originalReadDir
 	})
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,6 +77,7 @@ func registerRoutes(r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler
 		r.Get("/ssh-config/hosts", apiHandler.GetSSHConfigHosts)
 		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
 		r.Get("/detect-shell", apiHandler.GetDetectShell)
+		r.Get("/directories", apiHandler.GetDirectories)
 	})
 	r.Get("/ws/{sessionID}", wsHandler.ServeHTTP)
 	registerFrontend(r, frontendFS)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -196,3 +196,16 @@ func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.
 	assert.Equal(t, "right", cfg.Workspaces.TabPosition)
 	assert.Equal(t, "Default", cfg.Workspaces.Items[0].Title)
 }
+
+func TestServer_DirectoriesRouteWired(t *testing.T) {
+	cfg := testConfig()
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, emptyFS)
+	require.NotNil(t, srv)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/directories", nil)
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+
+	assert.NotEqual(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -61,3 +61,10 @@ type CWDGetter interface {
 type SSHConnNamer interface {
 	ConnectionName() string
 }
+
+// DirectoryEntry represents a browsable directory in a filesystem tree.
+type DirectoryEntry struct {
+	Name        string
+	Path        string
+	HasChildren bool
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -350,11 +350,6 @@ func validateRemotePath(label, path string) error {
 	return fmt.Errorf("invalid %s %q: %s", label, path, invalidRemotePathMsg)
 }
 
-// ValidateRemotePath applies the CodeQL-approved remote path validation rules.
-func ValidateRemotePath(label, path string) error {
-	return validateRemotePath(label, path)
-}
-
 func closeSSHResources(sess *ssh.Session, client, jumpClient *ssh.Client) {
 	if sess != nil {
 		sess.Close()

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -349,6 +350,11 @@ func validateRemotePath(label, path string) error {
 	return fmt.Errorf("invalid %s %q: %s", label, path, invalidRemotePathMsg)
 }
 
+// ValidateRemotePath applies the CodeQL-approved remote path validation rules.
+func ValidateRemotePath(label, path string) error {
+	return validateRemotePath(label, path)
+}
+
 func closeSSHResources(sess *ssh.Session, client, jumpClient *ssh.Client) {
 	if sess != nil {
 		sess.Close()
@@ -394,6 +400,102 @@ func DetectRemoteShell(cfg SSHConfig) (string, error) {
 		return "", errors.New("remote $SHELL is not set")
 	}
 	return shell, nil
+}
+
+// ListRemoteDirectories connects to the remote host and returns immediate child
+// directories below the requested path. When path is empty, the remote home
+// directory is used.
+func ListRemoteDirectories(cfg SSHConfig, path string, showHidden bool) ([]DirectoryEntry, string, error) {
+	if path != "" {
+		if err := validateRemotePath("directory path", path); err != nil {
+			return nil, "", err
+		}
+	}
+
+	client, jumpClient, err := dialSSHClient(cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("connecting to remote host: %w", err)
+	}
+	defer client.Close()
+	if jumpClient != nil {
+		defer jumpClient.Close()
+	}
+
+	sess, err := client.NewSession()
+	if err != nil {
+		return nil, "", fmt.Errorf("creating session: %w", err)
+	}
+	defer sess.Close()
+
+	out, err := sess.Output(remoteDirectoryListCommand(path, showHidden))
+	if err != nil {
+		return nil, "", fmt.Errorf("listing remote directories: %w", err)
+	}
+
+	resolvedPath, entries, err := parseRemoteDirectoryListOutput(out)
+	if err != nil {
+		return nil, "", err
+	}
+	return entries, resolvedPath, nil
+}
+
+func remoteDirectoryListCommand(path string, showHidden bool) string {
+	target := "$PWD"
+	if path != "" {
+		target = shellQuotePath(path)
+	}
+
+	showHiddenFlag := "0"
+	if showHidden {
+		showHiddenFlag = "1"
+	}
+
+	return strings.Join([]string{
+		"target=" + target,
+		"show_hidden=" + showHiddenFlag,
+		`if ! cd "$target" 2>/dev/null; then echo "__PANEMUX_NOT_DIR__"; exit 0; fi`,
+		`pwd`,
+		`find . -mindepth 1 -maxdepth 1 -type d -print | LC_ALL=C sort | while IFS= read -r entry; do`,
+		`  [ -n "$entry" ] || continue`,
+		`  name=${entry#./}`,
+		`  if [ "$show_hidden" != "1" ] && [ "${name#*.}" != "$name" ]; then continue; fi`,
+		`  has_children=0`,
+		`  child=$(find "$entry" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)`,
+		`  if [ -n "$child" ]; then has_children=1; fi`,
+		`  printf '%s\t%s\t%s\n' "$name" "$PWD/${name}" "$has_children"`,
+		`done`,
+	}, "\n")
+}
+
+func parseRemoteDirectoryListOutput(out []byte) (string, []DirectoryEntry, error) {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) == "" {
+		return "", nil, errors.New("remote directory listing returned no path")
+	}
+	if strings.TrimSpace(lines[0]) == "__PANEMUX_NOT_DIR__" {
+		return "", nil, errors.New("directory path does not exist")
+	}
+
+	resolvedPath := strings.TrimSpace(lines[0])
+	entries := make([]DirectoryEntry, 0, len(lines))
+	for _, line := range lines[1:] {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			return "", nil, fmt.Errorf("invalid remote directory listing row %q", line)
+		}
+		entries = append(entries, DirectoryEntry{
+			Name:        parts[0],
+			Path:        parts[1],
+			HasChildren: parts[2] == "1",
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
+	})
+	return resolvedPath, entries, nil
 }
 
 // buildHostKeyCallback resolves the known_hosts file path and returns a

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -171,6 +171,25 @@ func TestSSHGetCWDCmd_FallsBackToPwd(t *testing.T) {
 	assert.Contains(t, sshGetCWDCmd, "|| pwd")
 }
 
+func TestRemoteDirectoryListCommand_DoesNotUseShellGlobs(t *testing.T) {
+	cmd := remoteDirectoryListCommand("/home/user/project", false)
+	assert.NotContains(t, cmd, "./*")
+	assert.Contains(t, cmd, "find . -mindepth 1 -maxdepth 1 -type d -print")
+	assert.NotContains(t, cmd, "do;")
+}
+
+func TestRemoteDirectoryListCommand_FiltersHiddenDirectoriesWithoutGlobs(t *testing.T) {
+	cmd := remoteDirectoryListCommand("/home/user/project", false)
+	assert.Contains(t, cmd, `[ "${name#*.}" != "$name" ]`)
+}
+
+func TestParseRemoteDirectoryListOutput_EmptyDirectory(t *testing.T) {
+	resolvedPath, entries, err := parseRemoteDirectoryListOutput([]byte("/home/user/project\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/project", resolvedPath)
+	assert.Empty(t, entries)
+}
+
 // TestSSHConfig_ShellField verifies the Shell field exists on SSHConfig.
 func TestSSHConfig_ShellField(t *testing.T) {
 	cfg := SSHConfig{


### PR DESCRIPTION
## Summary
- add a directory browser to pane settings for choosing working directories
- support both local and SSH-backed directory listings through a new read-only API
- add frontend and backend tests plus docs for the new working-directory selection flow

## Test plan
- [x] make build-frontend
- [x] make lint-go
- [x] make lint-frontend
- [x] make test-go
- [x] make test-frontend
