### PR TITLE
fix: restore git header for ssh and ssh tmux panes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,7 @@ Why this hook:
 
 - first, it asks the session for its live working directory
 - second, it may ask for an active interactive agent workdir override
+- local and local tmux sessions inspect Git metadata on the local filesystem; SSH and SSH+tmux sessions inspect Git metadata on the remote host over the existing SSH connection so remote-only repositories still render header Git info
 
 The override path is intentionally narrow:
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -145,6 +145,10 @@ For pane-header Git status, local and local tmux panes inspect the local filesys
 and `ssh_tmux` panes run the equivalent Git inspection on the remote host. This allows headers to
 show branch/repository info even when the repository exists only on the SSH target.
 
+Remote Git inspection currently depends on `git rev-parse --path-format=absolute --git-common-dir`
+on the SSH target, which requires Git 2.31 or newer. Older remote Git versions degrade to "no git
+info" in the pane header for SSH-backed panes.
+
 ## REST API
 
 ### `GET /api/layout`

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -141,6 +141,10 @@ session and replays that snapshot when a pane reconnects after a workspace switc
 but prompt notifications no longer depend on the pane being visibly mounted at the time the output
 arrives.
 
+For pane-header Git status, local and local tmux panes inspect the local filesystem, while `ssh`
+and `ssh_tmux` panes run the equivalent Git inspection on the remote host. This allows headers to
+show branch/repository info even when the repository exists only on the SSH target.
+
 ## REST API
 
 ### `GET /api/layout`

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -712,13 +713,6 @@ type gitInfoResponse struct {
 	IsGit    bool   `json:"is_git"`
 }
 
-type gitContext struct {
-	branch    string
-	commonDir string
-	repo      string
-	root      string
-}
-
 // GetGitInfo returns git repository information for the session's current working directory.
 func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
@@ -747,24 +741,24 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	targetCWD := h.resolvePreferredCWD(sess, cwd)
-	ctx, err := h.inspectGitContext(targetCWD)
+	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
 	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
 	}
-	prURL, prNumber := h.lookupPRInfo(targetCWD, ctx.branch)
+	prURL, prNumber := h.lookupPRInfo(targetCWD, ctx)
 
 	writeJSON(w, gitInfoResponse{
 		IsGit:    true,
-		Branch:   ctx.branch,
-		Repo:     ctx.repo,
+		Branch:   ctx.Branch,
+		Repo:     ctx.Repo,
 		PRURL:    prURL,
 		PRNumber: prNumber,
 	})
 }
 
 func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
-	baseCtx, err := h.inspectGitContext(cwd)
+	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
 		return cwd
 	}
@@ -779,28 +773,39 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 		return cwd
 	}
 
-	ctx, err := h.inspectGitContext(candidate)
+	ctx, err := h.inspectGitContextForSession(sess, candidate)
 	if err != nil {
 		return cwd
 	}
-	if ctx.commonDir == baseCtx.commonDir && ctx.root != baseCtx.root {
+	if ctx.CommonDir == baseCtx.CommonDir && ctx.Root != baseCtx.Root {
 		return candidate
 	}
 
 	return cwd
 }
 
