### PR TITLE
feat: allow pane moves across workspaces

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -431,6 +431,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 - The original pane keeps its current visible terminal contents when split; it must not go blank or reset to a fresh prompt while the new sibling pane is created.
 - Closing a pane calls `DELETE /api/sessions/{id}`, removes the pane from the tree, collapses parents with a single child, and renormalizes sizes to total `100`.
 - Moving a pane calls the workspace layout save path only; it does not call session create or delete APIs.
+- Dropping a pane on another workspace tab moves it into that workspace, persists both affected workspace layouts, and switches the active workspace to the destination.
 
 ### New terminal creation
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -431,7 +431,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 - The original pane keeps its current visible terminal contents when split; it must not go blank or reset to a fresh prompt while the new sibling pane is created.
 - Closing a pane calls `DELETE /api/sessions/{id}`, removes the pane from the tree, collapses parents with a single child, and renormalizes sizes to total `100`.
 - Moving a pane calls the workspace layout save path only; it does not call session create or delete APIs.
-- Dropping a pane on another workspace tab moves it into that workspace, persists both affected workspace layouts, and switches the active workspace to the destination.
+- Dropping a pane on another workspace tab moves it into that workspace, inserts it at the destination workspace's right edge, persists both affected workspace layouts, and switches the active workspace to the destination.
 
 ### New terminal creation
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -43,7 +43,7 @@ const mockSplitPane = vi.fn()
 const mockClosePane = vi.fn()
 const mockSwapPanes = vi.fn()
 const mockCreatePane = vi.fn().mockResolvedValue(undefined)
-const mockMovePane = vi.fn()
+const mockMovePane = vi.fn().mockResolvedValue(undefined)
 const mockAddWorkspace = vi.fn()
 const mockUseWorkspaceAttentionMonitor = vi.hoisted(() => vi.fn())
 const mockUseBrowserNotificationPermission = vi.hoisted(() => vi.fn())
@@ -295,6 +295,20 @@ describe('App workspace deletion', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Place workspace tabs on right' }))
 
     expect(mockSetWorkspaceTabPosition).toHaveBeenCalledWith('right')
+  })
+
+  it('moves a dragged pane to another workspace tab', () => {
+    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
+      const ctx = useContext(LayoutActionsContext)
+      return <button onMouseDown={() => ctx?.setDragSourcePaneId(pane.id)}>Start drag {pane.id}</button>
+    })
+
+    render(<App />)
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Start drag main' }), { button: 0 })
+    fireEvent.mouseEnter(screen.getByRole('tab', { name: 'Ops' }))
+    fireEvent.mouseUp(screen.getByRole('tab', { name: 'Ops' }))
+
+    expect(mockMovePane).toHaveBeenCalledWith('main', { type: 'workspace-tab', workspaceId: 'ops' })
   })
 
   it('shows a user-visible error when moving a pane fails to persist', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { useBrowserNotificationPermission } from './hooks/useBrowserNotification
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
 import { findPaneById, generatePaneId, layoutContainsPane } from './utils/layoutTree'
-import type { PanePlacement } from './hooks/useLayout'
+import type { MovePanePlacement } from './hooks/useLayout'
 import type { LayoutChild, LayoutNode, SSHConfigHost } from './schemas'
 
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
@@ -129,7 +129,7 @@ export const App: React.FC = () => {
     })
   }, [createPane])
 
