### PR TITLE
fix: detect codex root process in tmux worktrees

### DIFF
--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -247,6 +247,10 @@ func parsePSOutput(out []byte) ([]processInfo, error) {
 }
 
 func newestInteractiveAgentDescendantPID(processes []processInfo, rootPID int) (int, bool) {
+	if proc, ok := processByPID(processes, rootPID); ok && isInteractiveAgentCommand(proc.Command) {
+		return rootPID, true
+	}
+
 	children := childProcessMap(processes)
 	stack := append([]processInfo(nil), children[rootPID]...)
 	var matched int

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -247,14 +247,15 @@ func parsePSOutput(out []byte) ([]processInfo, error) {
 }
 
 func newestInteractiveAgentDescendantPID(processes []processInfo, rootPID int) (int, bool) {
-	if proc, ok := processByPID(processes, rootPID); ok && isInteractiveAgentCommand(proc.Command) {
-		return rootPID, true
-	}
-
 	children := childProcessMap(processes)
 	stack := append([]processInfo(nil), children[rootPID]...)
-	var matched int
-	var ok bool
+	matched := 0
+	ok := false
+
+	if proc, found := processByPID(processes, rootPID); found && isInteractiveAgentCommand(proc.Command) {
+		matched = rootPID
+		ok = true
+	}
 
 	for len(stack) > 0 {
 		proc := stack[len(stack)-1]

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -193,6 +193,19 @@ func TestNewestInteractiveAgentDescendantPID_IgnoresNonInteractiveAgents(t *test
 	assert.Equal(t, 140, pid)
 }
 
+func TestNewestInteractiveAgentDescendantPID_PrefersNewerChildOverInteractiveRoot(t *testing.T) {
+	processes := []processInfo{
+		{PID: 100, PPID: 1, Command: "codex resume --last"},
+		{PID: 140, PPID: 100, Command: "claude"},
+		{PID: 150, PPID: 100, Command: "codex exec"},
+		{PID: 160, PPID: 100, Command: "codex"},
+	}
+
+	pid, ok := newestInteractiveAgentDescendantPID(processes, 100)
+	require.True(t, ok)
+	assert.Equal(t, 160, pid)
+}
+
 func TestDescendantPIDs(t *testing.T) {
 	processes := []processInfo{
 		{PID: 110, PPID: 100, Command: "/bin/zsh"},

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -681,3 +681,60 @@ func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *test
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/tmux-worktree-from-command", cwd)
 }
+
+func TestTmuxLocalSessionGetActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(t *testing.T) {
+	sessionLog := filepath.Join(t.TempDir(), ".codex", "sessions", "2026", "05", "17", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionLog), 0755))
+	require.NoError(t, os.WriteFile(
+		sessionLog,
+		[]byte(
+			"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n"+
+				"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n"+
+				codexExecCommandRecord(t, "go test ./...", "/tmp/tmux-root-codex-worktree"),
+		),
+		0600,
+	))
+
+	originalTmuxLocalOutput := tmuxLocalOutputFn
+	originalListProcesses := listProcessesFn
+	originalOpenFilePaths := openFilePathsForPIDFn
+	t.Cleanup(func() {
+		tmuxLocalOutputFn = originalTmuxLocalOutput
+		listProcessesFn = originalListProcesses
+		openFilePathsForPIDFn = originalOpenFilePaths
+	})
+
+	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {
+		switch {
+		case len(args) == 5 &&
+			args[0] == "display-message" &&
+			args[1] == "-p" &&
+			args[2] == "-t" &&
+			args[3] == "demo" &&
+			args[4] == "#{pane_pid}":
+			return []byte("220\n"), nil
+		case len(args) == 5 &&
+			args[0] == "display-message" &&
+			args[1] == "-p" &&
+			args[2] == "-t" &&
+			args[3] == "demo" &&
+			args[4] == "#{pane_current_path}":
+			return []byte("/repo/main\n"), nil
+		default:
+			return nil, errors.New("unexpected tmux args")
+		}
+	}
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 220, PPID: 1, Command: "codex resume --last"},
+		}, nil
+	}
+	openFilePathsForPIDFn = func(pid int) ([]string, error) {
+		require.Equal(t, 220, pid)
+		return []string{sessionLog}, nil
+	}
+
+	cwd, err := tmuxLocalActiveWorkdir("demo")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/tmux-root-codex-worktree", cwd)
+}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -456,6 +456,27 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	assert.Equal(t, "/tmp/remote-tmux-worktree-from-command", cwd)
 }
 
+func TestTmuxSSHActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(t *testing.T) {
+	sessionPath := "/home/user/.codex/sessions/2026/05/17/session.jsonl"
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t 'demo' '#{pane_pid}'":          []byte("230\n"),
+			"tmux display-message -p -t 'demo' '#{pane_current_path}'": []byte("/repo/main\n"),
+			sshListProcessesCmd:                       []byte(" 230 1 codex resume --last\n"),
+			fmt.Sprintf(sshOpenFilesCmdTemplate, 230): []byte(sessionPath + "\n"),
+			"cat " + shellQuotePath(sessionPath): []byte(
+				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					codexExecCommandRecord(t, "go test ./...", "/tmp/remote-root-codex-worktree"),
+			),
+		},
+	}
+
+	cwd, err := tmuxSSHActiveWorkdir(runner, "demo")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-root-codex-worktree", cwd)
+}
+
 func TestRemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 	const cwd = "/home/user/panemux"
 


### PR DESCRIPTION
## Summary
- treat the active tmux pane PID itself as an eligible interactive agent when it is `codex` or `claude`
- restore worktree-based git branch detection for `tmux` and `ssh_tmux` panes when Codex is the pane root process
- add regression tests for local tmux and ssh+tmux root-agent cases

## Test plan
- [x] `make build-frontend`
- [x] `make lint-go`
- [x] `make test-go`
