### PR TITLE
fix: open VSCode in active agent worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Common uses:
 - **Close a pane** from its header controls; the layout collapses automatically.
 - **Restart a pane** with the on-screen button if the underlying session exits.
 - **Open a linked PR** from the pane header when the current Git branch already has a GitHub pull request. For local panes, panemux can prefer the live worktree of an interactive `codex` or `claude` session, including resumed Codex sessions, and falls back to the pane's own working directory after the agent exits.
-- **Open VS Code** from supported panes using the pane header action.
+- **Open VS Code** from supported panes using the pane header action. Like pane Git/PR metadata, this can prefer the live worktree of an interactive `codex` or `claude` session and falls back to the pane's own working directory after the agent exits.
 
 ### Notifications and attention prompts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ Workspace-related endpoints:
 - `PUT /api/workspaces/{id}/layout` updates a specific workspace layout.
 - `GET/PUT /api/layout` remain as compatibility endpoints for the active workspace layout.
 
-`POST /api/sessions/{id}/open-vscode` launches VSCode pointed at the session's live working directory. For local sessions it runs `code <cwd>`; for SSH sessions it runs `code --remote ssh-remote+<connection> <cwd>`. The binary is located via `exec.LookPath("code")` with a macOS app-bundle fallback.
+`POST /api/sessions/{id}/open-vscode` launches VSCode pointed at the session's live working directory. Like `GET /api/sessions/{id}/git-info`, it may prefer the worktree of an active interactive `codex` or `claude` process when that worktree belongs to the same repository. For local sessions it runs `code <cwd>`; for SSH sessions it runs `code --remote ssh-remote+<connection> <cwd>`. The binary is located via `exec.LookPath("code")` with a macOS app-bundle fallback.
 
 Why REST here:
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -518,6 +518,8 @@ type openVSCodeResponse struct {
 }
 
 // PostOpenVSCode opens VSCode pointed at the session's current working directory.
+// When an interactive Codex or Claude agent is actively working in a sibling git
+// worktree for the same repository, panemux prefers that worktree instead.
 // For local sessions it runs: code <cwd>
 // For SSH sessions it runs: code --remote ssh-remote+<connection> <cwd>
 func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
@@ -539,6 +541,8 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to get working directory: %v", err), http.StatusInternalServerError)
 		return
 	}
+
+	cwd = h.resolvePreferredCWD(sess, cwd)
 
 	if !h.validateVSCodeCWD(w, sess, cwd) {
 		return
@@ -742,7 +746,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetCWD := h.resolveGitInfoCWD(sess, cwd)
+	targetCWD := h.resolvePreferredCWD(sess, cwd)
 	ctx, err := h.inspectGitContext(targetCWD)
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
@@ -759,7 +763,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (h *Handler) resolveGitInfoCWD(sess session.Session, cwd string) string {
+func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	baseCtx, err := h.inspectGitContext(cwd)
 	if err != nil {
 		return cwd

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1216,6 +1216,19 @@ func TestPostOpenVSCode_ActiveAgentWorkdir_PrefersWorktree(t *testing.T) {
 	assert.Equal(t, worktreeDir, resp.Cwd)
 }
 
+func TestPostOpenVSCode_EndedAgentFallsBackToPaneCWD(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	_ = addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
+
+	resp := postOpenVSCodeOK(t, "local-fallback", &mockCWDSession{
+		mockSession:   mockSession{id: "local-fallback", typ: session.TypeLocal},
+		activeWorkdir: "",
+		cwd:           repoDir,
+	})
+
+	assert.Equal(t, repoDir, resp.Cwd)
+}
+
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
 	t.Helper()
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1203,6 +1203,19 @@ func TestPostOpenVSCode_Local_200(t *testing.T) {
 	assert.Equal(t, dir, resp.Cwd)
 }
 
+func TestPostOpenVSCode_ActiveAgentWorkdir_PrefersWorktree(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
+
+	resp := postOpenVSCodeOK(t, "local-worktree", &mockCWDSession{
+		mockSession:   mockSession{id: "local-worktree", typ: session.TypeLocal},
+		activeWorkdir: worktreeDir,
+		cwd:           repoDir,
+	})
+
+	assert.Equal(t, worktreeDir, resp.Cwd)
+}
+
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- prefer the active interactive agent worktree when Open in VSCode is triggered from a pane in the same repository
- reuse the existing repository-context resolution logic for both Open in VSCode and pane git/PR metadata
- document the behavior in the README and architecture notes

## Why

When an agent is working from a sibling git worktree, opening VSCode from the pane header should follow that active worktree instead of reopening the pane's base repository directory.

## Test plan

- [x] go test ./internal/api -run TestPostOpenVSCode_ActiveAgentWorkdir_PrefersWorktree -count=1
- [x] make install-deps-ci
- [x] make build-frontend
- [x] make test-go
- [x] make lint-go