-  const handleMovePane = useCallback((sourcePaneId: string, placement: PanePlacement) => {
+  const handleMovePane = useCallback((sourcePaneId: string, placement: MovePanePlacement) => {
     setMovePaneError(null)
     void movePane(sourcePaneId, placement).catch((err) => {
       setMovePaneError(err instanceof Error ? err.message : 'Something went wrong')
@@ -214,6 +214,11 @@ export const App: React.FC = () => {
             workspaces={workspaces.items}
             activeWorkspaceId={workspaces.active}
             tabPosition={workspaces.tab_position}
+            dragSourcePaneId={dragSourcePaneId}
+            onMovePaneToWorkspace={(sourcePaneId, workspaceId) => {
+              handleMovePane(sourcePaneId, { type: 'workspace-tab', workspaceId })
+              setDragSourcePaneId(null)
+            }}
             onSelect={setActiveWorkspace}
             attentionWorkspaceIds={attentionWorkspaceIds}
             onClearAttention={clearWorkspaceAttention}

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -99,6 +99,47 @@ describe('WorkspaceTabs', () => {
     expect(onSelect).toHaveBeenCalledWith('ops')
   })
 
+  it('moves a dragged pane into another workspace when the tab receives a drop', () => {
+    const onMovePaneToWorkspace = vi.fn()
+    const dataTransfer = { dropEffect: 'none' }
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        dragSourcePaneId="pane-source"
+        onMovePaneToWorkspace={onMovePaneToWorkspace}
+        onSelect={() => {}}
+      />,
+    )
+
+    const tab = screen.getByRole('tab', { name: 'Ops' })
+    fireEvent.dragOver(tab, { dataTransfer })
+    fireEvent.drop(tab, { dataTransfer })
+
+    expect(onMovePaneToWorkspace).toHaveBeenCalledWith('pane-source', 'ops')
+  })
+
+  it('moves a dragged pane into another workspace on pointer drag release', () => {
+    const onMovePaneToWorkspace = vi.fn()
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        dragSourcePaneId="pane-source"
+        onMovePaneToWorkspace={onMovePaneToWorkspace}
+        onSelect={() => {}}
+      />,
+    )
+
+    const tab = screen.getByRole('tab', { name: 'Ops' })
+    fireEvent.mouseEnter(tab)
+    fireEvent.mouseUp(tab)
+
+    expect(onMovePaneToWorkspace).toHaveBeenCalledWith('pane-source', 'ops')
+  })
+
   it('hides workspace tabs for a single workspace while keeping add available', () => {
     const onAdd = vi.fn()
     render(

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -140,6 +140,45 @@ describe('WorkspaceTabs', () => {
     expect(onMovePaneToWorkspace).toHaveBeenCalledWith('pane-source', 'ops')
   })
 
+  it('clears the workspace drop highlight when dragging is cancelled externally', () => {
+    const { rerender } = render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        dragSourcePaneId="pane-source"
+        onMovePaneToWorkspace={() => {}}
+        onSelect={() => {}}
+      />,
+    )
+
+    const tab = screen.getByRole('tab', { name: 'Ops' }).parentElement
+    expect(tab).not.toBeNull()
+    fireEvent.mouseEnter(tab!)
+    expect(tab).toHaveStyle({
+      backgroundColor: 'rgba(86, 156, 214, 0.24)',
+      boxShadow: 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)',
+    })
+
+    rerender(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        dragSourcePaneId={null}
+        onMovePaneToWorkspace={() => {}}
+        onSelect={() => {}}
+      />,
+    )
+
+    const rerenderedTab = screen.getByRole('tab', { name: 'Ops' }).parentElement
+    expect(rerenderedTab).not.toBeNull()
+    expect(rerenderedTab).not.toHaveStyle({
+      backgroundColor: 'rgba(86, 156, 214, 0.24)',
+      boxShadow: 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)',
+    })
+  })
+
   it('hides workspace tabs for a single workspace while keeping add available', () => {
     const onAdd = vi.fn()
     render(

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -120,6 +120,12 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     }
   }, [editingWorkspaceId])
 
+  useEffect(() => {
+    if (!dragSourcePaneId) {
+      setHoveredDropWorkspaceId(null)
+    }
+  }, [dragSourcePaneId])
+
   const startRename = (workspace: Workspace) => {
     if (!onRename) return
     renameFinalizedRef.current = false
@@ -280,12 +286,12 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
                 style={{
                   borderRight: !vertical ? '1px solid #333842' : undefined,
                   borderBottom: vertical ? '1px solid #333842' : undefined,
-                  backgroundColor: hoveredDropWorkspaceId === workspace.id
+                  backgroundColor: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
                     ? 'rgba(86, 156, 214, 0.24)'
                     : active
                       ? '#2f3540'
                       : 'transparent',
-                  boxShadow: hoveredDropWorkspaceId === workspace.id
+                  boxShadow: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
                     ? 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)'
                     : 'none',
                   display: 'flex',

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -7,6 +7,8 @@ interface WorkspaceTabsProps {
   activeWorkspaceId: string
   tabPosition: TabPosition
   onSelect: (workspaceId: string) => void
+  dragSourcePaneId?: string | null
+  onMovePaneToWorkspace?: (sourcePaneId: string, workspaceId: string) => void
   onAdd?: () => void
   onDelete?: (workspaceId: string) => void
   onRename?: (workspaceId: string, title: string) => void
@@ -93,6 +95,8 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   activeWorkspaceId,
   tabPosition,
   onSelect,
+  dragSourcePaneId,
+  onMovePaneToWorkspace,
   onAdd,
   onDelete,
   onRename,
@@ -105,6 +109,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const showBar = showTabs || Boolean(onAdd || onDelete || onRename || onTabPositionChange)
   const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null)
   const [draftTitle, setDraftTitle] = useState('')
+  const [hoveredDropWorkspaceId, setHoveredDropWorkspaceId] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const renameFinalizedRef = useRef(false)
 
@@ -136,6 +141,12 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const cancelRename = () => {
     renameFinalizedRef.current = true
     setEditingWorkspaceId(null)
+  }
+
+  const moveDraggedPaneToWorkspace = (workspaceId: string) => {
+    if (!dragSourcePaneId || workspaceId === activeWorkspaceId) return
+    onMovePaneToWorkspace?.(dragSourcePaneId, workspaceId)
+    setHoveredDropWorkspaceId(null)
   }
 
   const positionControls = onTabPositionChange ? (
@@ -240,14 +251,43 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
             const active = workspace.id === activeWorkspaceId
             const editing = editingWorkspaceId === workspace.id
             const hasAttention = !active && (attentionWorkspaceIds?.has(workspace.id) ?? false)
+            const isWorkspaceDropTarget = Boolean(dragSourcePaneId) && !editing && workspace.id !== activeWorkspaceId
             return (
               <div
                 key={workspace.id}
                 className={hasAttention ? 'panemux-workspace-tab-attention' : undefined}
+                onDragOver={(event) => {
+                  if (!isWorkspaceDropTarget) return
+                  event.preventDefault()
+                  event.dataTransfer.dropEffect = 'move'
+                  setHoveredDropWorkspaceId(workspace.id)
+                }}
+                onDragLeave={() => setHoveredDropWorkspaceId((current) => current === workspace.id ? null : current)}
+                onDrop={(event) => {
+                  if (!isWorkspaceDropTarget) return
+                  event.preventDefault()
+                  moveDraggedPaneToWorkspace(workspace.id)
+                }}
+                onMouseEnter={() => {
+                  if (!isWorkspaceDropTarget) return
+                  setHoveredDropWorkspaceId(workspace.id)
+                }}
+                onMouseLeave={() => setHoveredDropWorkspaceId((current) => current === workspace.id ? null : current)}
+                onMouseUp={() => {
+                  if (!isWorkspaceDropTarget) return
+                  moveDraggedPaneToWorkspace(workspace.id)
+                }}
                 style={{
                   borderRight: !vertical ? '1px solid #333842' : undefined,
                   borderBottom: vertical ? '1px solid #333842' : undefined,
-                  backgroundColor: active ? '#2f3540' : 'transparent',
+                  backgroundColor: hoveredDropWorkspaceId === workspace.id
+                    ? 'rgba(86, 156, 214, 0.24)'
+                    : active
+                      ? '#2f3540'
+                      : 'transparent',
+                  boxShadow: hoveredDropWorkspaceId === workspace.id
+                    ? 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)'
+                    : 'none',
                   display: 'flex',
                   alignItems: 'center',
                   height: vertical ? 38 : 34,
@@ -290,6 +330,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
                     aria-selected={active}
                     data-attention={hasAttention ? 'true' : undefined}
                     onClick={() => {
+                      if (dragSourcePaneId) return
                       onClearAttention?.(workspace.id)
                       onSelect(workspace.id)
                     }}

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -1059,6 +1059,56 @@ describe('useLayout', () => {
       expect(result.current.workspaces?.active).toBe('dev')
     })
 
+    it('rolls back frontend state and restores the source workspace when the destination save fails', async () => {
+      const multiPaneWorkspaces = {
+        active: 'dev',
+        tab_position: 'top' as const,
+        items: [
+          {
+            id: 'dev',
+            title: 'Dev',
+            layout: {
+              direction: 'horizontal' as const,
+              children: [
+                { size: 50, pane: { id: 'main', type: 'local' as const } },
+                { size: 50, pane: { id: 'side', type: 'local' as const } },
+              ],
+            },
+          },
+          {
+            id: 'ops',
+            title: 'Ops',
+            layout: {
+              direction: 'vertical' as const,
+              children: [{ size: 100, pane: { id: 'ops-main', type: 'local' as const } }],
+            },
+          },
+        ],
+      }
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(multiPaneWorkspaces) } as Response)
+        .mockResolvedValueOnce({ ok: false } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response)
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response)
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.layout).not.toBeNull())
+
+      await act(async () => {
+        await expect(result.current.movePane('main', { type: 'workspace-tab', workspaceId: 'ops' })).rejects.toThrow('HTTP 500')
+      })
+
+      expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/workspaces/dev/layout', expect.objectContaining({ method: 'PUT' }))
+      expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/workspaces/ops/layout', expect.objectContaining({ method: 'PUT' }))
+      expect(fetchMock).toHaveBeenNthCalledWith(5, '/api/workspaces/dev/layout', expect.objectContaining({ method: 'PUT' }))
+      expect(result.current.workspaces?.active).toBe('dev')
+      expect(result.current.layout?.children[0].pane?.id).toBe('main')
+      expect(result.current.workspaces?.items.find((workspace) => workspace.id === 'dev')?.layout.children).toHaveLength(2)
+      expect(result.current.workspaces?.items.find((workspace) => workspace.id === 'ops')?.layout.children[0].pane?.id).toBe('ops-main')
+    })
+
     it('throws when persisting a moved pane fails', async () => {
       const fetchMock = vi.fn()
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -991,6 +991,74 @@ describe('useLayout', () => {
       expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/dev/layout', expect.objectContaining({ method: 'PUT' }))
     })
 
+    it('moves a pane to another workspace and activates the destination workspace', async () => {
+      const multiPaneWorkspaces = {
+        active: 'dev',
+        tab_position: 'top' as const,
+        items: [
+          {
+            id: 'dev',
+            title: 'Dev',
+            layout: {
+              direction: 'horizontal' as const,
+              children: [
+                { size: 50, pane: { id: 'main', type: 'local' as const } },
+                { size: 50, pane: { id: 'side', type: 'local' as const } },
+              ],
+            },
+          },
+          {
+            id: 'ops',
+            title: 'Ops',
+            layout: {
+              direction: 'vertical' as const,
+              children: [{ size: 100, pane: { id: 'ops-main', type: 'local' as const } }],
+            },
+          },
+        ],
+      }
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(multiPaneWorkspaces) } as Response)
+        .mockResolvedValueOnce({ ok: false } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response)
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.layout).not.toBeNull())
+
+      await act(async () => {
+        await result.current.movePane('main', { type: 'workspace-tab', workspaceId: 'ops' })
+      })
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/dev/layout', expect.objectContaining({ method: 'PUT' }))
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/ops/layout', expect.objectContaining({ method: 'PUT' }))
+      expect(result.current.workspaces?.active).toBe('ops')
+      expect(result.current.layout?.children[result.current.layout.children.length - 1].pane?.id).toBe('main')
+      expect(result.current.workspaces?.items.find((workspace) => workspace.id === 'dev')?.layout.children).toHaveLength(1)
+      expect(result.current.workspaces?.items.find((workspace) => workspace.id === 'dev')?.layout.children[0].pane?.id).toBe('side')
+    })
+
+    it('rejects moving the last pane out of a workspace', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+        .mockResolvedValueOnce({ ok: false } as Response)
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.layout).not.toBeNull())
+
+      await act(async () => {
+        await expect(result.current.movePane('main', { type: 'workspace-tab', workspaceId: 'ops' })).rejects.toThrow(
+          'Cannot move the last pane out of a workspace',
+        )
+      })
+
+      expect(fetchMock).not.toHaveBeenCalledWith('/api/workspaces/dev/layout', expect.anything())
+      expect(fetchMock).not.toHaveBeenCalledWith('/api/workspaces/ops/layout', expect.anything())
+      expect(result.current.workspaces?.active).toBe('dev')
+    })
+
     it('throws when persisting a moved pane fails', async () => {
       const fetchMock = vi.fn()
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -1109,6 +1109,55 @@ describe('useLayout', () => {
       expect(result.current.workspaces?.items.find((workspace) => workspace.id === 'ops')?.layout.children[0].pane?.id).toBe('ops-main')
     })
 
+    it('throws a distinct error when both the destination save and rollback save fail', async () => {
+      const multiPaneWorkspaces = {
+        active: 'dev',
+        tab_position: 'top' as const,
+        items: [
+          {
+            id: 'dev',
+            title: 'Dev',
+            layout: {
+              direction: 'horizontal' as const,
+              children: [
+                { size: 50, pane: { id: 'main', type: 'local' as const } },
+                { size: 50, pane: { id: 'side', type: 'local' as const } },
+              ],
+            },
+          },
+          {
+            id: 'ops',
+            title: 'Ops',
+            layout: {
+              direction: 'vertical' as const,
+              children: [{ size: 100, pane: { id: 'ops-main', type: 'local' as const } }],
+            },
+          },
+        ],
+      }
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(multiPaneWorkspaces) } as Response)
+        .mockResolvedValueOnce({ ok: false } as Response)
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) } as Response)
+        .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+        .mockRejectedValueOnce(new Error('rollback failed'))
+      window.fetch = fetchMock
+
+      const { result } = renderHook(() => useLayout())
+      await waitFor(() => expect(result.current.layout).not.toBeNull())
+
+      await act(async () => {
+        await expect(result.current.movePane('main', { type: 'workspace-tab', workspaceId: 'ops' })).rejects.toThrow(
+          'Move failed and rollback also failed. Reload to sync.',
+        )
+      })
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error))
+      expect(result.current.workspaces?.active).toBe('dev')
+      expect(result.current.layout?.children[0].pane?.id).toBe('main')
+    })
+
     it('throws when persisting a moved pane fails', async () => {
       const fetchMock = vi.fn()
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -301,6 +301,7 @@ export function useLayout() {
           await saveWorkspaceLayout(sourceWorkspace.id, sourceWorkspace.layout)
         } catch (rollbackErr) {
           console.error(rollbackErr)
+          throw new Error('Move failed and rollback also failed. Reload to sync.')
         }
         throw err
       }

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { DetectShellResponseSchema, DisplayConfig, DisplayConfigSchema, LayoutNode, PaneConfig, TabPosition, WorkspacesResponse, WorkspacesResponseSchema, WorkspaceTabPositionRequestSchema } from '../schemas'
-import { PaneEdge, findPaneById, generatePaneId, generateTmuxSessionName, insertPaneAtWorkspaceEdge, insertPaneBesideTargetPane, movePaneBesideTargetPane, movePaneToWorkspaceEdge, removePaneFromTree, splitPaneInTree, swapPanesInTree } from '../utils/layoutTree'
+import { PaneEdge, findPaneById, generatePaneId, generateTmuxSessionName, insertPaneAtWorkspaceEdge, insertPaneBesideTargetPane, layoutContainsPane, movePaneBesideTargetPane, movePaneToWorkspaceEdge, removePaneFromTree, splitPaneInTree, swapPanesInTree } from '../utils/layoutTree'
 
-export type PanePlacement =
-  | { type: 'workspace-edge'; edge: PaneEdge }
-  | { type: 'pane-edge'; targetPaneId: string; edge: PaneEdge }
+type WorkspaceEdgePlacement = { type: 'workspace-edge'; edge: PaneEdge }
+type PaneEdgePlacement = { type: 'pane-edge'; targetPaneId: string; edge: PaneEdge }
+type WorkspaceTabPlacement = { type: 'workspace-tab'; workspaceId: string }
+
+export type CreatePanePlacement = WorkspaceEdgePlacement | PaneEdgePlacement
+export type MovePanePlacement = CreatePanePlacement | WorkspaceTabPlacement
 
 export function useLayout() {
   const [layout, setLayout] = useState<LayoutNode | null>(null)
@@ -234,7 +237,7 @@ export function useLayout() {
     [layout, saveLayout],
   )
 
-  const createPane = useCallback(async (pane: PaneConfig, placement: PanePlacement) => {
+  const createPane = useCallback(async (pane: PaneConfig, placement: CreatePanePlacement) => {
     if (!layout) return
     const paneWithDefaults = await ensurePaneDefaults(pane)
     setError(null)
@@ -256,18 +259,61 @@ export function useLayout() {
     await saveLayout(newLayout, true)
   }, [ensurePaneDefaults, layout, saveLayout])
 
-  const movePane = useCallback(async (sourcePaneId: string, placement: PanePlacement) => {
-    if (!layout) return
+  const movePane = useCallback(async (sourcePaneId: string, placement: MovePanePlacement) => {
+    if (!layout || !workspaces) return
     setError(null)
+
+    if (placement.type === 'workspace-tab') {
+      const sourceWorkspace = workspaces.items.find((workspace) => layoutContainsPane(workspace.layout, sourcePaneId))
+      const targetWorkspace = workspaces.items.find((workspace) => workspace.id === placement.workspaceId)
+      if (!sourceWorkspace || !targetWorkspace || sourceWorkspace.id === targetWorkspace.id) return
+
+      const sourceWithoutPane = removePaneFromTree(sourceWorkspace.layout, sourcePaneId)
+      if (!sourceWithoutPane) {
+        throw new Error('Cannot move the last pane out of a workspace')
+      }
+
+      const sourcePane = findPaneById(sourceWorkspace.layout, sourcePaneId)
+      if (!sourcePane) return
+
+      const targetWithPane = insertPaneAtWorkspaceEdge(targetWorkspace.layout, 'right', sourcePane)
+      const updatedWorkspaces: WorkspacesResponse = {
+        ...workspaces,
+        active: targetWorkspace.id,
+        items: workspaces.items.map((workspace) => {
+          if (workspace.id === sourceWorkspace.id) return { ...workspace, layout: sourceWithoutPane }
+          if (workspace.id === targetWorkspace.id) return { ...workspace, layout: targetWithPane }
+          return workspace
+        }),
+      }
+
+      setWorkspaces(updatedWorkspaces)
+      setLayout(targetWithPane)
+      await saveWorkspaceLayout(sourceWorkspace.id, sourceWithoutPane)
+      await saveWorkspaceLayout(targetWorkspace.id, targetWithPane)
+      return
+    }
+
     const newLayout = placement.type === 'workspace-edge'
       ? movePaneToWorkspaceEdge(layout, sourcePaneId, placement.edge)
       : movePaneBesideTargetPane(layout, sourcePaneId, placement.targetPaneId, placement.edge)
     setLayout(newLayout)
     setWorkspaces((current) => current ? replaceActiveWorkspaceLayout(current, newLayout) : current)
     await saveLayout(newLayout, true)
-  }, [layout, saveLayout])
+  }, [layout, saveLayout, workspaces])
 
   return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, createPane, movePane, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition }
+}
+
+async function saveWorkspaceLayout(workspaceID: string, updatedLayout: LayoutNode) {
+  const response = await fetch(`/api/workspaces/${encodeURIComponent(workspaceID)}/layout`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updatedLayout),
+  })
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`)
+  }
 }
 
 function replaceActiveWorkspaceLayout(workspaces: WorkspacesResponse, layout: LayoutNode): WorkspacesResponse {

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -268,6 +268,8 @@ export function useLayout() {
       const targetWorkspace = workspaces.items.find((workspace) => workspace.id === placement.workspaceId)
       if (!sourceWorkspace || !targetWorkspace || sourceWorkspace.id === targetWorkspace.id) return
 
+      const previousWorkspaces = workspaces
+      const previousLayout = layout
       const sourceWithoutPane = removePaneFromTree(sourceWorkspace.layout, sourcePaneId)
       if (!sourceWithoutPane) {
         throw new Error('Cannot move the last pane out of a workspace')
@@ -289,8 +291,19 @@ export function useLayout() {
 
       setWorkspaces(updatedWorkspaces)
       setLayout(targetWithPane)
-      await saveWorkspaceLayout(sourceWorkspace.id, sourceWithoutPane)
-      await saveWorkspaceLayout(targetWorkspace.id, targetWithPane)
+      try {
+        await saveWorkspaceLayout(sourceWorkspace.id, sourceWithoutPane)
+        await saveWorkspaceLayout(targetWorkspace.id, targetWithPane)
+      } catch (err) {
+        setWorkspaces(previousWorkspaces)
+        setLayout(previousLayout)
+        try {
+          await saveWorkspaceLayout(sourceWorkspace.id, sourceWorkspace.layout)
+        } catch (rollbackErr) {
+          console.error(rollbackErr)
+        }
+        throw err
+      }
       return
     }
 


### PR DESCRIPTION
## Summary
- allow dragging a pane onto another workspace tab to move it across workspaces
- persist both source and destination workspace layouts and switch to the destination workspace after the move
- add regression coverage for cross-workspace moves and document the behavior

## Test Plan
- [x] make lint-frontend
- [x] make test-frontend