-func (h *Handler) inspectGitContext(cwd string) (gitContext, error) {
+func (h *Handler) inspectGitContextForSession(sess session.Session, cwd string) (session.GitContext, error) {
+	if getter, ok := sess.(session.GitContextGetter); ok {
+		ctx, err := getter.InspectGitContext(cwd)
+		if err != nil {
+			return session.GitContext{}, fmt.Errorf("inspect session git context: %w", err)
+		}
+		return ctx, nil
+	}
+	return h.inspectLocalGitContext(cwd)
+}
+
+func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error) {
 	safeCWD, err := sanitizeGitExecDir(cwd)
 	if err != nil {
-		return gitContext{}, err
+		return session.GitContext{}, err
 	}
 
 	toplevelCmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	toplevelCmd.Dir = safeCWD
 	toplevelOut, err := toplevelCmd.Output()
 	if err != nil {
-		return gitContext{}, fmt.Errorf("git show toplevel for %q: %w", cwd, err)
+		return session.GitContext{}, fmt.Errorf("git show toplevel for %q: %w", cwd, err)
 	}
 	toplevelOut = bytes.TrimSpace(toplevelOut)
 
@@ -808,7 +813,7 @@ func (h *Handler) inspectGitContext(cwd string) (gitContext, error) {
 	commonDirCmd.Dir = safeCWD
 	commonDirOut, err := commonDirCmd.Output()
 	if err != nil {
-		return gitContext{}, fmt.Errorf("git show common dir for %q: %w", cwd, err)
+		return session.GitContext{}, fmt.Errorf("git show common dir for %q: %w", cwd, err)
 	}
 	commonDirOut = bytes.TrimSpace(commonDirOut)
 
@@ -823,11 +828,11 @@ func (h *Handler) inspectGitContext(cwd string) (gitContext, error) {
 	branchOut = bytes.TrimSpace(branchOut)
 
 	root := string(toplevelOut)
-	return gitContext{
-		branch:    string(branchOut),
-		commonDir: string(commonDirOut),
-		repo:      filepath.Base(root),
-		root:      root,
+	return session.GitContext{
+		Branch:    string(branchOut),
+		CommonDir: string(commonDirOut),
+		Repo:      filepath.Base(root),
+		Root:      root,
 	}, nil
 }
 
@@ -855,8 +860,8 @@ func (h *Handler) findGH() (string, error) {
 	return path, nil
 }
 
-func (h *Handler) lookupPRInfo(cwd, branch string) (string, int) {
-	if branch == "" {
+func (h *Handler) lookupPRInfo(cwd string, gitCtx session.GitContext) (string, int) {
+	if gitCtx.Branch == "" {
 		return "", 0
 	}
 
@@ -876,11 +881,15 @@ func (h *Handler) lookupPRInfo(cwd, branch string) (string, int) {
 		ghPath,
 		"pr",
 		"view",
-		branch,
+		gitCtx.Branch,
 		"--json",
 		"url,number",
 	)
-	cmd.Dir = cwd
+	if repoSpec := repoSpecFromOriginURL(gitCtx.OriginURL); repoSpec != "" {
+		cmd.Args = append(cmd.Args, "--repo", repoSpec)
+	} else {
+		cmd.Dir = cwd
+	}
 	out, err := cmd.Output()
 	if err != nil {
 		return "", 0
@@ -894,6 +903,31 @@ func (h *Handler) lookupPRInfo(cwd, branch string) (string, int) {
 		return "", 0
 	}
 	return strings.TrimSpace(resp.URL), resp.Number
+}
+
+func repoSpecFromOriginURL(origin string) string {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(origin, ".git"))
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "git@") {
+		hostPath := strings.TrimPrefix(trimmed, "git@")
+		parts := strings.SplitN(hostPath, ":", 2)
+		if len(parts) != 2 {
+			return ""
+		}
+		return parts[0] + "/" + strings.TrimPrefix(parts[1], "/")
+	}
+
+	u, err := url.Parse(trimmed)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	path := strings.TrimPrefix(u.Path, "/")
+	if path == "" {
+		return ""
+	}
+	return u.Host + "/" + path
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -746,7 +746,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
 	}
-	prURL, prNumber := h.lookupPRInfo(targetCWD, ctx)
+	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, ctx)
 
 	writeJSON(w, gitInfoResponse{
 		IsGit:    true,
@@ -860,7 +860,7 @@ func (h *Handler) findGH() (string, error) {
 	return path, nil
 }
 
-func (h *Handler) lookupPRInfo(cwd string, gitCtx session.GitContext) (string, int) {
+func (h *Handler) lookupPRInfo(sess session.Session, cwd string, gitCtx session.GitContext) (string, int) {
 	if gitCtx.Branch == "" {
 		return "", 0
 	}
@@ -887,6 +887,11 @@ func (h *Handler) lookupPRInfo(cwd string, gitCtx session.GitContext) (string, i
 	)
 	if repoSpec := repoSpecFromOriginURL(gitCtx.OriginURL); repoSpec != "" {
 		cmd.Args = append(cmd.Args, "--repo", repoSpec)
+	} else if _, ok := sess.(session.GitContextGetter); ok {
+		// Remote SSH-backed sessions may point at repositories that do not exist
+		// on the local filesystem. Without an origin-derived repo spec, `gh`
+		// cannot resolve PR metadata for that remote-only checkout.
+		return "", 0
 	} else {
 		cmd.Dir = cwd
 	}
@@ -923,11 +928,15 @@ func repoSpecFromOriginURL(origin string) string {
 	if err != nil || u.Host == "" {
 		return ""
 	}
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
 	path := strings.TrimPrefix(u.Path, "/")
 	if path == "" {
 		return ""
 	}
-	return u.Host + "/" + path
+	return host + "/" + path
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1645,7 +1645,7 @@ func TestLookupPRInfo_TimesOutAndFallsBack(t *testing.T) {
 	prLookupTimeout = 10 * time.Millisecond
 	t.Cleanup(func() { prLookupTimeout = prev })
 
-	url, number := h.lookupPRInfo(t.TempDir(), session.GitContext{Branch: "feature/slow"})
+	url, number := h.lookupPRInfo(newMockSession("s1"), t.TempDir(), session.GitContext{Branch: "feature/slow"})
 	assert.Empty(t, url)
 	assert.Zero(t, number)
 }
@@ -1808,6 +1808,17 @@ func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T
 	assert.Equal(t, "panemux", resp.Repo)
 }
 
+func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nexit 99\n")
+
+	url, number := h.lookupPRInfo(&mockRemoteGitSession{}, "/home/demo/panemux", session.GitContext{
+		Branch: "feature/no-origin",
+	})
+	assert.Empty(t, url)
+	assert.Zero(t, number)
+}
+
 func TestSanitizeGitExecDir_ValidAbsolutePath(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "repo")
 	require.NoError(t, os.MkdirAll(dir, 0755))
@@ -1818,10 +1829,54 @@ func TestSanitizeGitExecDir_ValidAbsolutePath(t *testing.T) {
 }
 
 func TestRepoSpecFromOriginURL(t *testing.T) {
-	assert.Equal(t, "github.com/example/panemux", repoSpecFromOriginURL("git@github.com:example/panemux.git"))
-	assert.Equal(t, "github.com/example/panemux", repoSpecFromOriginURL("https://github.com/example/panemux.git"))
-	assert.Equal(t, "git.example.com/team/panemux", repoSpecFromOriginURL("ssh://git@git.example.com/team/panemux.git"))
-	assert.Empty(t, repoSpecFromOriginURL("not-a-url"))
+	credentialOrigin := "https://user:" + "placeholder" + "@github.com/example/panemux.git"
+	tests := []struct {
+		name   string
+		origin string
+		want   string
+	}{
+		{
+			name:   "scp style ssh",
+			origin: "git@github.com:example/panemux.git",
+			want:   "github.com/example/panemux",
+		},
+		{
+			name:   "https",
+			origin: "https://github.com/example/panemux.git",
+			want:   "github.com/example/panemux",
+		},
+		{
+			name:   "ssh url",
+			origin: "ssh://git@git.example.com/team/panemux.git",
+			want:   "git.example.com/team/panemux",
+		},
+		{
+			name:   "ssh url with explicit port",
+			origin: "ssh://git@git.example.com:2222/team/panemux.git",
+			want:   "git.example.com/team/panemux",
+		},
+		{
+			name:   "https without git suffix",
+			origin: "https://github.com/example/panemux",
+			want:   "github.com/example/panemux",
+		},
+		{
+			name:   "https with embedded credentials",
+			origin: credentialOrigin,
+			want:   "github.com/example/panemux",
+		},
+		{
+			name:   "invalid",
+			origin: "not-a-url",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, repoSpecFromOriginURL(tt.origin))
+		})
+	}
 }
 
 func TestSanitizeGitExecDir_RejectsRelativePath(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1163,6 +1163,31 @@ type mockSSHCWDSession struct {
 func (m *mockSSHCWDSession) GetCWD() (string, error) { return m.cwd, nil }
 func (m *mockSSHCWDSession) ConnectionName() string  { return m.connName }
 
+// mockRemoteGitSession is a mock SSH-like session that resolves git metadata
+// on the remote host instead of through the local filesystem.
+//
+//nolint:govet // test helper layout is not performance-sensitive
+type mockRemoteGitSession struct {
+	mockSession
+	activeWorkdir string
+	activeErr     error
+	cwd           string
+	cwdErr        error
+	gitContexts   map[string]session.GitContext
+}
+
+func (m *mockRemoteGitSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
+func (m *mockRemoteGitSession) GetActiveWorkdir() (string, error) {
+	return m.activeWorkdir, m.activeErr
+}
+func (m *mockRemoteGitSession) InspectGitContext(cwd string) (session.GitContext, error) {
+	ctx, ok := m.gitContexts[cwd]
+	if !ok {
+		return session.GitContext{}, errors.New("not a git repo")
+	}
+	return ctx, nil
+}
+
 func setupRouterWithVSCode(h *Handler) *chi.Mux {
 	r := setupRouterWithHandler(h)
 	r.Post("/api/sessions/{id}/open-vscode", h.PostOpenVSCode)
@@ -1620,7 +1645,7 @@ func TestLookupPRInfo_TimesOutAndFallsBack(t *testing.T) {
 	prLookupTimeout = 10 * time.Millisecond
 	t.Cleanup(func() { prLookupTimeout = prev })
 
-	url, number := h.lookupPRInfo(t.TempDir(), "feature/slow")
+	url, number := h.lookupPRInfo(t.TempDir(), session.GitContext{Branch: "feature/slow"})
 	assert.Empty(t, url)
 	assert.Zero(t, number)
 }
@@ -1708,6 +1733,81 @@ func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
 	assert.False(t, resp.IsGit)
 }
 
+func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
+	const remoteRepo = "/home/demo/panemux"
+
+	mgr := session.NewManager()
+	mgr.Add(&mockRemoteGitSession{
+		mockSession: mockSession{id: "ssh-remote", typ: session.TypeSSH},
+		cwd:         remoteRepo,
+		gitContexts: map[string]session.GitContext{
+			remoteRepo: {
+				Branch:    "main",
+				CommonDir: "/home/demo/panemux/.git",
+				Repo:      "panemux",
+				Root:      remoteRepo,
+			},
+		},
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "main", resp.Branch)
+	assert.Equal(t, "panemux", resp.Repo)
+}
+
+func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T) {
+	const (
+		remoteRepo     = "/home/demo/panemux"
+		remoteWorktree = "/home/demo/panemux-worktree"
+		commonDir      = "/home/demo/panemux/.git"
+	)
+
+	mgr := session.NewManager()
+	mgr.Add(&mockRemoteGitSession{
+		mockSession:   mockSession{id: "ssh-worktree", typ: session.TypeSSHTmux},
+		cwd:           remoteRepo,
+		activeWorkdir: remoteWorktree,
+		gitContexts: map[string]session.GitContext{
+			remoteRepo: {
+				Branch:    "main",
+				CommonDir: commonDir,
+				Repo:      "panemux",
+				Root:      remoteRepo,
+			},
+			remoteWorktree: {
+				Branch:    "feature/remote-worktree",
+				CommonDir: commonDir,
+				Repo:      "panemux",
+				Root:      remoteWorktree,
+			},
+		},
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-worktree/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "feature/remote-worktree", resp.Branch)
+	assert.Equal(t, "panemux", resp.Repo)
+}
+
 func TestSanitizeGitExecDir_ValidAbsolutePath(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "repo")
 	require.NoError(t, os.MkdirAll(dir, 0755))
@@ -1715,6 +1815,13 @@ func TestSanitizeGitExecDir_ValidAbsolutePath(t *testing.T) {
 	got, err := sanitizeGitExecDir(dir)
 	require.NoError(t, err)
 	assert.Equal(t, dir, got)
+}
+
+func TestRepoSpecFromOriginURL(t *testing.T) {
+	assert.Equal(t, "github.com/example/panemux", repoSpecFromOriginURL("git@github.com:example/panemux.git"))
+	assert.Equal(t, "github.com/example/panemux", repoSpecFromOriginURL("https://github.com/example/panemux.git"))
+	assert.Equal(t, "git.example.com/team/panemux", repoSpecFromOriginURL("ssh://git@git.example.com/team/panemux.git"))
+	assert.Empty(t, repoSpecFromOriginURL("not-a-url"))
 }
 
 func TestSanitizeGitExecDir_RejectsRelativePath(t *testing.T) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,21 @@ type ActiveWorkdirGetter interface {
 	GetActiveWorkdir() (string, error)
 }
 
+// GitContext describes the repository state for a session's working directory.
+type GitContext struct {
+	Branch    string
+	CommonDir string
+	OriginURL string
+	Repo      string
+	Root      string
+}
+
+// GitContextGetter is implemented by sessions that must inspect Git state
+// somewhere other than the local filesystem, such as a remote SSH host.
+type GitContextGetter interface {
+	InspectGitContext(cwd string) (GitContext, error)
+}
+
 // SSHConnNamer is implemented by sessions that have an SSH connection name.
 type SSHConnNamer interface {
 	ConnectionName() string

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -688,6 +688,12 @@ const sshOpenFilesCmdTemplate = `{ ls -1 /proc/%[1]d/fd 2>/dev/null | ` +
 	`{ lsof -a -p %[1]d -Fn 2>/dev/null | awk '/^n/{print substr($0,2)}'; }`
 const sshPIDCWDCmdTemplate = `{ readlink /proc/%[1]d/cwd 2>/dev/null || ` +
 	`lsof -a -p %[1]d -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2)}'; }`
+const sshGitContextCmdTemplate = `cd %[1]s && ` +
+	`root=$(git rev-parse --show-toplevel) && ` +
+	`common=$(git rev-parse --path-format=absolute --git-common-dir) && ` +
+	`branch=$(git branch --show-current 2>/dev/null || true) && ` +
+	`origin=$(git config --get remote.origin.url 2>/dev/null || true) && ` +
+	`printf '%%s\n%%s\n%%s\n%%s\n' "$root" "$common" "$branch" "$origin"`
 
 // GetCWD returns the current working directory of the interactive shell by
 // inspecting the sshd process tree. See sshGetCWDCmd for the full rationale.
@@ -725,6 +731,18 @@ func (s *SSHSession) GetActiveWorkdir() (string, error) {
 	}
 
 	return activeRemoteWorkdir(sess, baseCWD, rootPID)
+}
+
+// InspectGitContext resolves Git metadata on the remote host for the provided
+// absolute working directory.
+func (s *SSHSession) InspectGitContext(cwd string) (GitContext, error) {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return GitContext{}, fmt.Errorf("new ssh session for git context: %w", err)
+	}
+	defer sess.Close()
+
+	return remoteGitContext(sess, cwd)
 }
 
 func remoteShellPID(runner sshSessionRunner) (int, error) {
@@ -825,6 +843,31 @@ func remoteCodexSessionCWD(runner sshSessionRunner, processes []processInfo, age
 	}
 
 	return parseCodexSessionCWD(out)
+}
+
+func remoteGitContext(runner sshSessionRunner, cwd string) (GitContext, error) {
+	if err := validateRemotePath("working directory", cwd); err != nil {
+		return GitContext{}, err
+	}
+
+	out, err := runner.Output(fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)))
+	if err != nil {
+		return GitContext{}, fmt.Errorf("git context over ssh: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) < 4 {
+		return GitContext{}, errors.New("git context over ssh: incomplete response")
+	}
+
+	root := strings.TrimSpace(lines[0])
+	return GitContext{
+		Branch:    strings.TrimSpace(lines[2]),
+		CommonDir: strings.TrimSpace(lines[1]),
+		OriginURL: strings.TrimSpace(lines[3]),
+		Repo:      filepath.Base(root),
+		Root:      root,
+	}, nil
 }
 
 func remoteOpenFiles(runner sshSessionRunner, pid int) ([]string, error) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -455,3 +455,32 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/remote-tmux-worktree-from-command", cwd)
 }
+
+func TestRemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
+	const cwd = "/home/user/panemux"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)): []byte(
+				"/home/user/panemux\n" +
+					"/home/user/panemux/.git\n" +
+					"main\n" +
+					"git@github.com:example/panemux.git\n",
+			),
+		},
+	}
+
+	ctx, err := remoteGitContext(runner, cwd)
+	require.NoError(t, err)
+	assert.Equal(t, "main", ctx.Branch)
+	assert.Equal(t, "/home/user/panemux/.git", ctx.CommonDir)
+	assert.Equal(t, "git@github.com:example/panemux.git", ctx.OriginURL)
+	assert.Equal(t, "panemux", ctx.Repo)
+	assert.Equal(t, cwd, ctx.Root)
+}
+
+func TestRemoteGitContext_RejectsRelativePath(t *testing.T) {
+	_, err := remoteGitContext(&fakeSSHRunner{}, "panemux")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "working directory")
+}

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -156,6 +156,18 @@ func (s *TmuxSSHSession) GetActiveWorkdir() (string, error) {
 	return tmuxSSHActiveWorkdir(sess, s.tmuxSession)
 }
 
