### PR TITLE
chore: replace CLAUDE.md with symlink to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,6 @@
+@DEVELOPMENT.md
+@docs/security.md
+
 # AGENTS.md
 
 This file is an index for coding agents working in this repository. Do not duplicate long-form guidance here; follow the linked documents.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-@AGENTS.md
-@DEVELOPMENT.md
-@docs/security.md
+AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md` を `AGENTS.md` へのシンボリックリンクに変更
- 以前の `@AGENTS.md`, `@DEVELOPMENT.md`, `@docs/security.md` の include は削除（AGENTS.md がエントリポイントとして機能するため不要）

## Test plan

- [ ] `ls -la CLAUDE.md` で `CLAUDE.md -> AGENTS.md` が表示される
- [ ] `cat CLAUDE.md` で AGENTS.md の内容が表示される