### PR TITLE
feat: link pane header repo name to repository page

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -473,6 +473,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 - If the agent exits, no longer has an eligible worktree, or the resolved worktree is not a sibling worktree of the pane's current repository, panemux falls back to the pane's own working directory immediately.
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.
+- If the resolved repository origin can be converted into a browser URL, the header shows the repository name as a link to that repository page.
 - If the resolved branch has a GitHub pull request, the header shows a PR link labeled `#<number>`.
 
 ## Operational Assumptions

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -474,7 +474,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.
 - If the resolved repository origin can be converted into a browser URL, the header shows the repository name as a link to that repository page.
-- For SCP-style SSH origins such as `git@alias:owner/repo.git`, panemux uses `~/.ssh/config` `Host` aliases to resolve the browser link hostname when a matching alias exists; otherwise it treats the SSH host token as the hostname directly.
+- For SCP-style SSH origins such as `git@alias:owner/repo.git`, panemux uses `~/.ssh/config` `Host` aliases to resolve both the browser link hostname and GitHub PR lookup repo host when a matching alias exists; otherwise it treats the SSH host token as the hostname directly.
 - If the resolved branch has a GitHub pull request, the header shows a PR link labeled `#<number>`.
 
 ## Operational Assumptions

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -474,6 +474,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.
 - If the resolved repository origin can be converted into a browser URL, the header shows the repository name as a link to that repository page.
+- For SCP-style SSH origins such as `git@alias:owner/repo.git`, panemux uses `~/.ssh/config` `Host` aliases to resolve the browser link hostname when a matching alias exists; otherwise it treats the SSH host token as the hostname directly.
 - If the resolved branch has a GitHub pull request, the header shows a PR link labeled `#<number>`.
 
 ## Operational Assumptions

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -85,6 +85,8 @@ From left to right, the header contains:
 
 The header background stays `#252526` with a `#333` bottom border so the new controls inherit the established terminal chrome instead of introducing a second visual language.
 
+When panemux can derive a repository page URL from the pane's Git origin, the repository name is rendered as an inline text link using the same visual treatment as the PR shortcut.
+
 The PR shortcut is rendered as an inline text link labeled `#<number>`. It does not use a pill, badge, or outlined capsule treatment. On hover, the link shifts to a slightly stronger blue and shows an underline so it reads like the rest of the header chrome instead of a separate button system.
 
 ### Split vs quick-add