+// InspectGitContext resolves Git metadata on the remote host for the provided
+// absolute working directory.
+func (s *TmuxSSHSession) InspectGitContext(cwd string) (GitContext, error) {
+	sess, err := s.client.NewSession()
+	if err != nil {
+		return GitContext{}, fmt.Errorf("new ssh session for tmux git context: %w", err)
+	}
+	defer sess.Close()
+
+	return remoteGitContext(sess, cwd)
+}
+
 func tmuxSSHActiveWorkdir(runner sshSessionRunner, tmuxSession string) (string, error) {
 	panePIDOut, err := runner.Output(fmt.Sprintf("tmux display-message -p -t '%s' '#{pane_pid}'", tmuxSession))
 	if err != nil {


### PR DESCRIPTION
## Summary

- fix git header resolution for ssh and ssh_tmux panes by inspecting remote git state over SSH
- keep active worktree preference for remote agent sessions and support PR lookup from remote origin metadata
- add backend tests for remote git context resolution and document the behavior

## Test Plan

- [x] go test ./internal/api ./internal/session
- [x] make test-go
- [x] make lint-go
- [x] Manual reproduction against `server` with a fresh panemux config: confirm `/api/sessions/ssh-repro/git-info` and `/api/sessions/ssh-tmux-repro/git-info` return `{"branch":"main","repo":"panemux","is_git":true}`
