### PR TITLE
fix: keep agent worktree git context after exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ This installs npm packages and downloads Go modules. Required once per environme
 ## Read This First
 
 1. Read [DEVELOPMENT.md](DEVELOPMENT.md) for build, test, branch, and PR workflow rules.
+   This includes the path-sanitization rule for tests, fixtures, PR bodies, PR comments, and review replies.
 2. Read [docs/overview.md](docs/overview.md) for the product purpose and current boundaries.
 3. Read [docs/architecture.md](docs/architecture.md) for implementation structure and security design.
 4. Read [docs/security.md](docs/security.md) before implementing changes that affect command execution, shell argument handling, SSH path handling, or `gosec` posture.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,7 +47,7 @@ make check
 
 ### Path sanitization
 
-- Do not record real local or remote directory paths from a developer machine or environment in tests, fixtures, docs, screenshots, PR bodies, review replies, or commit history.
+- Do not record real local or remote directory paths from a developer machine or environment in tests, fixtures, docs, screenshots, PR bodies, PR comments, review replies, or commit history.
 - Replace environment-specific paths with fake placeholders such as `/workspace/user/project`, `/tmp/sample-project`, or `/remote/home/demo`.
 - If a real path is used temporarily for investigation, remove it before committing and rewrite the branch history if that path already landed in a published commit on the PR branch.
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ Common uses:
 - **Move a pane** by dragging the handle in its header; drop it on a workspace edge to create a new outer split, or on another pane edge / divider to insert it there.
 - **Close a pane** from its header controls; the layout collapses automatically.
 - **Restart a pane** with the on-screen button if the underlying session exits.
-- **Open a linked PR** from the pane header when the current Git branch already has a GitHub pull request. For local panes, panemux can prefer the live worktree of an interactive `codex` or `claude` session, including resumed Codex sessions, and falls back to the pane's own working directory after the agent exits.
-- **Open VS Code** from supported panes using the pane header action. Like pane Git/PR metadata, this can prefer the live worktree of an interactive `codex` or `claude` session and falls back to the pane's own working directory after the agent exits.
+- **Open a linked PR** from the pane header when the current Git branch already has a GitHub pull request. For local panes, panemux can prefer the live worktree of an interactive `codex` or `claude` session, including resumed Codex sessions, and keeps the last valid sibling worktree pinned after the agent exits until a newer valid context is detected.
+- **Open VS Code** from supported panes using the pane header action. Like pane Git/PR metadata, this can prefer the live worktree of an interactive `codex` or `claude` session and keeps the last valid sibling worktree pinned after the agent exits until a newer valid context is detected.
 
 ### Notifications and attention prompts
 
@@ -124,7 +124,7 @@ Common uses:
 - `tmux` and `ssh_tmux` panes automatically create the target tmux session if it does not already exist.
 - Set `cwd` on `local`, `ssh`, or `ssh_tmux` panes when you want the shell to start in a specific directory.
 - In the pane settings dialog, `Working Directory` can be chosen from a browsable directory tree for both local and SSH-backed panes. Hidden directories are available through a toggle.
-- Pane headers resolve Git and PR metadata from the live working context, including interactive `codex` and `claude` worktrees for both local and SSH-backed panes. `tmux` and `ssh_tmux` use the currently active tmux pane only.
+- Pane headers resolve Git and PR metadata from the live working context, including interactive `codex` and `claude` worktrees for both local and SSH-backed panes. When a valid sibling worktree was detected recently, panemux keeps that worktree pinned after the agent exits until the pane moves to a different repository context. `tmux` and `ssh_tmux` use the currently active tmux pane only.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ Workspace-related endpoints:
 - `PUT /api/workspaces/{id}/layout` updates a specific workspace layout.
 - `GET/PUT /api/layout` remain as compatibility endpoints for the active workspace layout.
 
-`POST /api/sessions/{id}/open-vscode` launches VSCode pointed at the session's live working directory. Like `GET /api/sessions/{id}/git-info`, it may prefer the worktree of an active interactive `codex` or `claude` process when that worktree belongs to the same repository. For local sessions it runs `code <cwd>`; for SSH sessions it runs `code --remote ssh-remote+<connection> <cwd>`. The binary is located via `exec.LookPath("code")` with a macOS app-bundle fallback.
+`POST /api/sessions/{id}/open-vscode` launches VSCode pointed at the session's live working directory. Like `GET /api/sessions/{id}/git-info`, it may prefer the worktree of an active interactive `codex` or `claude` process when that worktree belongs to the same repository, and it keeps using the last valid sibling worktree after the agent exits until the pane changes repository context. For local sessions it runs `code <cwd>`; for SSH sessions it runs `code --remote ssh-remote+<connection> <cwd>`. The binary is located via `exec.LookPath("code")` with a macOS app-bundle fallback.
 
 Why REST here:
 
@@ -170,6 +170,12 @@ The override path is intentionally narrow:
 - local and local tmux sessions only consider descendants of the pane's own shell process or active tmux pane process
 - SSH sessions scan the remote process list on the current SSH connection, and SSH+tmux sessions restrict that scan to the active remote tmux pane's process tree
 - only worktrees that belong to the same Git common dir as the pane's base repository are accepted
+
+When a valid override worktree is accepted, the API layer caches that sibling worktree per pane
+session. Later requests reuse it when no active agent workdir is currently detectable, but only
+while the pane still resolves to the same Git common dir and a different worktree root. This keeps
+pane headers and editor-opening behavior stable after an agent exits without allowing stale
+cross-repository reuse.
 
 For interactive Codex sessions, all four session implementations (`local`, `ssh`, `tmux`, and `ssh_tmux`) may inspect the open Codex session log under `~/.codex/sessions/...jsonl` when the Codex process has that file open. Panemux currently prefers the latest `exec_command.arguments.workdir` recorded in `response_item` / `function_call` log entries, then falls back to `turn_context.cwd`, then `session_meta.cwd`.
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -145,6 +145,12 @@ For pane-header Git status, local and local tmux panes inspect the local filesys
 and `ssh_tmux` panes run the equivalent Git inspection on the remote host. This allows headers to
 show branch/repository info even when the repository exists only on the SSH target.
 
