### PR TITLE
fix: reconnect disconnected SSH sessions

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -396,6 +396,11 @@ During replayed reconnect output, xterm stdin is suppressed until the replay end
 applied, so terminal query responses embedded in old output are not regenerated as fresh shell
 input.
 
+When an SSH-backed pane loses its transport unexpectedly, panemux classifies that session as
+`disconnected` instead of `exited`. The frontend performs one automatic recovery attempt by
+recreating the session and reconnecting the pane. Deliberate remote shell termination such as
+`exit` remains `exited` and shows the restart action instead of auto-reconnecting.
+
 ### Selection and copy behavior
 
 - Terminal text can be selected with the mouse using xterm.js standard selection behavior.

--- a/frontend/src/components/TerminalPane.test.tsx
+++ b/frontend/src/components/TerminalPane.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 class ResizeObserverMock {
   observe() {}
@@ -9,14 +9,12 @@ class ResizeObserverMock {
 
 vi.stubGlobal('ResizeObserver', ResizeObserverMock)
 
+const { mockUseTerminal } = vi.hoisted(() => ({
+  mockUseTerminal: vi.fn(),
+}))
+
 vi.mock('../hooks/useTerminal', () => ({
-  useTerminal: () => ({
-    handleResize: vi.fn(),
-    connected: true,
-    dims: null,
-    sessionExited: false,
-    restartSession: vi.fn(),
-  }),
+  useTerminal: mockUseTerminal,
 }))
 vi.mock('../hooks/useGitInfo', () => ({
   useGitInfo: () => ({ is_git: false }),
@@ -25,6 +23,17 @@ import { dropZoneStyle, PANE_DROP_ZONE_RATIO, resolvePaneDropEdge, TerminalPane 
 import { LayoutActionsContext, type LayoutActionsContextValue } from './SplitContainer'
 
 describe('TerminalPane drop zones', () => {
+  beforeEach(() => {
+    mockUseTerminal.mockReturnValue({
+      handleResize: vi.fn(),
+      connected: true,
+      dims: null,
+      sessionState: 'running',
+      reconnectFailed: false,
+      restartSession: vi.fn(),
+    })
+  })
+
   it('uses a top or bottom half-pane preview for horizontal edge drop zones', () => {
     expect(dropZoneStyle('top', false)).toMatchObject({ height: `${PANE_DROP_ZONE_RATIO * 100}%` })
     expect(dropZoneStyle('bottom', true)).toMatchObject({ height: `${PANE_DROP_ZONE_RATIO * 100}%` })
@@ -91,6 +100,45 @@ describe('TerminalPane drop zones', () => {
 
     expect(ctx.onMovePaneBeside).toHaveBeenCalledWith('pane-source', 'pane-target', 'left')
     expect(ctx.setDragSourcePaneId).toHaveBeenCalledWith(null)
+  })
+
+  it('shows restart button only when the session exited', () => {
+    mockUseTerminal.mockReturnValue({
+      handleResize: vi.fn(),
+      connected: false,
+      dims: null,
+      sessionState: 'exited',
+      reconnectFailed: false,
+      restartSession: vi.fn(),
+    })
+
+    const { getByRole } = render(
+      <LayoutActionsContext.Provider value={makeCtx()}>
+        <TerminalPane pane={{ id: 'pane-1', type: 'local', title: 'Pane 1' }} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    expect(getByRole('button', { name: 'Restart Session' })).toBeInTheDocument()
+  })
+
+  it('shows reconnect button after disconnected auto-recovery fails', () => {
+    mockUseTerminal.mockReturnValue({
+      handleResize: vi.fn(),
+      connected: false,
+      dims: null,
+      sessionState: 'disconnected',
+      reconnectFailed: true,
+      restartSession: vi.fn(),
+    })
+
+    const { getByRole, queryByRole } = render(
+      <LayoutActionsContext.Provider value={makeCtx()}>
+        <TerminalPane pane={{ id: 'pane-1', type: 'local', title: 'Pane 1' }} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    expect(getByRole('button', { name: 'Reconnect Session' })).toBeInTheDocument()
+    expect(queryByRole('button', { name: 'Restart Session' })).toBeNull()
   })
 })
 

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -30,7 +30,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const isDragSource = ctx?.dragSourcePaneId === pane.id
   const dragActive = Boolean(ctx?.dragSourcePaneId)
 
-  const { handleResize, connected, dims, sessionExited, restartSession } = useTerminal({
+  const { handleResize, connected, dims, sessionState, reconnectFailed, restartSession } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
   })
@@ -178,7 +178,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
             style={dropZoneStyle(hoverEdge, true)}
           />
         )}
-        {sessionExited && (
+        {(sessionState === 'exited' || (sessionState === 'disconnected' && reconnectFailed)) && (
           <div style={{
             position: 'absolute',
             inset: 0,
@@ -200,7 +200,7 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
                 cursor: 'pointer',
               }}
             >
-              Restart Session
+              {sessionState === 'exited' ? 'Restart Session' : 'Reconnect Session'}
             </button>
           </div>
         )}

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -539,10 +539,10 @@ describe('useTerminal', () => {
   it('sessionExited is false initially', () => {
     const container = makeContainer()
     const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
-    expect(result.current.sessionExited).toBe(false)
+    expect(result.current.sessionState).toBe('running')
   })
 
-  it('sessionExited is true after exited status frame', () => {
+  it('sessionState is exited after exited status frame', () => {
     const container = makeContainer()
     const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
     act(() => MockWebSocket.instances[0].simulateOpen())
@@ -552,10 +552,10 @@ describe('useTerminal', () => {
         JSON.stringify({ type: 'status', state: 'exited' })
       )
     )
-    expect(result.current.sessionExited).toBe(true)
+    expect(result.current.sessionState).toBe('exited')
   })
 
-  it('sessionExited resets to false when WebSocket reconnects', () => {
+  it('sessionState resets to running when WebSocket reconnects', () => {
     const container = makeContainer()
     const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
     act(() => MockWebSocket.instances[0].simulateOpen())
@@ -565,11 +565,11 @@ describe('useTerminal', () => {
         JSON.stringify({ type: 'status', state: 'exited' })
       )
     )
-    expect(result.current.sessionExited).toBe(true)
+    expect(result.current.sessionState).toBe('exited')
 
     // Simulate WebSocket reconnecting
     act(() => MockWebSocket.instances[0].simulateOpen())
-    expect(result.current.sessionExited).toBe(false)
+    expect(result.current.sessionState).toBe('running')
   })
 
   it('restartSession calls restart API then reconnects', async () => {
@@ -585,6 +585,76 @@ describe('useTerminal', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/api/sessions/pane1/restart', { method: 'POST' })
     expect(MockWebSocket.instances.length).toBeGreaterThan(countBefore)
+  })
+
+  it('disconnected status triggers one restart attempt and reconnect', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 'pane1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    const countBefore = MockWebSocket.instances.length
+    await act(async () => {
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'disconnected' })
+      )
+      await Promise.resolve()
+    })
+
+    expect(result.current.sessionState).toBe('disconnected')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/api/sessions/pane1/restart', { method: 'POST' })
+    expect(MockWebSocket.instances.length).toBeGreaterThan(countBefore)
+    expect(result.current.reconnectFailed).toBe(false)
+  })
+
+  it('disconnected status does not start concurrent restart attempts', async () => {
+    let resolveFetch: ((value: { ok: boolean }) => void) | null = null
+    const fetchMock = vi.fn().mockImplementation(
+      () => new Promise<{ ok: boolean }>((resolve) => { resolveFetch = resolve })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 'pane1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    act(() => {
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'disconnected' })
+      )
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'disconnected' })
+      )
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFetch?.({ ok: true })
+      await Promise.resolve()
+    })
+  })
+
+  it('failed disconnected recovery exposes reconnectFailed state', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network error'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 'pane1', container }))
+    act(() => MockWebSocket.instances[0].simulateOpen())
+
+    await act(async () => {
+      MockWebSocket.instances[0].simulateMessage(
+        JSON.stringify({ type: 'status', state: 'disconnected' })
+      )
+      await Promise.resolve()
+    })
+
+    expect(result.current.sessionState).toBe('disconnected')
+    expect(result.current.reconnectFailed).toBe(true)
   })
 
   it('reuses the same terminal instance across remounts for the same session', () => {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { useWebSocket } from './useWebSocket'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+import type { SessionState } from '../schemas'
 
 const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 
@@ -31,6 +32,7 @@ interface PendingTerminalMessage {
 }
 
 const terminalEntries = new Map<string, TerminalEntry>()
+type TerminalLifecycleState = 'running' | 'disconnected' | 'exited'
 
 export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null)
@@ -39,8 +41,11 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   const sendRef = useRef<((data: string | ArrayBuffer | Uint8Array) => void) | null>(null)
   const entryRef = useRef<TerminalEntry | null>(null)
   const pendingMessagesRef = useRef<PendingTerminalMessage[]>([])
+  const reconnectingAfterDisconnectRef = useRef(false)
+  const recoverDisconnectedSessionRef = useRef<(() => Promise<void>) | null>(null)
   const [dims, setDims] = useState<{ cols: number; rows: number } | null>(null)
-  const [sessionExited, setSessionExited] = useState(false)
+  const [sessionState, setSessionState] = useState<TerminalLifecycleState>('running')
+  const [reconnectFailed, setReconnectFailed] = useState(false)
 
   const applyMessageToTerminal = useCallback((data: ArrayBuffer | string, isBinary: boolean) => {
     const term = termRef.current
@@ -54,10 +59,18 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
       try {
         const msg = JSON.parse(data as string)
         if (msg.type === 'status') {
-          console.log(`Session ${sessionId} status:`, msg.state)
-          if (msg.state === 'exited') {
-            setSessionExited(true)
+          const state = msg.state as SessionState
+          console.log(`Session ${sessionId} status:`, state)
+          if (state === 'exited') {
+            setSessionState('exited')
+            setReconnectFailed(false)
             term.write('\r\n\x1b[2m[Session ended]\x1b[0m\r\n')
+          } else if (state === 'disconnected') {
+            setSessionState('disconnected')
+            void recoverDisconnectedSessionRef.current?.()
+          } else {
+            setSessionState('running')
+            setReconnectFailed(false)
           }
         } else if (msg.type === 'replay') {
           if (msg.state === 'start') {
@@ -96,11 +109,34 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   const { send, connected, reconnect } = useWebSocket(wsUrl, {
     onMessage: handleMessage,
     onOpen: () => {
-      setSessionExited(false)
+      setSessionState('running')
+      setReconnectFailed(false)
+      reconnectingAfterDisconnectRef.current = false
       const entry = entryRef.current
       if (entry) resetReplayState(entry)
     },
   })
+
+  const recoverDisconnectedSession = useCallback(async () => {
+    if (reconnectingAfterDisconnectRef.current) return
+    reconnectingAfterDisconnectRef.current = true
+    setReconnectFailed(false)
+
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/restart`, { method: 'POST' })
+      if (!res.ok) {
+        setReconnectFailed(true)
+        return
+      }
+      reconnect()
+    } catch {
+      setReconnectFailed(true)
+    } finally {
+      reconnectingAfterDisconnectRef.current = false
+    }
+  }, [reconnect, sessionId])
+
+  recoverDisconnectedSessionRef.current = recoverDisconnectedSession
 
   // Keep sendRef in sync so onData closure always has the latest send
   useLayoutEffect(() => {
@@ -192,9 +228,14 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
   const restartSession = useCallback(async () => {
     try {
       const res = await fetch(`/api/sessions/${sessionId}/restart`, { method: 'POST' })
-      if (res.ok) reconnect()
+      if (res.ok) {
+        setReconnectFailed(false)
+        reconnect()
+      } else if (sessionState === 'disconnected') {
+        setReconnectFailed(true)
+      }
     } catch { /* ignore network errors */ }
-  }, [sessionId, reconnect])
+  }, [sessionId, reconnect, sessionState])
 
   // Handle resize
   const handleResize = useCallback(() => {
@@ -208,7 +249,7 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     }
   }, [send, connected])
 
-  return { handleResize, connected, dims, sessionExited, restartSession }
+  return { handleResize, connected, dims, sessionState, reconnectFailed, restartSession }
 }
 
 function flushPendingMessages(

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -136,6 +136,8 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     }
   }, [reconnect, sessionId])
 
+  // This ref is read from an async status-frame handler that can run before an
+  // effect flushes, so keep it current during render rather than one commit later.
   recoverDisconnectedSessionRef.current = recoverDisconnectedSession
 
   // Keep sendRef in sync so onData closure always has the latest send

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -17,6 +17,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null)
   const attemptsRef = useRef(0)
   const mountedRef = useRef(true)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [connected, setConnected] = useState(false)
 
   // Store callbacks in refs so connect() doesn't need them as deps
@@ -28,6 +29,13 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
   useEffect(() => { onOpenRef.current = options.onOpen })
   useEffect(() => { onCloseRef.current = options.onClose })
 
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+  }, [])
+
   const connect = useCallback(() => {
     if (!mountedRef.current) return
     if (attemptsRef.current >= maxReconnectAttempts) return
@@ -37,6 +45,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
     wsRef.current = ws
 
     ws.onopen = () => {
+      clearReconnectTimer()
       attemptsRef.current = 0
       setConnected(true)
       onOpenRef.current?.()
@@ -61,23 +70,28 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
       onCloseRef.current?.()
       if (mountedRef.current) {
         attemptsRef.current++
-        setTimeout(connect, reconnectDelay)
+        clearReconnectTimer()
+        reconnectTimerRef.current = setTimeout(() => {
+          reconnectTimerRef.current = null
+          connect()
+        }, reconnectDelay)
       }
     }
 
     ws.onerror = () => {
       ws.close()
     }
-  }, [url, reconnectDelay, maxReconnectAttempts]) // callbacks excluded via refs
+  }, [url, reconnectDelay, maxReconnectAttempts, clearReconnectTimer]) // callbacks excluded via refs
 
   useEffect(() => {
     mountedRef.current = true
     connect()
     return () => {
       mountedRef.current = false
+      clearReconnectTimer()
       wsRef.current?.close()
     }
-  }, [connect])
+  }, [connect, clearReconnectTimer])
 
   const send = useCallback((data: string | ArrayBuffer | Uint8Array) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -88,6 +102,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
   // Imperatively reconnect: detach the current socket (without triggering the
   // onclose reconnect loop), reset the attempt counter, then connect fresh.
   const reconnect = useCallback(() => {
+    clearReconnectTimer()
     const ws = wsRef.current
     if (ws) {
       ws.onclose = null
@@ -98,7 +113,7 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
     }
     attemptsRef.current = 0
     connect()
-  }, [connect])
+  }, [connect, clearReconnectTimer])
 
   return { send, connected, reconnect }
 }

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -83,13 +83,17 @@ export const SessionInfoSchema = z.object({
 
 export type SessionInfo = z.infer<typeof SessionInfoSchema>
 
+export const SessionStateSchema = z.enum(['connected', 'disconnected', 'exited'])
+
+export type SessionState = z.infer<typeof SessionStateSchema>
+
 export const WSControlMessageSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('resize'),
     cols: z.number().positive(),
     rows: z.number().positive(),
   }),
-  z.object({ type: z.literal('status'), state: z.string() }),
+  z.object({ type: z.literal('status'), state: SessionStateSchema }),
   z.object({ type: z.literal('replay'), state: z.enum(['start', 'end']) }),
   z.object({ type: z.literal('error'), message: z.string().max(2000) }),
 ])

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -369,8 +369,8 @@ func closeSSHResources(sess *ssh.Session, client, jumpClient *ssh.Client) {
 func monitorSSHSession(sess *ssh.Session, pw *io.PipeWriter, markExited func(State)) {
 	go func() {
 		waitErr := sess.Wait()
-		pw.Close()
 		markExited(classifySSHWaitError(waitErr))
+		pw.Close()
 	}()
 }
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -277,10 +277,10 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		jumpClient:     jumpClient,
 	}
 
-	monitorSSHSession(sess, pw, func() {
+	monitorSSHSession(sess, pw, func(state State) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		s.state = StateExited
+		s.state = state
 	})
 
 	return s, nil
@@ -366,12 +366,30 @@ func closeSSHResources(sess *ssh.Session, client, jumpClient *ssh.Client) {
 	}
 }
 
-func monitorSSHSession(sess *ssh.Session, pw *io.PipeWriter, markExited func()) {
+func monitorSSHSession(sess *ssh.Session, pw *io.PipeWriter, markExited func(State)) {
 	go func() {
-		sess.Wait()
+		waitErr := sess.Wait()
 		pw.Close()
-		markExited()
+		markExited(classifySSHWaitError(waitErr))
 	}()
+}
+
+func classifySSHWaitError(err error) State {
+	if err == nil {
+		return StateExited
+	}
+
+	var exitErr *ssh.ExitError
+	if errors.As(err, &exitErr) {
+		return StateExited
+	}
+
+	var exitMissingErr *ssh.ExitMissingError
+	if errors.As(err, &exitMissingErr) {
+		return StateExited
+	}
+
+	return StateDisconnected
 }
 
 // DetectRemoteShell connects to the remote host via SSH and returns the value of $SHELL.

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -296,6 +297,24 @@ func TestSSHSessionConnectionName(t *testing.T) {
 func TestTmuxSSHSessionConnectionName(t *testing.T) {
 	s := &TmuxSSHSession{connectionName: "remote-box"}
 	assert.Equal(t, "remote-box", s.ConnectionName())
+}
+
+func TestClassifySSHWaitError_ExitedOnNil(t *testing.T) {
+	assert.Equal(t, StateExited, classifySSHWaitError(nil))
+}
+
+func TestClassifySSHWaitError_ExitedOnExitError(t *testing.T) {
+	err := &gossh.ExitError{Waitmsg: gossh.Waitmsg{}}
+	assert.Equal(t, StateExited, classifySSHWaitError(err))
+}
+
+func TestClassifySSHWaitError_ExitedOnExitMissingError(t *testing.T) {
+	err := &gossh.ExitMissingError{}
+	assert.Equal(t, StateExited, classifySSHWaitError(err))
+}
+
+func TestClassifySSHWaitError_DisconnectedOnTransportError(t *testing.T) {
+	assert.Equal(t, StateDisconnected, classifySSHWaitError(io.EOF))
 }
 
 func TestNewTmuxSSH_InvalidSessionName_Error(t *testing.T) {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -82,10 +82,10 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		jumpClient:     jumpClient,
 	}
 
-	monitorSSHSession(sess, pw, func() {
+	monitorSSHSession(sess, pw, func(state State) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		s.state = StateExited
+		s.state = state
 	})
 
 	return s, nil

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -172,7 +172,7 @@ func (h *Handler) forwardTerminalOutput(
 		log.Printf("session %s stream closed in state %s", sessionID, sess.State())
 	}
 
-	h.sendStatus(conn, "exited")
+	h.sendStatus(conn, string(sess.State()))
 }
 
 func (h *Handler) pipeWebSocketToTerminal(

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -304,7 +304,7 @@ func TestWS_ReplayEndWriteFailureDetected(t *testing.T) {
 	assert.Equal(t, "start", replayStart.State)
 }
 
-func TestWS_SendsExitedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {
+func TestWS_SendsDisconnectedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {
 	mgr := session.NewManager()
 	sess := newWsMock("s1")
 	sess.state = session.StateDisconnected
@@ -331,6 +331,35 @@ func TestWS_SendsExitedStatusWhenSessionStreamEndsWithReadError(t *testing.T) {
 
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	msgType, data, err = conn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.TextMessage, msgType)
+
+	var disconnected ControlMessage
+	require.NoError(t, json.Unmarshal(data, &disconnected))
+	assert.Equal(t, "disconnected", disconnected.State)
+}
+
+func TestWS_SendsExitedStatusWhenSessionStreamEndsExplicitly(t *testing.T) {
+	mgr := session.NewManager()
+	sess := newWsMock("s1")
+	sess.state = session.StateExited
+	mgr.Add(sess)
+	close(sess.out)
+	time.Sleep(50 * time.Millisecond)
+
+	srv := setupWSServer(mgr)
+	defer srv.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv, "s1"), nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _, err = conn.ReadMessage()
+	require.NoError(t, err)
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	msgType, data, err := conn.ReadMessage()
 	require.NoError(t, err)
 	assert.Equal(t, websocket.TextMessage, msgType)
 


### PR DESCRIPTION
## Summary
- distinguish explicit SSH session exit from transport disconnects
- auto-recreate disconnected panes once and reconnect the WebSocket session
- keep restart UI only for explicit exits and add regression coverage

## Test Plan
- [x] go test ./internal/session ./internal/ws
- [x] npm test -- --run src/hooks/useWebSocket.test.ts src/hooks/useTerminal.test.ts src/components/TerminalPane.test.tsx
- [x] make test-frontend
- [x] make build-frontend
- [x] make lint-go