--- a/frontend/src/components/PaneHeader.test.tsx
+++ b/frontend/src/components/PaneHeader.test.tsx
@@ -107,6 +107,7 @@ describe('PaneHeader VSCode button', () => {
         gitInfo={{
           is_git: true,
           repo: 'panemux',
+          repo_url: 'https://github.com/example/panemux',
           branch: 'feature/pane-pr-link',
           pr_number: 123,
           pr_url: 'https://github.com/example/panemux/pull/123',
@@ -128,6 +129,7 @@ describe('PaneHeader VSCode button', () => {
         gitInfo={{
           is_git: true,
           repo: 'panemux',
+          repo_url: 'https://github.com/example/panemux',
           branch: 'feature/pane-pr-link',
           pr_number: 123,
           pr_url: 'https://github.com/example/panemux/pull/123',
@@ -136,6 +138,63 @@ describe('PaneHeader VSCode button', () => {
     )
 
     const link = screen.getByRole('link', { name: '#123' })
+    fireEvent.mouseEnter(link)
+
+    expect(link).toHaveStyle({
+      textDecoration: 'underline',
+      textUnderlineOffset: '2px',
+    })
+  })
+
+  it('renders the repo name as a link when repo_url is present', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          repo: 'panemux',
+          repo_url: 'https://github.com/example/panemux',
+          branch: 'main',
+        }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'panemux' })
+    expect(link).toHaveAttribute('href', 'https://github.com/example/panemux')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('shows repo name as plain text when repo_url is absent', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          repo: 'panemux',
+          branch: 'main',
+        }}
+      />
+    )
+
+    expect(screen.queryByRole('link', { name: 'panemux' })).toBeNull()
+    expect(screen.getByText('panemux')).toBeInTheDocument()
+  })
+
+  it('shows an underline on repo link hover', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          repo: 'panemux',
+          repo_url: 'https://github.com/example/panemux',
+          branch: 'main',
+        }}
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'panemux' })
     fireEvent.mouseEnter(link)
 
     expect(link).toHaveStyle({

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -216,7 +216,15 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
       {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch) && (
         <span style={{ color: '#6e8a6e', fontSize: '11px', display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
-          {gitInfo.repo && <span>{gitInfo.repo}</span>}
+          {gitInfo.repo && (gitInfo.repo_url ? (
+            <InlineHeaderLink
+              href={gitInfo.repo_url}
+              title="Open repository"
+              label={gitInfo.repo}
+            />
+          ) : (
+            <span>{gitInfo.repo}</span>
+          ))}
           {gitInfo.repo && gitInfo.branch && <span style={{ color: '#4a6a4a' }}>{' '}⎇{' '}</span>}
           {gitInfo.branch && <span>{gitInfo.branch}</span>}
           {gitInfo.pr_url && gitInfo.pr_number && (

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -22,6 +22,7 @@ describe('GitInfoSchema', () => {
       is_git: true,
       branch: 'feature/pane-pr-link',
       repo: 'panemux',
+      repo_url: 'https://github.com/example/panemux',
       pr_number: 123,
       pr_url: 'https://github.com/example/panemux/pull/123',
     })

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -100,6 +100,7 @@ export const GitInfoSchema = z.object({
   is_git: z.boolean(),
   branch: z.string().optional(),
   repo: z.string().optional(),
+  repo_url: z.string().url().optional(),
   pr_number: z.number().int().positive().optional(),
   pr_url: z.string().url().optional(),
 })

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -710,6 +710,7 @@ type gitInfoResponse struct {
 	Branch   string `json:"branch,omitempty"`
 	PRURL    string `json:"pr_url,omitempty"`
 	Repo     string `json:"repo,omitempty"`
+	RepoURL  string `json:"repo_url,omitempty"`
 	PRNumber int    `json:"pr_number,omitempty"`
 	IsGit    bool   `json:"is_git"`
 }
@@ -753,6 +754,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		IsGit:    true,
 		Branch:   ctx.Branch,
 		Repo:     ctx.Repo,
+		RepoURL:  repoPageURLFromOriginURL(ctx.OriginURL),
 		PRURL:    prURL,
 		PRNumber: prNumber,
 	})
@@ -844,10 +846,19 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	}
 	branchOut = bytes.TrimSpace(branchOut)
 
+	originCmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	originCmd.Dir = safeCWD
+	originOut, err := originCmd.Output()
+	if err != nil {
+		originOut = nil
+	}
+	originOut = bytes.TrimSpace(originOut)
+
 	root := string(toplevelOut)
 	return session.GitContext{
 		Branch:    string(branchOut),
 		CommonDir: string(commonDirOut),
+		OriginURL: string(originOut),
 		Repo:      filepath.Base(root),
 		Root:      root,
 	}, nil
@@ -928,32 +939,50 @@ func (h *Handler) lookupPRInfo(sess session.Session, cwd string, gitCtx session.
 }
 
 func repoSpecFromOriginURL(origin string) string {
+	host, path := repoHostAndPathFromOriginURL(origin)
+	if host == "" || path == "" {
+		return ""
+	}
+	return host + "/" + path
+}
+
+func repoPageURLFromOriginURL(origin string) string {
+	host, path := repoHostAndPathFromOriginURL(origin)
+	if host == "" || path == "" {
+		return ""
+	}
+	return "https://" + host + "/" + path
+}
+
+func repoHostAndPathFromOriginURL(origin string) (string, string) {
 	trimmed := strings.TrimSpace(strings.TrimSuffix(origin, ".git"))
 	if trimmed == "" {
-		return ""
+		return "", ""
 	}
 	if strings.HasPrefix(trimmed, "git@") {
 		hostPath := strings.TrimPrefix(trimmed, "git@")
 		parts := strings.SplitN(hostPath, ":", 2)
 		if len(parts) != 2 {
-			return ""
+			return "", ""
 		}
-		return parts[0] + "/" + strings.TrimPrefix(parts[1], "/")
+		host := strings.TrimSpace(parts[0])
+		path := strings.TrimPrefix(strings.TrimSpace(parts[1]), "/")
+		if host == "" || path == "" {
+			return "", ""
+		}
+		return host, path
 	}
 
 	u, err := url.Parse(trimmed)
 	if err != nil || u.Host == "" {
-		return ""
+		return "", ""
 	}
 	host := u.Hostname()
-	if host == "" {
-		return ""
-	}
 	path := strings.TrimPrefix(u.Path, "/")
-	if path == "" {
-		return ""
+	if host == "" || path == "" {
+		return "", ""
 	}
-	return host + "/" + path
+	return host, path
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -913,7 +913,7 @@ func (h *Handler) lookupPRInfo(sess session.Session, cwd string, gitCtx session.
 		"--json",
 		"url,number",
 	)
-	if repoSpec := repoSpecFromOriginURL(gitCtx.OriginURL); repoSpec != "" {
+	if repoSpec := h.repoSpecFromOriginURL(gitCtx.OriginURL); repoSpec != "" {
 		cmd.Args = append(cmd.Args, "--repo", repoSpec)
 	} else if _, ok := sess.(session.GitContextGetter); ok {
 		// Remote SSH-backed sessions may point at repositories that do not exist
@@ -942,6 +942,17 @@ func repoSpecFromOriginURL(origin string) string {
 	host, path := repoHostAndPathFromOriginURL(origin)
 	if host == "" || path == "" {
 		return ""
+	}
+	return host + "/" + path
+}
+
+func (h *Handler) repoSpecFromOriginURL(origin string) string {
+	host, path, scpStyle := repoHostAndPathFromOriginURLDetailed(origin)
+	if host == "" || path == "" {
+		return ""
+	}
+	if scpStyle {
+		host = h.resolveSSHConfigHostAlias(host)
 	}
 	return host + "/" + path
 }

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -754,7 +754,7 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		IsGit:    true,
 		Branch:   ctx.Branch,
 		Repo:     ctx.Repo,
-		RepoURL:  repoPageURLFromOriginURL(ctx.OriginURL),
+		RepoURL:  h.repoPageURLFromOriginURL(ctx.OriginURL),
 		PRURL:    prURL,
 		PRNumber: prNumber,
 	})
@@ -954,35 +954,68 @@ func repoPageURLFromOriginURL(origin string) string {
 	return "https://" + host + "/" + path
 }
 
+func (h *Handler) repoPageURLFromOriginURL(origin string) string {
+	host, path, scpStyle := repoHostAndPathFromOriginURLDetailed(origin)
+	if host == "" || path == "" {
+		return ""
+	}
+	if scpStyle {
+		host = h.resolveSSHConfigHostAlias(host)
+	}
+	return "https://" + host + "/" + path
+}
+
+func (h *Handler) resolveSSHConfigHostAlias(host string) string {
+	hosts, err := sshconfig.ParseHosts(h.sshConfigPath)
+	if err != nil {
+		log.Printf("parse ssh config for repo URL alias resolution failed: %v", err)
+		return host
+	}
+	for _, candidate := range hosts {
+		if candidate.Name == host {
+			if candidate.Hostname != "" {
+				return candidate.Hostname
+			}
+			return host
+		}
+	}
+	return host
+}
+
 func repoHostAndPathFromOriginURL(origin string) (string, string) {
+	host, path, _ := repoHostAndPathFromOriginURLDetailed(origin)
+	return host, path
+}
+
+func repoHostAndPathFromOriginURLDetailed(origin string) (string, string, bool) {
 	trimmed := strings.TrimSpace(strings.TrimSuffix(origin, ".git"))
 	if trimmed == "" {
-		return "", ""
+		return "", "", false
 	}
 	if strings.HasPrefix(trimmed, "git@") {
 		hostPath := strings.TrimPrefix(trimmed, "git@")
 		parts := strings.SplitN(hostPath, ":", 2)
 		if len(parts) != 2 {
-			return "", ""
+			return "", "", false
 		}
 		host := strings.TrimSpace(parts[0])
 		path := strings.TrimPrefix(strings.TrimSpace(parts[1]), "/")
 		if host == "" || path == "" {
-			return "", ""
+			return "", "", false
 		}
-		return host, path
+		return host, path, true
 	}
 
 	u, err := url.Parse(trimmed)
 	if err != nil || u.Host == "" {
-		return "", ""
+		return "", "", false
 	}
 	host := u.Hostname()
 	path := strings.TrimPrefix(u.Path, "/")
 	if host == "" || path == "" {
-		return "", ""
+		return "", "", false
 	}
-	return host, path
+	return host, path, false
 }
 
 func writeValidationError(w http.ResponseWriter, msg string) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1939,6 +1939,11 @@ func TestRepoPageURLFromOriginURL(t *testing.T) {
 			want:   "https://git.example.com/team/panemux",
 		},
 		{
+			name:   "ssh url with explicit port",
+			origin: "ssh://git@git.example.com:2222/team/panemux.git",
+			want:   "https://git.example.com/team/panemux",
+		},
+		{
 			name:   "https with embedded credentials",
 			origin: credentialOrigin,
 			want:   "https://github.com/example/panemux",

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1889,6 +1889,28 @@ func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
 	assert.Zero(t, number)
 }
 
+func TestLookupPRInfo_RemoteSessionWithSSHConfigAliasOrigin_UsesResolvedRepoSpec(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
+	h.ghBinaryPath = writeFakeGHBinary(
+		t,
+		"#!/bin/sh\n"+
+			"if [ \"$6\" != \"--repo\" ] || [ \"$7\" != \"github.com/example/panemux\" ]; then\n"+
+			"  echo \"unexpected repo args: $6 $7\" >&2\n"+
+			"  exit 1\n"+
+			"fi\n"+
+			"echo '{\"url\":\"https://github.com/example/panemux/pull/999\",\"number\":999}'\n",
+	)
+
+	url, number := h.lookupPRInfo(&mockRemoteGitSession{}, "/home/demo/panemux", session.GitContext{
+		Branch:    "feature/alias-pr",
+		OriginURL: "git@github-work:example/panemux.git",
+	})
+
+	assert.Equal(t, "https://github.com/example/panemux/pull/999", url)
+	assert.Equal(t, 999, number)
+}
+
 func TestSanitizeGitExecDir_ValidAbsolutePath(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "repo")
 	require.NoError(t, os.MkdirAll(dir, 0755))
@@ -2011,6 +2033,15 @@ func TestHandlerRepoPageURLFromOriginURL_LeavesUnknownSCPHostUntouched(t *testin
 	got := h.repoPageURLFromOriginURL("git@source:example/panemux.git")
 
 	assert.Equal(t, "https://source/example/panemux", got)
+}
+
+func TestHandlerRepoSpecFromOriginURL_ResolvesSSHConfigAlias(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
+
+	got := h.repoSpecFromOriginURL("git@github-work:example/panemux.git")
+
+	assert.Equal(t, "github.com/example/panemux", got)
 }
 
 func TestSanitizeGitExecDir_RejectsRelativePath(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1418,6 +1418,7 @@ func initTempGitRepo(t *testing.T) string {
 		{"git", "-C", dir, "config", "user.email", "test@example.com"},
 		{"git", "-C", dir, "config", "user.name", "Test"},
 		{"git", "-C", dir, "config", "commit.gpgsign", "false"},
+		{"git", "-C", dir, "remote", "add", "origin", "git@github.com:example/panemux.git"},
 		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
 	}
 	for _, args := range cmds {
@@ -1526,6 +1527,7 @@ func TestGetGitInfo_IsGitRepo_ReturnsBranchAndRepo(t *testing.T) {
 	assert.True(t, resp.IsGit)
 	assert.Equal(t, "main", resp.Branch)
 	assert.NotEmpty(t, resp.Repo)
+	assert.Equal(t, "https://github.com/example/panemux", resp.RepoURL)
 }
 
 func TestGetGitInfo_IsGitRepo_WithLinkedPR_ReturnsPRInfo(t *testing.T) {
@@ -1561,6 +1563,7 @@ func TestGetGitInfo_IsGitRepo_WithLinkedPR_ReturnsPRInfo(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.True(t, resp.IsGit)
 	assert.Equal(t, "feature/pane-pr-link", resp.Branch)
+	assert.Equal(t, "https://github.com/example/panemux", resp.RepoURL)
 	assert.Equal(t, "https://github.com/example/panemux/pull/123", resp.PRURL)
 	assert.Equal(t, 123, resp.PRNumber)
 }
@@ -1763,6 +1766,7 @@ func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 	assert.True(t, resp.IsGit)
 	assert.Equal(t, "main", resp.Branch)
 	assert.Equal(t, "panemux", resp.Repo)
+	assert.Empty(t, resp.RepoURL)
 }
 
 func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T) {
@@ -1806,6 +1810,39 @@ func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T
 	assert.True(t, resp.IsGit)
 	assert.Equal(t, "feature/remote-worktree", resp.Branch)
 	assert.Equal(t, "panemux", resp.Repo)
+	assert.Empty(t, resp.RepoURL)
+}
+
+func TestGetGitInfo_RemoteGitContext_WithOrigin_ReturnsRepoURL(t *testing.T) {
+	const remoteRepo = "/home/demo/panemux"
+
+	mgr := session.NewManager()
+	mgr.Add(&mockRemoteGitSession{
+		mockSession: mockSession{id: "ssh-remote-origin", typ: session.TypeSSH},
+		cwd:         remoteRepo,
+		gitContexts: map[string]session.GitContext{
+			remoteRepo: {
+				Branch:    "main",
+				CommonDir: "/home/demo/panemux/.git",
+				OriginURL: "git@github.com:example/panemux.git",
+				Repo:      "panemux",
+				Root:      remoteRepo,
+			},
+		},
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote-origin/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "https://github.com/example/panemux", resp.RepoURL)
 }
 
 func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
@@ -1875,6 +1912,47 @@ func TestRepoSpecFromOriginURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, repoSpecFromOriginURL(tt.origin))
+		})
+	}
+}
+
+func TestRepoPageURLFromOriginURL(t *testing.T) {
+	credentialOrigin := "https://user:" + "placeholder" + "@github.com/example/panemux.git"
+	tests := []struct {
+		name   string
+		origin string
+		want   string
+	}{
+		{
+			name:   "scp style ssh",
+			origin: "git@github.com:example/panemux.git",
+			want:   "https://github.com/example/panemux",
+		},
+		{
+			name:   "https",
+			origin: "https://github.com/example/panemux.git",
+			want:   "https://github.com/example/panemux",
+		},
+		{
+			name:   "ssh url",
+			origin: "ssh://git@git.example.com/team/panemux.git",
+			want:   "https://git.example.com/team/panemux",
+		},
+		{
+			name:   "https with embedded credentials",
+			origin: credentialOrigin,
+			want:   "https://github.com/example/panemux",
+		},
+		{
+			name:   "invalid",
+			origin: "not-a-url",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, repoPageURLFromOriginURL(tt.origin))
 		})
 	}
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1845,6 +1845,39 @@ func TestGetGitInfo_RemoteGitContext_WithOrigin_ReturnsRepoURL(t *testing.T) {
 	assert.Equal(t, "https://github.com/example/panemux", resp.RepoURL)
 }
 
+func TestGetGitInfo_RemoteGitContext_WithSSHConfigAliasOrigin_ReturnsResolvedRepoURL(t *testing.T) {
+	const remoteRepo = "/home/demo/panemux"
+
+	mgr := session.NewManager()
+	mgr.Add(&mockRemoteGitSession{
+		mockSession: mockSession{id: "ssh-remote-alias-origin", typ: session.TypeSSH},
+		cwd:         remoteRepo,
+		gitContexts: map[string]session.GitContext{
+			remoteRepo: {
+				Branch:    "main",
+				CommonDir: "/home/demo/panemux/.git",
+				OriginURL: "git@github-work:example/panemux.git",
+				Repo:      "panemux",
+				Root:      remoteRepo,
+			},
+		},
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote-alias-origin/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "https://github.com/example/panemux", resp.RepoURL)
+}
+
 func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), session.NewManager())
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nexit 99\n")
@@ -1960,6 +1993,24 @@ func TestRepoPageURLFromOriginURL(t *testing.T) {
 			assert.Equal(t, tt.want, repoPageURLFromOriginURL(tt.origin))
 		})
 	}
+}
+
+func TestHandlerRepoPageURLFromOriginURL_ResolvesSSHConfigAlias(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
+
+	got := h.repoPageURLFromOriginURL("git@github-work:example/panemux.git")
+
+	assert.Equal(t, "https://github.com/example/panemux", got)
+}
+
+func TestHandlerRepoPageURLFromOriginURL_LeavesUnknownSCPHostUntouched(t *testing.T) {
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
+
+	got := h.repoPageURLFromOriginURL("git@source:example/panemux.git")
+
+	assert.Equal(t, "https://source/example/panemux", got)
 }
 
 func TestSanitizeGitExecDir_RejectsRelativePath(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `repo_url` to pane git info so the UI can open the repository page from header chrome
- resolve browser-safe repository URLs from local and remote git origins
- render the pane header repository name as an inline link and cover the new behavior in tests and docs

## Test Plan
- [x] make check
