### PR TITLE
fix: resolve codex worktree git context across session types

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,15 @@ The override path is intentionally narrow:
 - SSH sessions scan the remote process list on the current SSH connection, and SSH+tmux sessions restrict that scan to the active remote tmux pane's process tree
 - only worktrees that belong to the same Git common dir as the pane's base repository are accepted
 
-For resumed Codex sessions, the local and SSH session implementations can inspect the open Codex session log under `~/.codex/sessions/...jsonl` and prefer the latest `turn_context.cwd` when available. This exists because a resumed interactive Codex process may keep its OS-level process cwd at the original pane directory while the live Codex session itself is operating against a different worktree.
+For interactive Codex sessions, all four session implementations (`local`, `ssh`, `tmux`, and `ssh_tmux`) may inspect the open Codex session log under `~/.codex/sessions/...jsonl` when the Codex process has that file open. Panemux currently prefers the latest `exec_command.arguments.workdir` recorded in `response_item` / `function_call` log entries, then falls back to `turn_context.cwd`, then `session_meta.cwd`.
+
+This ordering is intentional and reflects observed Codex behavior as of `codex-tui` `0.130.0`:
+
+- the interactive Codex process may keep its OS-level process cwd at the original pane directory
+- `session_meta.cwd` and later `turn_context.cwd` may also remain pinned to that original pane directory
+- individual tool calls still record their actual execution directory in `exec_command.arguments.workdir`
+
+Panemux treats that `workdir` field as the strongest available signal for the active worktree because it is the only one that changes when Codex executes tools inside a sibling Git worktree while the parent interactive process remains attached to the original pane directory. If a future Codex release changes this logging contract, compare new logs against these three fields before changing the resolver so behavior remains reviewable and intentional.
 
 ### `useWorkspaceAttentionMonitor`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -457,7 +457,10 @@ When a pane moves to a different parent node, the component may be remounted by 
 - When a local, local tmux, SSH, or SSH+tmux pane has an active interactive `codex` or `claude` process working in a different Git worktree for the same repository, panemux prefers that agent worktree over the pane's base directory.
 - Only interactive agents are eligible for worktree override.
 - Non-interactive commands such as `codex exec`, `claude -p`, and `claude --print` must not affect the displayed Git or PR metadata.
-- For `codex resume` flows, panemux may derive the active worktree from the Codex session log metadata (`turn_context.cwd`, falling back to `session_meta.cwd`) when the process has the session log open.
+- For interactive Codex flows across all four pane types (`local`, `ssh`, `tmux`, and `ssh_tmux`), panemux may derive the active worktree from the Codex session log when the process has that log open.
+- Codex log resolution currently prefers the most recent `response_item.payload.arguments.workdir` from `exec_command` tool calls, then falls back to `turn_context.cwd`, then `session_meta.cwd`.
+- This ordering exists because the interactive Codex process and its thread metadata may stay on the original pane directory even while tool calls are executing inside a sibling Git worktree.
+- If future Codex versions change their session-log schema or start updating `turn_context.cwd` to the active worktree reliably, compare the three fields above before changing panemux's resolver order.
 - If the agent exits, no longer has an eligible worktree, or the resolved worktree is not a sibling worktree of the pane's current repository, panemux falls back to the pane's own working directory immediately.
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -465,12 +465,13 @@ func readCodexSessionCWD(path string) (string, error) {
 	return parseCodexSessionCWD(data)
 }
 
+type codexSessionRecord struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
 func parseCodexSessionCWD(data []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	type codexSessionRecord struct {
-		Type    string          `json:"type"`
-		Payload json.RawMessage `json:"payload"`
-	}
 
 	var latestTurnCWD string
 	var sessionMetaCWD string
@@ -506,10 +507,7 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 	return sessionMetaCWD, nil
 }
 