+When panemux detects that an interactive `codex` or `claude` session is operating in a sibling Git
+worktree for the same repository, pane-header Git/PR metadata and the VS Code open action prefer
+that worktree. After the agent exits, panemux keeps the last valid sibling worktree pinned for that
+pane session until a newer valid sibling worktree is detected or the pane itself changes to a
+different repository.
+
 Remote Git inspection currently depends on `git rev-parse --path-format=absolute --git-common-dir`
 on the SSH target, which requires Git 2.31 or newer. Older remote Git versions degrade to "no git
 info" in the pane header for SSH-backed panes.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -776,9 +776,11 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
+	logScope := h.gitInfoLogScope(sess)
+
 	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
-		log.Printf("git info base context lookup failed: %v", err)
+		log.Printf("%s base context lookup failed: %v", logScope, err)
 		h.clearPreferredCWD(sess.ID())
 		return cwd
 	}
@@ -791,20 +793,21 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	candidate, err := activeGetter.GetActiveWorkdir()
 	if err != nil || candidate == "" {
 		if err != nil {
-			log.Printf("git info active workdir lookup failed: %v", err)
+			log.Printf("%s active workdir lookup failed: %v", logScope, err)
 		}
 		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 
 	ctx, err := h.inspectGitContextForSession(sess, candidate)
 	if err != nil {
-		log.Printf("git info active workdir candidate context lookup failed: %v", err)
+		log.Printf("%s active workdir candidate context lookup failed: %v", logScope, err)
 		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 	if ctx.CommonDir == baseCtx.CommonDir && ctx.Root != baseCtx.Root {
 		h.rememberPreferredCWD(sess.ID(), candidate, ctx)
 		log.Printf(
-			"git info selected active workdir branch transition %q -> %q",
+			"%s selected active workdir branch transition %q -> %q",
+			logScope,
 			baseCtx.Branch,
 			ctx.Branch,
 		)
@@ -813,7 +816,8 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 
 	h.clearPreferredCWD(sess.ID())
 	log.Printf(
-		"git info ignored active workdir candidate (same_root=%t same_common_dir=%t)",
+		"%s ignored active workdir candidate (same_root=%t same_common_dir=%t)",
+		logScope,
 		ctx.Root == baseCtx.Root,
 		ctx.CommonDir == baseCtx.CommonDir,
 	)
@@ -852,6 +856,10 @@ func (h *Handler) clearPreferredCWD(sessionID string) {
 	defer h.preferredCWDMu.Unlock()
 
 	delete(h.preferredCWDBySession, sessionID)
+}
+
+func (h *Handler) gitInfoLogScope(sess session.Session) string {
+	return fmt.Sprintf("git info pane=%q type=%q", sess.ID(), sess.Type())
 }
 
 func (h *Handler) inspectGitContextForSession(sess session.Session, cwd string) (session.GitContext, error) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -562,7 +562,7 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cwd = h.resolveValidatedPreferredCWD(sess, cwd)
+	cwd, _ = h.resolveValidatedPreferredCWD(sess, cwd)
 
 	if !h.validateVSCodeCWD(w, sess, cwd) {
 		return
@@ -760,13 +760,12 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetCWD := h.resolveValidatedPreferredCWD(sess, cwd)
-	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
-	if err != nil {
+	targetCWD, ctx := h.resolveValidatedPreferredCWD(sess, cwd)
+	if ctx == nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
 	}
-	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, ctx)
+	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, *ctx)
 
 	writeJSON(w, gitInfoResponse{
 		IsGit:    true,
@@ -827,16 +826,25 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	return cwd
 }
 
-func (h *Handler) resolveValidatedPreferredCWD(sess session.Session, cwd string) string {
+func (h *Handler) resolveValidatedPreferredCWD(sess session.Session, cwd string) (string, *session.GitContext) {
 	targetCWD := h.resolvePreferredCWD(sess, cwd)
 	if targetCWD == cwd {
-		return cwd
+		ctx, err := h.inspectGitContextForSession(sess, cwd)
+		if err != nil {
+			return cwd, nil
+		}
+		return cwd, &ctx
 	}
-	if _, err := h.inspectGitContextForSession(sess, targetCWD); err == nil {
-		return targetCWD
+	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
+	if err == nil {
+		return targetCWD, &ctx
 	}
 	h.clearPreferredCWD(sess.ID())
-	return cwd
+	ctx, err = h.inspectGitContextForSession(sess, cwd)
+	if err != nil {
+		return cwd, nil
+	}
+	return cwd, &ctx
 }
 
 func (h *Handler) rememberPreferredCWD(sessionID, cwd string, ctx session.GitContext) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -242,6 +242,7 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, pane := range panesInLayout(workspace.Layout) {
 		_ = h.manager.Remove(pane.ID)
+		h.clearPreferredCWD(pane.ID)
 	}
 	writeJSON(w, h.cfg.WorkspacesView())
 }
@@ -377,6 +378,7 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
+	h.clearPreferredCWD(id)
 	h.cfg.RemovePaneFromLayout(id)
 	if err := h.cfg.SaveLayout(h.cfg.Layout); err != nil {
 		http.Error(w, "failed to save layout", http.StatusInternalServerError)
@@ -402,6 +404,7 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.manager.Remove(id) //nolint:errcheck // ok if already gone
+	h.clearPreferredCWD(id)
 
 	sess, err := h.createSession(found, h.cfg.SSHConnections)
 	if err != nil {
@@ -760,8 +763,15 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 	targetCWD := h.resolvePreferredCWD(sess, cwd)
 	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
 	if err != nil {
-		writeJSON(w, gitInfoResponse{IsGit: false})
-		return
+		if targetCWD != cwd {
+			h.clearPreferredCWD(sess.ID())
+			targetCWD = cwd
+			ctx, err = h.inspectGitContextForSession(sess, targetCWD)
+		}
+		if err != nil {
+			writeJSON(w, gitInfoResponse{IsGit: false})
+			return
+		}
 	}
 	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, ctx)
 
@@ -781,7 +791,6 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
 		log.Printf("%s base context lookup failed: %v", logScope, err)
-		h.clearPreferredCWD(sess.ID())
 		return cwd
 	}
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -562,7 +562,7 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cwd = h.resolvePreferredCWD(sess, cwd)
+	cwd = h.resolveValidatedPreferredCWD(sess, cwd)
 
 	if !h.validateVSCodeCWD(w, sess, cwd) {
 		return
@@ -760,18 +760,11 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetCWD := h.resolvePreferredCWD(sess, cwd)
+	targetCWD := h.resolveValidatedPreferredCWD(sess, cwd)
 	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
 	if err != nil {
-		if targetCWD != cwd {
-			h.clearPreferredCWD(sess.ID())
-			targetCWD = cwd
-			ctx, err = h.inspectGitContextForSession(sess, targetCWD)
-		}
-		if err != nil {
-			writeJSON(w, gitInfoResponse{IsGit: false})
-			return
-		}
+		writeJSON(w, gitInfoResponse{IsGit: false})
+		return
 	}
 	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, ctx)
 
@@ -831,6 +824,18 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 		ctx.CommonDir == baseCtx.CommonDir,
 	)
 
+	return cwd
+}
+
+func (h *Handler) resolveValidatedPreferredCWD(sess session.Session, cwd string) string {
+	targetCWD := h.resolvePreferredCWD(sess, cwd)
+	if targetCWD == cwd {
+		return cwd
+	}
+	if _, err := h.inspectGitContextForSession(sess, targetCWD); err == nil {
+		return targetCWD
+	}
+	h.clearPreferredCWD(sess.ID())
 	return cwd
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -43,6 +44,14 @@ type Handler struct {
 	listLocalDirectoriesFn  func(path string, showHidden bool) (directoryBrowserResponse, error)
 	listRemoteDirectoriesFn func(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error)
 	readDirFn               func(name string) ([]os.DirEntry, error)
+	preferredCWDMu          sync.Mutex
+	preferredCWDBySession   map[string]preferredCWDState
+}
+
+type preferredCWDState struct {
+	CWD       string
+	CommonDir string
+	Root      string
 }
 
 var gitExistsFn = func() error {
@@ -106,7 +115,12 @@ var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
 func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
-	h := &Handler{cfg: cfg, manager: manager, sshConfigPath: sshconfig.DefaultPath()}
+	h := &Handler{
+		cfg:                   cfg,
+		manager:               manager,
+		sshConfigPath:         sshconfig.DefaultPath(),
+		preferredCWDBySession: make(map[string]preferredCWDState),
+	}
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
 	h.detectRemoteShellFn = session.DetectRemoteShell
@@ -521,7 +535,8 @@ type openVSCodeResponse struct {
 
 // PostOpenVSCode opens VSCode pointed at the session's current working directory.
 // When an interactive Codex or Claude agent is actively working in a sibling git
-// worktree for the same repository, panemux prefers that worktree instead.
+// worktree for the same repository, panemux prefers that worktree instead and
+// keeps the last valid sibling worktree pinned until the pane changes repo context.
 // For local sessions it runs: code <cwd>
 // For SSH sessions it runs: code --remote ssh-remote+<connection> <cwd>
 func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
@@ -764,12 +779,13 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
 		log.Printf("git info base context lookup failed: %v", err)
+		h.clearPreferredCWD(sess.ID())
 		return cwd
 	}
 
 	activeGetter, ok := sess.(session.ActiveWorkdirGetter)
 	if !ok {
-		return cwd
+		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 
 	candidate, err := activeGetter.GetActiveWorkdir()
@@ -777,15 +793,16 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 		if err != nil {
 			log.Printf("git info active workdir lookup failed: %v", err)
 		}
-		return cwd
+		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 
 	ctx, err := h.inspectGitContextForSession(sess, candidate)
 	if err != nil {
 		log.Printf("git info active workdir candidate context lookup failed: %v", err)
-		return cwd
+		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 	if ctx.CommonDir == baseCtx.CommonDir && ctx.Root != baseCtx.Root {
+		h.rememberPreferredCWD(sess.ID(), candidate, ctx)
 		log.Printf(
 			"git info selected active workdir branch transition %q -> %q",
 			baseCtx.Branch,
@@ -794,6 +811,7 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 		return candidate
 	}
 
+	h.clearPreferredCWD(sess.ID())
 	log.Printf(
 		"git info ignored active workdir candidate (same_root=%t same_common_dir=%t)",
 		ctx.Root == baseCtx.Root,
@@ -801,6 +819,39 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 	)
 
 	return cwd
+}
+
+func (h *Handler) rememberPreferredCWD(sessionID, cwd string, ctx session.GitContext) {
+	h.preferredCWDMu.Lock()
+	defer h.preferredCWDMu.Unlock()
+
+	h.preferredCWDBySession[sessionID] = preferredCWDState{
+		CWD:       cwd,
+		CommonDir: ctx.CommonDir,
+		Root:      ctx.Root,
+	}
+}
+
+func (h *Handler) recallPreferredCWD(sessionID, cwd string, baseCtx session.GitContext) string {
+	h.preferredCWDMu.Lock()
+	defer h.preferredCWDMu.Unlock()
+
+	state, ok := h.preferredCWDBySession[sessionID]
+	if !ok {
+		return cwd
+	}
+	if state.CommonDir != baseCtx.CommonDir || state.Root == baseCtx.Root || state.CWD == "" {
+		delete(h.preferredCWDBySession, sessionID)
+		return cwd
+	}
+	return state.CWD
+}
+
+func (h *Handler) clearPreferredCWD(sessionID string) {
+	h.preferredCWDMu.Lock()
+	defer h.preferredCWDMu.Unlock()
+
+	delete(h.preferredCWDBySession, sessionID)
 }
 
 func (h *Handler) inspectGitContextForSession(sess session.Session, cwd string) (session.GitContext, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1254,6 +1254,31 @@ func TestPostOpenVSCode_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 	assert.Equal(t, repoDir, resp.Cwd)
 }
 
+func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
+
+	sess := &mockCWDSession{
+		mockSession:   mockSession{id: "local-sticky", typ: session.TypeLocal},
+		activeWorkdir: worktreeDir,
+		cwd:           repoDir,
+	}
+
+	mgr := session.NewManager()
+	mgr.Add(sess)
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.codeBinaryPath = "/bin/echo"
+	r := setupRouterWithVSCode(h)
+
+	resp := postOpenVSCodeOKWithRouter(t, r, "local-sticky")
+	assert.Equal(t, worktreeDir, resp.Cwd)
+
+	sess.activeWorkdir = ""
+
+	resp = postOpenVSCodeOKWithRouter(t, r, "local-sticky")
+	assert.Equal(t, worktreeDir, resp.Cwd)
+}
+
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
 	t.Helper()
 
@@ -1262,6 +1287,12 @@ func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeR
 	h := NewHandler(defaultTestConfig(), mgr)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
+
+	return postOpenVSCodeOKWithRouter(t, r, id)
+}
+
+func postOpenVSCodeOKWithRouter(t *testing.T, r *chi.Mux, id string) openVSCodeResponse {
+	t.Helper()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/"+id+"/open-vscode", nil)
@@ -1711,6 +1742,143 @@ func TestGetGitInfo_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.True(t, resp.IsGit)
 	assert.Equal(t, "main", resp.Branch)
+}
+
+func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeDir := addTempGitWorktree(t, repoDir, "feature/worktree-pr")
+
+	sess := &mockCWDSession{
+		mockSession:   mockSession{id: "local-sticky", typ: session.TypeLocal},
+		activeWorkdir: worktreeDir,
+		cwd:           repoDir,
+	}
+	mgr := session.NewManager()
+	mgr.Add(sess)
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.ghBinaryPath = writeFakeGHBinary(
+		t,
+		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/999\",\"number\":999}'\n",
+	)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-sticky/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	sess.activeWorkdir = ""
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-sticky/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "feature/worktree-pr", resp.Branch)
+	assert.Equal(t, "https://github.com/example/panemux/pull/999", resp.PRURL)
+	assert.Equal(t, 999, resp.PRNumber)
+}
+
+func TestResolvePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) {
+	baseRepo := "/repo/base"
+	worktreeDir := "/repo/base-worktree"
+	otherRepo := "/repo/other"
+
+	sess := &mockRemoteGitSession{
+		mockSession:   mockSession{id: "remote-sticky", typ: session.TypeSSH},
+		activeWorkdir: worktreeDir,
+		cwd:           baseRepo,
+		gitContexts: map[string]session.GitContext{
+			baseRepo: {
+				Branch:    "main",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      baseRepo,
+			},
+			worktreeDir: {
+				Branch:    "feature/worktree",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      worktreeDir,
+			},
+			otherRepo: {
+				Branch:    "main",
+				CommonDir: "/repo/other/.git",
+				Repo:      "other",
+				Root:      otherRepo,
+			},
+		},
+	}
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	assert.Equal(t, worktreeDir, h.resolvePreferredCWD(sess, sess.cwd))
+
+	sess.activeWorkdir = ""
+	sess.cwd = otherRepo
+
+	assert.Equal(t, otherRepo, h.resolvePreferredCWD(sess, sess.cwd))
+}
+
+func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {
+	const (
+		baseRepo     = "/home/demo/panemux"
+		worktreeRepo = "/home/demo/panemux-worktree"
+	)
+
+	sess := &mockRemoteGitSession{
+		mockSession:   mockSession{id: "ssh-sticky", typ: session.TypeSSH},
+		activeWorkdir: worktreeRepo,
+		cwd:           baseRepo,
+		gitContexts: map[string]session.GitContext{
+			baseRepo: {
+				Branch:    "main",
+				CommonDir: "/home/demo/panemux/.git",
+				OriginURL: "git@github.com:example/panemux.git",
+				Repo:      "panemux",
+				Root:      baseRepo,
+			},
+			worktreeRepo: {
+				Branch:    "feature/remote-worktree",
+				CommonDir: "/home/demo/panemux/.git",
+				OriginURL: "git@github.com:example/panemux.git",
+				Repo:      "panemux",
+				Root:      worktreeRepo,
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(sess)
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.ghBinaryPath = writeFakeGHBinary(
+		t,
+		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/654\",\"number\":654}'\n",
+	)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-sticky/git-info", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	sess.activeWorkdir = ""
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-sticky/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "feature/remote-worktree", resp.Branch)
+	assert.Equal(t, "https://github.com/example/panemux/pull/654", resp.PRURL)
+	assert.Equal(t, 654, resp.PRNumber)
 }
 
 func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1395,6 +1395,34 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestResolveValidatedPreferredCWD_ReusesInspectedContext(t *testing.T) {
+	sess := &mockRemoteGitSession{
+		mockSession:   mockSession{id: "pane-ctx", typ: session.TypeSSH},
+		activeWorkdir: "/repo/base-worktree",
+		cwd:           "/repo/base",
+		gitContexts: map[string]session.GitContext{
+			"/repo/base": {
+				Branch:    "main",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      "/repo/base",
+			},
+			"/repo/base-worktree": {
+				Branch:    "feature/worktree",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      "/repo/base-worktree",
+			},
+		},
+	}
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	cwd, ctx := h.resolveValidatedPreferredCWD(sess, sess.cwd)
+	require.NotNil(t, ctx)
+	assert.Equal(t, "/repo/base-worktree", cwd)
+	assert.Equal(t, "feature/worktree", ctx.Branch)
+}
+
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
 	t.Helper()
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1358,6 +1358,43 @@ func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
 	assert.Equal(t, worktreeDir, resp.Cwd)
 }
 
+func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
+
+	sess := &mockCWDSession{
+		mockSession:   mockSession{id: "local-open-stale", typ: session.TypeLocal},
+		activeWorkdir: worktreeDir,
+		cwd:           repoDir,
+	}
+
+	mgr := session.NewManager()
+	mgr.Add(sess)
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.codeBinaryPath = "/bin/echo"
+	r := setupRouterWithVSCode(h)
+
+	resp := postOpenVSCodeOKWithRouter(t, r, "local-open-stale")
+	assert.Equal(t, worktreeDir, resp.Cwd)
+
+	sess.activeWorkdir = ""
+	out, err := exec.Command( //nolint:gosec // trusted test args
+		"git",
+		"-C",
+		repoDir,
+		"worktree",
+		"remove",
+		worktreeDir,
+		"--force",
+	).CombinedOutput()
+	require.NoError(t, err, "git worktree remove failed: %s", string(out))
+
+	resp = postOpenVSCodeOKWithRouter(t, r, "local-open-stale")
+	assert.Equal(t, repoDir, resp.Cwd)
+	_, ok := h.preferredCWDBySession["local-open-stale"]
+	assert.False(t, ok)
+}
+
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
 	t.Helper()
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -434,6 +434,30 @@ func TestDeleteWorkspace_RemovesWorkspaceSessionsAndPersists(t *testing.T) {
 	require.Len(t, loaded.Workspaces.Items, 1)
 }
 
+func TestDeleteWorkspace_ClearsPreferredCWDForRemovedPanes(t *testing.T) {
+	cfg, _ := loadWorkspaceTestConfigFromFile(t)
+	require.True(t, cfg.SetActiveWorkspace("two"))
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("one-main"))
+	mgr.Add(newMockSession("two-main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.preferredCWDBySession["two-main"] = preferredCWDState{
+		CWD:       "/tmp/worktree",
+		CommonDir: "/repo/.git",
+		Root:      "/tmp/worktree",
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/two", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, ok := h.preferredCWDBySession["two-main"]
+	assert.False(t, ok)
+}
+
 func TestPutWorkspace_RenamesWorkspaceAndPersists(t *testing.T) {
 	cfg, path := loadWorkspaceTestConfigFromFile(t)
 	h := NewHandler(cfg, session.NewManager())
@@ -767,6 +791,39 @@ func TestRestartSession_Found_200(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.preferredCWDBySession["main"] = preferredCWDState{
+		CWD:       "/tmp/worktree",
+		CommonDir: "/repo/.git",
+		Root:      "/tmp/worktree",
+	}
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		return newMockSession(pane.ID), nil
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, ok := h.preferredCWDBySession["main"]
+	assert.False(t, ok)
+}
+
 func TestRestartSession_NotFound_404(t *testing.T) {
 	r := setupRouter(defaultTestConfig(), session.NewManager())
 	rec := httptest.NewRecorder()
@@ -795,6 +852,27 @@ func TestDeleteSession_RemovesSessionAndSaves(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	_, ok := mgr.Get("s1")
+	assert.False(t, ok)
+}
+
+func TestDeleteSession_ClearsPreferredCWD(t *testing.T) {
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("s1"))
+	cfg := defaultTestConfig()
+	h := NewHandler(cfg, mgr)
+	h.preferredCWDBySession["s1"] = preferredCWDState{
+		CWD:       "/tmp/worktree",
+		CommonDir: "/repo/.git",
+		Root:      "/tmp/worktree",
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/s1", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, ok := h.preferredCWDBySession["s1"]
 	assert.False(t, ok)
 }
 
@@ -1783,6 +1861,51 @@ func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
 	assert.Equal(t, "feature/worktree-pr", resp.Branch)
 	assert.Equal(t, "https://github.com/example/panemux/pull/999", resp.PRURL)
 	assert.Equal(t, 999, resp.PRNumber)
+}
+
+func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeDir := addTempGitWorktree(t, repoDir, "feature/worktree-pr")
+
+	sess := &mockCWDSession{
+		mockSession:   mockSession{id: "local-stale", typ: session.TypeLocal},
+		activeWorkdir: worktreeDir,
+		cwd:           repoDir,
+	}
+	mgr := session.NewManager()
+	mgr.Add(sess)
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-stale/git-info", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	sess.activeWorkdir = ""
+	out, err := exec.Command( //nolint:gosec // trusted test args
+		"git",
+		"-C",
+		repoDir,
+		"worktree",
+		"remove",
+		worktreeDir,
+		"--force",
+	).CombinedOutput()
+	require.NoError(t, err, "git worktree remove failed: %s", string(out))
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-stale/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "main", resp.Branch)
+	_, ok := h.preferredCWDBySession["local-stale"]
+	assert.False(t, ok)
 }
 
 func TestResolvePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1822,6 +1823,42 @@ func TestResolvePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) 
 	sess.cwd = otherRepo
 
 	assert.Equal(t, otherRepo, h.resolvePreferredCWD(sess, sess.cwd))