-func codexSessionRecordCWD(rec struct {
-	Type    string          `json:"type"`
-	Payload json.RawMessage `json:"payload"`
-}) (execWorkdir, turnCWD, metaCWD string) {
+func codexSessionRecordCWD(rec codexSessionRecord) (execWorkdir, turnCWD, metaCWD string) {
 	switch rec.Type {
 	case "turn_context":
 		return "", parsePayloadCWD(rec.Payload), ""

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -467,18 +467,7 @@ func readCodexSessionCWD(path string) (string, error) {
 
 func parseCodexSessionCWD(data []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	type payloadWithCWD struct {
-		Cwd string `json:"cwd"`
-	}
-	type responseItemPayload struct {
-		Type      string `json:"type"`
-		Name      string `json:"name"`
-		Arguments string `json:"arguments"`
-	}
-	type commandArguments struct {
-		Workdir string `json:"workdir"`
-	}
-	type record struct {
+	type codexSessionRecord struct {
 		Type    string          `json:"type"`
 		Payload json.RawMessage `json:"payload"`
 	}
@@ -487,34 +476,19 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 	var sessionMetaCWD string
 	var latestExecWorkdir string
 	for scanner.Scan() {
-		var rec record
+		var rec codexSessionRecord
 		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
 			continue
 		}
-		switch rec.Type {
-		case "turn_context":
-			var payload payloadWithCWD
-			if err := json.Unmarshal(rec.Payload, &payload); err == nil && payload.Cwd != "" {
-				latestTurnCWD = payload.Cwd
-			}
-		case "session_meta":
-			var payload payloadWithCWD
-			if err := json.Unmarshal(rec.Payload, &payload); err == nil && payload.Cwd != "" && sessionMetaCWD == "" {
-				sessionMetaCWD = payload.Cwd
-			}
-		case "response_item":
-			var payload responseItemPayload
-			if err := json.Unmarshal(rec.Payload, &payload); err != nil {
-				continue
-			}
-			if payload.Type != "function_call" || payload.Name != "exec_command" || payload.Arguments == "" {
-				continue
-			}
-
-			var args commandArguments
-			if err := json.Unmarshal([]byte(payload.Arguments), &args); err == nil && args.Workdir != "" {
-				latestExecWorkdir = args.Workdir
-			}
+		execWorkdir, turnCWD, metaCWD := codexSessionRecordCWD(rec)
+		if execWorkdir != "" {
+			latestExecWorkdir = execWorkdir
+		}
+		if turnCWD != "" {
+			latestTurnCWD = turnCWD
+		}
+		if metaCWD != "" && sessionMetaCWD == "" {
+			sessionMetaCWD = metaCWD
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -530,6 +504,59 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 		return latestTurnCWD, nil
 	}
 	return sessionMetaCWD, nil
+}
+
+func codexSessionRecordCWD(rec struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}) (execWorkdir, turnCWD, metaCWD string) {
+	switch rec.Type {
+	case "turn_context":
+		return "", parsePayloadCWD(rec.Payload), ""
+	case "session_meta":
+		return "", "", parsePayloadCWD(rec.Payload)
+	case "response_item":
+		return parseExecCommandWorkdir(rec.Payload), "", ""
+	default:
+		return "", "", ""
+	}
+}
+
+func parsePayloadCWD(raw json.RawMessage) string {
+	type payloadWithCWD struct {
+		Cwd string `json:"cwd"`
+	}
+
+	var payload payloadWithCWD
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	return payload.Cwd
+}
+
+func parseExecCommandWorkdir(raw json.RawMessage) string {
+	type responseItemPayload struct {
+		Type      string `json:"type"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	type commandArguments struct {
+		Workdir string `json:"workdir"`
+	}
+
+	var payload responseItemPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return ""
+	}
+	if payload.Type != "function_call" || payload.Name != "exec_command" || payload.Arguments == "" {
+		return ""
+	}
+
+	var args commandArguments
+	if err := json.Unmarshal([]byte(payload.Arguments), &args); err != nil {
+		return ""
+	}
+	return args.Workdir
 }
 
 // validateShell ensures the shell path is safe to execute.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -470,13 +470,22 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 	type payloadWithCWD struct {
 		Cwd string `json:"cwd"`
 	}
+	type responseItemPayload struct {
+		Type      string `json:"type"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	type commandArguments struct {
+		Workdir string `json:"workdir"`
+	}
 	type record struct {
-		Type    string         `json:"type"`
-		Payload payloadWithCWD `json:"payload"`
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
 	}
 
 	var latestTurnCWD string
 	var sessionMetaCWD string
+	var latestExecWorkdir string
 	for scanner.Scan() {
 		var rec record
 		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
@@ -484,17 +493,38 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 		}
 		switch rec.Type {
 		case "turn_context":
-			if rec.Payload.Cwd != "" {
-				latestTurnCWD = rec.Payload.Cwd
+			var payload payloadWithCWD
+			if err := json.Unmarshal(rec.Payload, &payload); err == nil && payload.Cwd != "" {
+				latestTurnCWD = payload.Cwd
 			}
 		case "session_meta":
-			if rec.Payload.Cwd != "" && sessionMetaCWD == "" {
-				sessionMetaCWD = rec.Payload.Cwd
+			var payload payloadWithCWD
+			if err := json.Unmarshal(rec.Payload, &payload); err == nil && payload.Cwd != "" && sessionMetaCWD == "" {
+				sessionMetaCWD = payload.Cwd
+			}
+		case "response_item":
+			var payload responseItemPayload
+			if err := json.Unmarshal(rec.Payload, &payload); err != nil {
+				continue
+			}
+			if payload.Type != "function_call" || payload.Name != "exec_command" || payload.Arguments == "" {
+				continue
+			}
+
+			var args commandArguments
+			if err := json.Unmarshal([]byte(payload.Arguments), &args); err == nil && args.Workdir != "" {
+				latestExecWorkdir = args.Workdir
 			}
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("scan codex session log: %w", err)
+	}
+	// Codex may keep both process cwd and turn/session metadata pinned to the
+	// original pane directory while tool calls run inside a sibling worktree.
+	// The latest exec_command workdir is therefore the strongest signal.
+	if latestExecWorkdir != "" {
+		return latestExecWorkdir, nil
 	}
 	if latestTurnCWD != "" {
 		return latestTurnCWD, nil

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"os/user"
@@ -223,13 +224,45 @@ func TestCodexSessionPath(t *testing.T) {
 	assert.Equal(t, "/Users/tomo/.codex/sessions/2026/05/17/rollout.jsonl", path)
 }
 
-func codexExecCommandRecord(cmd, workdir string) string {
-	return "" +
-		"{\"type\":\"response_item\",\"payload\":{" +
-		"\"type\":\"function_call\"," +
-		"\"name\":\"exec_command\"," +
-		"\"arguments\":\"{\\\"cmd\\\":\\\"" + cmd + "\\\",\\\"workdir\\\":\\\"" + workdir + "\\\"}\"" +
-		"}}\n"
+func mustJSONLine(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(data) + "\n"
+}
+
+func codexExecCommandRecord(t *testing.T, cmd, workdir string) string {
+	t.Helper()
+
+	type commandArguments struct {
+		Cmd     string `json:"cmd"`
+		Workdir string `json:"workdir"`
+	}
+	type responseItemPayload struct {
+		Type      string `json:"type"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	argsJSON, err := json.Marshal(commandArguments{Cmd: cmd, Workdir: workdir})
+	require.NoError(t, err)
+
+	return mustJSONLine(t, codexSessionRecord{
+		Type: "response_item",
+		Payload: mustRawJSON(t, responseItemPayload{
+			Type:      "function_call",
+			Name:      "exec_command",
+			Arguments: string(argsJSON),
+		}),
+	})
+}
+
+func mustRawJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
 }
 
 func TestReadCodexSessionCWD_PrefersTurnContext(t *testing.T) {
@@ -260,13 +293,26 @@ func TestReadCodexSessionCWD_PrefersLatestExecCommandWorkdir(t *testing.T) {
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		codexExecCommandRecord("git status --short --branch", "/tmp/worktree-a") +
-		codexExecCommandRecord("go test ./...", "/tmp/worktree-b")
+		codexExecCommandRecord(t, "git status --short --branch", "/tmp/worktree-a") +
+		codexExecCommandRecord(t, "go test ./...", "/tmp/worktree-b")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	cwd, err := readCodexSessionCWD(path)
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/worktree-b", cwd)
+}
+
+func TestReadCodexSessionCWD_PrefersExecCommandWorkdirEvenWhenTurnContextAppearsLater(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	content := "" +
+		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		codexExecCommandRecord(t, "git status", "/tmp/worktree-from-command") +
+		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	cwd, err := readCodexSessionCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-from-command", cwd)
 }
 
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
@@ -431,7 +477,7 @@ func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		codexExecCommandRecord("git status", "/tmp/worktree-from-command")
+		codexExecCommandRecord(t, "git status", "/tmp/worktree-from-command")
 	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {
@@ -598,7 +644,7 @@ func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *test
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		codexExecCommandRecord("go test ./...", "/tmp/tmux-worktree-from-command")
+		codexExecCommandRecord(t, "go test ./...", "/tmp/tmux-worktree-from-command")
 	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
 
 	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -246,6 +246,20 @@ func TestReadCodexSessionCWD_FallsBackToSessionMeta(t *testing.T) {
 	assert.Equal(t, "/repo/main", cwd)
 }
 
+func TestReadCodexSessionCWD_PrefersLatestExecCommandWorkdir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	content := "" +
+		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status --short --branch\\\",\\\"workdir\\\":\\\"/tmp/worktree-a\\\"}\"}}\n" +
+		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/worktree-b\\\"}\"}}\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	cwd, err := readCodexSessionCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-b", cwd)
+}
+
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
 	sess := &LocalSession{pid: 100}
 
@@ -391,6 +405,52 @@ func TestGetActiveWorkdir_PrefersCodexSessionCWD(t *testing.T) {
 	assert.Equal(t, "/tmp/worktree-from-session", cwd)
 }
 
+func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalOpenFilePaths := openFilePathsForPIDFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		openFilePathsForPIDFn = originalOpenFilePaths
+	})
+
+	sessionLog := filepath.Join(t.TempDir(), ".codex", "sessions", "2026", "05", "17", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionLog), 0755))
+	content := "" +
+		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status\\\",\\\"workdir\\\":\\\"/tmp/worktree-from-command\\\"}\"}}\n"
+	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "codex resume --last"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "/repo/main", nil
+		case 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+	openFilePathsForPIDFn = func(pid int) ([]string, error) {
+		assert.Equal(t, 220, pid)
+		return []string{sessionLog}, nil
+	}
+
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-from-command", cwd)
+}
+
 func TestValidateShell_InEtcShells_OK(t *testing.T) {
 	got, err := validateShell("/bin/sh")
 	assert.NoError(t, err)
@@ -510,4 +570,59 @@ func TestTmuxLocalSessionGetActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {
 	cwd, err := sess.GetActiveWorkdir()
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/worktree", cwd)
+}
+
+func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
+	prevTmuxOutput := tmuxLocalOutputFn
+	prevListProcesses := listProcessesFn
+	prevGetPIDCWD := getPIDCWDFn
+	prevOpenFilePaths := openFilePathsForPIDFn
+	t.Cleanup(func() {
+		tmuxLocalOutputFn = prevTmuxOutput
+		listProcessesFn = prevListProcesses
+		getPIDCWDFn = prevGetPIDCWD
+		openFilePathsForPIDFn = prevOpenFilePaths
+	})
+
+	sessionLog := filepath.Join(t.TempDir(), ".codex", "sessions", "2026", "05", "17", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionLog), 0755))
+	content := "" +
+		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/tmux-worktree-from-command\\\"}\"}}\n"
+	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
+
+	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {
+		switch {
+		case len(args) == 5 && args[4] == "#{pane_pid}":
+			return []byte("220\n"), nil
+		case len(args) == 5 && args[4] == "#{pane_current_path}":
+			return []byte("/repo/main\n"), nil
+		default:
+			return nil, errors.New("unexpected tmux args")
+		}
+	}
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 220, PPID: 1, Command: "zsh"},
+			{PID: 230, PPID: 220, Command: "codex"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 230:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+	openFilePathsForPIDFn = func(pid int) ([]string, error) {
+		assert.Equal(t, 230, pid)
+		return []string{sessionLog}, nil
+	}
+
+	sess := &TmuxLocalSession{tmuxSession: "demo"}
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/tmux-worktree-from-command", cwd)
 }

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -223,6 +223,15 @@ func TestCodexSessionPath(t *testing.T) {
 	assert.Equal(t, "/Users/tomo/.codex/sessions/2026/05/17/rollout.jsonl", path)
 }
 
+func codexExecCommandRecord(cmd, workdir string) string {
+	return "" +
+		"{\"type\":\"response_item\",\"payload\":{" +
+		"\"type\":\"function_call\"," +
+		"\"name\":\"exec_command\"," +
+		"\"arguments\":\"{\\\"cmd\\\":\\\"" + cmd + "\\\",\\\"workdir\\\":\\\"" + workdir + "\\\"}\"" +
+		"}}\n"
+}
+
 func TestReadCodexSessionCWD_PrefersTurnContext(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	content := "" +
@@ -251,8 +260,8 @@ func TestReadCodexSessionCWD_PrefersLatestExecCommandWorkdir(t *testing.T) {
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status --short --branch\\\",\\\"workdir\\\":\\\"/tmp/worktree-a\\\"}\"}}\n" +
-		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/worktree-b\\\"}\"}}\n"
+		codexExecCommandRecord("git status --short --branch", "/tmp/worktree-a") +
+		codexExecCommandRecord("go test ./...", "/tmp/worktree-b")
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
 	cwd, err := readCodexSessionCWD(path)
@@ -422,7 +431,7 @@ func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status\\\",\\\"workdir\\\":\\\"/tmp/worktree-from-command\\\"}\"}}\n"
+		codexExecCommandRecord("git status", "/tmp/worktree-from-command")
 	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {
@@ -589,7 +598,7 @@ func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *test
 	content := "" +
 		"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 		"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-		"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/tmux-worktree-from-command\\\"}\"}}\n"
+		codexExecCommandRecord("go test ./...", "/tmp/tmux-worktree-from-command")
 	require.NoError(t, os.WriteFile(sessionLog, []byte(content), 0600))
 
 	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -272,6 +272,25 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexSessionCWD(t *testing.T) {
 	assert.Equal(t, "/tmp/remote-worktree", cwd)
 }
 
+func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) {
+	sessionPath := "/home/user/.codex/sessions/2026/05/17/session.jsonl"
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:                       []byte(" 100 1 sh\n 220 100 codex resume --last\n"),
+			fmt.Sprintf(sshOpenFilesCmdTemplate, 220): []byte(sessionPath + "\n"),
+			"cat " + shellQuotePath(sessionPath): []byte(
+				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status\\\",\\\"workdir\\\":\\\"/tmp/remote-worktree-from-command\\\"}\"}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-worktree-from-command", cwd)
+}
+
 func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
@@ -329,4 +348,25 @@ func TestTmuxSSHActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {
 	cwd, err := tmuxSSHActiveWorkdir(runner, "demo")
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/remote-worktree", cwd)
+}
+
+func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
+	sessionPath := "/home/user/.codex/sessions/2026/05/17/session.jsonl"
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t 'demo' '#{pane_pid}'":          []byte("220\n"),
+			"tmux display-message -p -t 'demo' '#{pane_current_path}'": []byte("/repo/main\n"),
+			sshListProcessesCmd:                       []byte(" 220 1 zsh\n 230 220 codex resume --last\n"),
+			fmt.Sprintf(sshOpenFilesCmdTemplate, 230): []byte(sessionPath + "\n"),
+			"cat " + shellQuotePath(sessionPath): []byte(
+				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/remote-tmux-worktree-from-command\\\"}\"}}\n",
+			),
+		},
+	}
+
+	cwd, err := tmuxSSHActiveWorkdir(runner, "demo")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-tmux-worktree-from-command", cwd)
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -281,7 +281,7 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) 
 			"cat " + shellQuotePath(sessionPath): []byte(
 				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-					codexExecCommandRecord("git status", "/tmp/remote-worktree-from-command"),
+					codexExecCommandRecord(t, "git status", "/tmp/remote-worktree-from-command"),
 			),
 		},
 	}
@@ -361,7 +361,7 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 			"cat " + shellQuotePath(sessionPath): []byte(
 				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-					codexExecCommandRecord("go test ./...", "/tmp/remote-tmux-worktree-from-command"),
+					codexExecCommandRecord(t, "go test ./...", "/tmp/remote-tmux-worktree-from-command"),
 			),
 		},
 	}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -281,7 +281,7 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) 
 			"cat " + shellQuotePath(sessionPath): []byte(
 				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-					"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"git status\\\",\\\"workdir\\\":\\\"/tmp/remote-worktree-from-command\\\"}\"}}\n",
+					codexExecCommandRecord("git status", "/tmp/remote-worktree-from-command"),
 			),
 		},
 	}
@@ -361,7 +361,7 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 			"cat " + shellQuotePath(sessionPath): []byte(
 				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
 					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
-					"{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"exec_command\",\"arguments\":\"{\\\"cmd\\\":\\\"go test ./...\\\",\\\"workdir\\\":\\\"/tmp/remote-tmux-worktree-from-command\\\"}\"}}\n",
+					codexExecCommandRecord("go test ./...", "/tmp/remote-tmux-worktree-from-command"),
 			),
 		},
 	}


### PR DESCRIPTION
## Summary
- prefer the latest Codex exec-command workdir when deriving pane git context
- cover local, tmux, ssh, and ssh+tmux session types with regression tests
- document the observed Codex session-log fields and resolver priority for future comparisons

## Test Plan
- [x] make lint-go
- [x] make test-go
- [x] make coverage-go
- [x] make check