+}
+
+func TestResolvePreferredCWD_LogsPaneIdentity(t *testing.T) {
+	sess := &mockRemoteGitSession{
+		mockSession:   mockSession{id: "pane-123", typ: session.TypeSSHTmux},
+		activeWorkdir: "/repo/base-worktree",
+		cwd:           "/repo/base",
+		gitContexts: map[string]session.GitContext{
+			"/repo/base": {
+				Branch:    "main",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      "/repo/base",
+			},
+			"/repo/base-worktree": {
+				Branch:    "feature/worktree",
+				CommonDir: "/repo/.git",
+				Repo:      "base",
+				Root:      "/repo/base-worktree",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+	assert.Equal(t, "/repo/base-worktree", h.resolvePreferredCWD(sess, sess.cwd))
+	assert.Contains(t, buf.String(), `git info pane="pane-123" type="ssh_tmux" selected active workdir`)
 }
 
 func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -25,11 +25,13 @@ var listProcessesFn = listProcesses
 var getPIDCWDFn = getPIDCWD
 var openFilePathsForPIDFn = openFilePathsForPID
 var userHomeDirFn = os.UserHomeDir
+var readFileFn = os.ReadFile
 
 // validShellPath matches a valid absolute shell path.
 // Only alphanumeric characters, dots, underscores, hyphens, and slashes are permitted.
 // This character allowlist is the sanitizer CodeQL requires for go/command-injection.
 var validShellPath = regexp.MustCompile(`^(/[a-zA-Z0-9._\-/]+)$`)
+var claudeBashCDPattern = regexp.MustCompile(`(?:^|&&)\s*cd\s+((?:"[^"]+"|'[^']+'|[^&|;]+))\s*&&`)
 
 // LocalSession is a local PTY-based terminal session.
 type LocalSession struct {
@@ -408,9 +410,9 @@ func findClaudeSessionMeta(homeDir string, agentPID int) (*claudeSessionMeta, er
 		}
 
 		path := filepath.Join(sessionsDir, entry.Name())
-		data, err := os.ReadFile(path)
+		data, err := readFileFn(path)
 		if err != nil {
-			return nil, fmt.Errorf("read claude session metadata %q: %w", path, err)
+			continue
 		}
 
 		var meta claudeSessionMeta
@@ -547,7 +549,7 @@ func processIDArg(pid int) (string, error) {
 }
 
 func readCodexSessionCWD(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	data, err := readFileFn(path)
 	if err != nil {
 		return "", fmt.Errorf("read codex session log %q: %w", path, err)
 	}
@@ -651,7 +653,7 @@ func claudeProjectDirName(cwd string) string {
 }
 
 func readClaudeProjectCWD(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	data, err := readFileFn(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", nil
@@ -708,14 +710,18 @@ func claudeRecordPath(line []byte) string {
 }
 
 func latestClaudeTrackedPath(backups map[string]json.RawMessage) string {
-	latest := ""
+	paths := make([]string, 0, len(backups))
 	for path := range backups {
 		if isClaudeAuxiliaryPath(path) {
 			continue
 		}
-		latest = path
+		paths = append(paths, path)
 	}
-	return latest
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		return ""
+	}
+	return paths[len(paths)-1]
 }
 
 func latestClaudeToolPath(content []json.RawMessage) string {
@@ -772,7 +778,7 @@ func isClaudeAuxiliaryPath(path string) bool {
 }
 
 func claudeBashCommandDir(command string) string {
-	matches := regexp.MustCompile(`(?:^|&&)\s*cd\s+((?:"[^"]+"|'[^']+'|[^&|;]+))\s*&&`).FindStringSubmatch(command)
+	matches := claudeBashCDPattern.FindStringSubmatch(command)
 	if len(matches) < 2 {
 		return ""
 	}

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -24,6 +24,7 @@ import (
 var listProcessesFn = listProcesses
 var getPIDCWDFn = getPIDCWD
 var openFilePathsForPIDFn = openFilePathsForPID
+var userHomeDirFn = os.UserHomeDir
 
 // validShellPath matches a valid absolute shell path.
 // Only alphanumeric characters, dots, underscores, hyphens, and slashes are permitted.
@@ -297,7 +298,7 @@ func descendantPIDs(processes []processInfo, rootPID int) []int {
 }
 
 func resolveInteractiveAgentWorkdir(processes []processInfo, agentPID int, baseCWD string) (string, error) {
-	if sessionCWD, err := codexSessionCWD(processes, agentPID); err == nil && sessionCWD != "" {
+	if sessionCWD, err := interactiveAgentSessionCWD(processes, agentPID); err == nil && sessionCWD != "" {
 		return sessionCWD, nil
 	}
 
@@ -327,6 +328,21 @@ func resolveInteractiveAgentWorkdir(processes []processInfo, agentPID int, baseC
 	return "", nil
 }
 
+func interactiveAgentSessionCWD(processes []processInfo, agentPID int) (string, error) {
+	proc, ok := processByPID(processes, agentPID)
+	if !ok {
+		return "", nil
+	}
+	switch {
+	case isCodexCommand(proc.Command):
+		return codexSessionCWD(processes, agentPID)
+	case isClaudeCommand(proc.Command):
+		return claudeSessionCWD(agentPID)
+	default:
+		return "", nil
+	}
+}
+
 func codexSessionCWD(processes []processInfo, agentPID int) (string, error) {
 	proc, ok := processByPID(processes, agentPID)
 	if !ok || !isCodexCommand(proc.Command) {
@@ -344,6 +360,69 @@ func codexSessionCWD(processes []processInfo, agentPID int) (string, error) {
 	}
 
 	return readCodexSessionCWD(sessionPath)
+}
+
+type claudeSessionMeta struct {
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+	PID       int    `json:"pid"`
+}
+
+func claudeSessionCWD(agentPID int) (string, error) {
+	homeDir, err := userHomeDirFn()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir for claude session: %w", err)
+	}
+
+	sessionMeta, err := findClaudeSessionMeta(homeDir, agentPID)
+	if err != nil {
+		return "", err
+	}
+	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
+		return "", nil
+	}
+
+	projectPath := filepath.Join(
+		homeDir,
+		".claude",
+		"projects",
+		claudeProjectDirName(sessionMeta.CWD),
+		sessionMeta.SessionID+".jsonl",
+	)
+	return readClaudeProjectCWD(projectPath)
+}
+
+func findClaudeSessionMeta(homeDir string, agentPID int) (*claudeSessionMeta, error) {
+	sessionsDir := filepath.Join(homeDir, ".claude", "sessions")
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read claude sessions dir %q: %w", sessionsDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		path := filepath.Join(sessionsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read claude session metadata %q: %w", path, err)
+		}
+
+		var meta claudeSessionMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		if meta.PID == agentPID {
+			return &meta, nil
+		}
+	}
+
+	return nil, nil
 }
 
 func processByPID(processes []processInfo, pid int) (processInfo, bool) {
@@ -375,6 +454,11 @@ func isInteractiveAgentCommand(command string) bool {
 func isCodexCommand(command string) bool {
 	fields := strings.Fields(command)
 	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == "codex"
+}
+
+func isClaudeCommand(command string) bool {
+	fields := strings.Fields(command)
+	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == "claude"
 }
 
 func containsToken(tokens []string, target string) bool {
@@ -560,6 +644,139 @@ func parseExecCommandWorkdir(raw json.RawMessage) string {
 		return ""
 	}
 	return args.Workdir
+}
+
+func claudeProjectDirName(cwd string) string {
+	return strings.ReplaceAll(filepath.Clean(cwd), string(os.PathSeparator), "-")
+}
+
+func readClaudeProjectCWD(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read claude transcript %q: %w", path, err)
+	}
+	return parseClaudeProjectCWD(data)
+}
+
+func parseClaudeProjectCWD(data []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	var latestPath string
+	for scanner.Scan() {
+		if candidate := claudeRecordPath(scanner.Bytes()); candidate != "" {
+			latestPath = candidate
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan claude transcript: %w", err)
+	}
+	if latestPath == "" {
+		return "", nil
+	}
+	if info, err := os.Stat(latestPath); err == nil && info.IsDir() {
+		return latestPath, nil
+	}
+	return filepath.Dir(latestPath), nil
+}
+
+type claudeProjectRecord struct {
+	Type     string `json:"type"`
+	Snapshot struct {
+		TrackedFileBackups map[string]json.RawMessage `json:"trackedFileBackups"`
+	} `json:"snapshot"`
+	Message struct {
+		Content []json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+func claudeRecordPath(line []byte) string {
+	var rec claudeProjectRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return ""
+	}
+
+	switch rec.Type {
+	case "file-history-snapshot":
+		return latestClaudeTrackedPath(rec.Snapshot.TrackedFileBackups)
+	case "assistant":
+		return latestClaudeToolPath(rec.Message.Content)
+	default:
+		return ""
+	}
+}
+
+func latestClaudeTrackedPath(backups map[string]json.RawMessage) string {
+	latest := ""
+	for path := range backups {
+		if isClaudeAuxiliaryPath(path) {
+			continue
+		}
+		latest = path
+	}
+	return latest
+}
+
+func latestClaudeToolPath(content []json.RawMessage) string {
+	latest := ""
+	for _, item := range content {
+		if path := claudeToolPath(item); path != "" {
+			latest = path
+		}
+	}
+	return latest
+}
+
+func claudeToolPath(raw json.RawMessage) string {
+	type toolUseContent struct {
+		Type  string          `json:"type"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	}
+	type fileInput struct {
+		FilePath string `json:"file_path"`
+	}
+	type bashInput struct {
+		Command string `json:"command"`
+	}
+
+	var item toolUseContent
+	if err := json.Unmarshal(raw, &item); err != nil || item.Type != "tool_use" {
+		return ""
+	}
+
+	switch item.Name {
+	case "Read", "Edit", "Write", "MultiEdit", "NotebookEdit":
+		var input fileInput
+		if err := json.Unmarshal(item.Input, &input); err != nil {
+			return ""
+		}
+		if input.FilePath == "" || isClaudeAuxiliaryPath(input.FilePath) {
+			return ""
+		}
+		return input.FilePath
+	case "Bash":
+		var input bashInput
+		if err := json.Unmarshal(item.Input, &input); err != nil {
+			return ""
+		}
+		return claudeBashCommandDir(input.Command)
+	default:
+		return ""
+	}
+}
+
+func isClaudeAuxiliaryPath(path string) bool {
+	return strings.Contains(path, "/.claude/")
+}
+
+func claudeBashCommandDir(command string) string {
+	matches := regexp.MustCompile(`(?:^|&&)\s*cd\s+((?:"[^"]+"|'[^']+'|[^&|;]+))\s*&&`).FindStringSubmatch(command)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(matches[1]), `"'`)
 }
 
 // validateShell ensures the shell path is safe to execute.

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -328,6 +328,42 @@ func TestReadCodexSessionCWD_PrefersExecCommandWorkdirEvenWhenTurnContextAppears
 	assert.Equal(t, "/tmp/worktree-from-command", cwd)
 }
 
+func TestParseClaudeProjectCWD_PrefersLatestTrackedFileBackup(t *testing.T) {
+	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
+	targetFile := filepath.Join(worktreeDir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(targetFile, []byte("test"), 0600))
+
+	prefix := "{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":"
+	data := []byte(
+		prefix +
+			"{\"/Users/demo/.claude/plans/demo.md\":{},\"" +
+			targetFile +
+			"\":{}}}}\n",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, worktreeDir, cwd)
+}
+
+func TestParseClaudeProjectCWD_PrefersBashCDWorktree(t *testing.T) {
+	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
+
+	prefix := "{\"type\":\"assistant\",\"message\":{\"content\":["
+	data := []byte(
+		prefix +
+			"{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"cd " +
+			worktreeDir +
+			" && git status\"}}]}}\n",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, worktreeDir, cwd)
+}
+
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
 	sess := &LocalSession{pid: 100}
 
@@ -517,6 +553,60 @@ func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	cwd, err := sess.GetActiveWorkdir()
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/worktree-from-command", cwd)
+}
+
+func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	sessionMetaPath := filepath.Join(homeDir, ".claude", "sessions", "220.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionMetaPath), 0755))
+	require.NoError(t, os.WriteFile(sessionMetaPath, []byte(
+		`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`,
+	), 0600))
+
+	transcriptPath := filepath.Join(homeDir, ".claude", "projects", "-repo-main", "session-123.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
+	worktreeFile := filepath.Join(t.TempDir(), "panemux-worktree", "AGENTS.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
+	require.NoError(t, os.WriteFile(worktreeFile, []byte("test"), 0600))
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(
+		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\""+
+			worktreeFile+
+			"\":{}}}}\n",
+	), 0600))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100:
+			return "/repo/main", nil
+		case 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
 }
 
 func TestValidateShell_InEtcShells_OK(t *testing.T) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -378,6 +378,27 @@ func TestLatestClaudeTrackedPath_IsDeterministic(t *testing.T) {
 	assert.Equal(t, "/tmp/repo-worktree/README.md", first)
 }
 
+func TestParseClaudeProjectCWD_TrackedBackupTieBreakUsesAlphabeticalLastPath(t *testing.T) {
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "repo-main", "AGENTS.md")
+	worktreeFile := filepath.Join(dir, "repo-worktree", "README.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(mainFile), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
+	require.NoError(t, os.WriteFile(mainFile, []byte("main"), 0600))
+	require.NoError(t, os.WriteFile(worktreeFile, []byte("worktree"), 0600))
+
+	data := []byte(
+		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{" +
+			"\"" + mainFile + "\":{}," +
+			"\"" + worktreeFile + "\":{}" +
+			"}}}\n",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+}
+
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
 	sess := &LocalSession{pid: 100}
 

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -231,10 +231,10 @@ func TestIsInteractiveAgentCommand(t *testing.T) {
 func TestCodexSessionPath(t *testing.T) {
 	path, ok := codexSessionPath([]string{
 		"/tmp/other.log",
-		"/Users/tomo/.codex/sessions/2026/05/17/rollout.jsonl",
+		"/Users/demo/.codex/sessions/2026/05/17/rollout.jsonl",
 	})
 	require.True(t, ok)
-	assert.Equal(t, "/Users/tomo/.codex/sessions/2026/05/17/rollout.jsonl", path)
+	assert.Equal(t, "/Users/demo/.codex/sessions/2026/05/17/rollout.jsonl", path)
 }
 
 func mustJSONLine(t *testing.T, value any) string {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -364,6 +364,20 @@ func TestParseClaudeProjectCWD_PrefersBashCDWorktree(t *testing.T) {
 	assert.Equal(t, worktreeDir, cwd)
 }
 
+func TestLatestClaudeTrackedPath_IsDeterministic(t *testing.T) {
+	backups := map[string]json.RawMessage{
+		"/tmp/repo-main/AGENTS.md":       {},
+		"/tmp/repo-worktree/README.md":   {},
+		"/Users/demo/.claude/plans/x.md": {},
+	}
+
+	first := latestClaudeTrackedPath(backups)
+	for range 20 {
+		assert.Equal(t, first, latestClaudeTrackedPath(backups))
+	}
+	assert.Equal(t, "/tmp/repo-worktree/README.md", first)
+}
+
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
 	sess := &LocalSession{pid: 100}
 
@@ -598,6 +612,68 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 		case 100:
 			return "/repo/main", nil
 		case 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+}
+
+func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	originalReadFile := readFileFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+		readFileFn = originalReadFile
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	badSessionPath := filepath.Join(homeDir, ".claude", "sessions", "100.json")
+	goodSessionPath := filepath.Join(homeDir, ".claude", "sessions", "220.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(badSessionPath), 0755))
+	require.NoError(t, os.WriteFile(goodSessionPath, []byte(
+		`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`,
+	), 0600))
+
+	transcriptPath := filepath.Join(homeDir, ".claude", "projects", "-repo-main", "session-123.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
+	worktreeFile := filepath.Join(t.TempDir(), "panemux-worktree", "AGENTS.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
+	require.NoError(t, os.WriteFile(worktreeFile, []byte("test"), 0600))
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(
+		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\""+
+			worktreeFile+
+			"\":{}}}}\n",
+	), 0600))
+
+	readFileFn = func(path string) ([]byte, error) {
+		if path == badSessionPath {
+			return nil, errors.New("transient read failure")
+		}
+		return os.ReadFile(path)
+	}
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
 			return "/repo/main", nil
 		default:
 			return "", errors.New("unexpected pid")


### PR DESCRIPTION
## Summary

- keep pane header Git/PR metadata pinned to the last valid sibling worktree after an interactive agent exits
- reuse the same sticky worktree resolution for the VS Code open action
- add local and remote regression tests for sticky worktree reuse and repo-change invalidation
- document the updated pane header and VS Code behavior

## Root Cause

Panemux only preferred a sibling worktree while an interactive `codex` or `claude` process was still detectable. Once the agent process ended, Git/PR lookup and the VS Code action immediately fell back to the pane's original working directory, which caused Claude worktree context to disappear after task completion.

## Impact

- Claude and Codex panes now keep showing the expected branch and linked PR after task completion when the last detected worktree still belongs to the same repository.
- SSH-backed panes get the same sticky behavior as local panes.
- The sticky override is dropped automatically when the pane moves to a different repository context.

## Test Plan

- [x] `go test ./internal/api`
- [x] `go test ./internal/session`
- [x] `go test ./internal/...`

## Notes

- `make test-go` still fails in this worktree because the top-level package embeds `frontend/dist`, which is not present yet.
- `make build-frontend` failed in this environment with `sh: tsc: command not found`, so I could not generate `frontend/dist` here before retrying the full gate.
