### PR TITLE
fix: resolve remote Claude worktree headers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,6 +187,8 @@ This ordering is intentional and reflects observed Codex behavior as of `codex-t
 
 Panemux treats that `workdir` field as the strongest available signal for the active worktree because it is the only one that changes when Codex executes tools inside a sibling Git worktree while the parent interactive process remains attached to the original pane directory. If a future Codex release changes this logging contract, compare new logs against these three fields before changing the resolver so behavior remains reviewable and intentional.
 
+For interactive Claude sessions, all four session implementations may inspect `~/.claude/sessions/<pid>.json` to locate the active transcript under `~/.claude/projects/...`. Panemux derives the active worktree from the latest non-auxiliary file path or `Bash` tool `cd ... &&` target recorded in that transcript.
+
 ### `useWorkspaceAttentionMonitor`
 
 Opens lightweight background WebSocket subscriptions for every pane ID across all workspaces and

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -481,6 +481,8 @@ When a pane moves to a different parent node, the component may be remounted by 
 - Codex log resolution currently prefers the most recent `response_item.payload.arguments.workdir` from `exec_command` tool calls, then falls back to `turn_context.cwd`, then `session_meta.cwd`.
 - This ordering exists because the interactive Codex process and its thread metadata may stay on the original pane directory even while tool calls are executing inside a sibling Git worktree.
 - If future Codex versions change their session-log schema or start updating `turn_context.cwd` to the active worktree reliably, compare the three fields above before changing panemux's resolver order.
+- For interactive Claude flows across all four pane types, panemux may derive the active worktree from `~/.claude/sessions/<pid>.json` plus the matching transcript under `~/.claude/projects/...`.
+- Claude transcript resolution prefers the latest non-auxiliary tracked file path or `Bash` tool `cd ... &&` target recorded in that transcript.
 - If the agent exits, no longer has an eligible worktree, or the resolved worktree is not a sibling worktree of the pane's current repository, panemux falls back to the pane's own working directory immediately.
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -665,22 +665,22 @@ func readClaudeProjectCWD(path string) (string, error) {
 
 func parseClaudeProjectCWD(data []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	var latestPath string
+	var latest claudePathCandidate
 	for scanner.Scan() {
-		if candidate := claudeRecordPath(scanner.Bytes()); candidate != "" {
-			latestPath = candidate
+		if candidate := claudeRecordPath(scanner.Bytes()); candidate.Path != "" {
+			latest = candidate
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("scan claude transcript: %w", err)
 	}
-	if latestPath == "" {
+	if latest.Path == "" {
 		return "", nil
 	}
-	if info, err := os.Stat(latestPath); err == nil && info.IsDir() {
-		return latestPath, nil
+	if latest.IsDir {
+		return latest.Path, nil
 	}
-	return filepath.Dir(latestPath), nil
+	return filepath.Dir(latest.Path), nil
 }
 
 type claudeProjectRecord struct {
@@ -693,19 +693,24 @@ type claudeProjectRecord struct {
 	} `json:"message"`
 }
 
-func claudeRecordPath(line []byte) string {
+type claudePathCandidate struct {
+	Path  string
+	IsDir bool
+}
+
+func claudeRecordPath(line []byte) claudePathCandidate {
 	var rec claudeProjectRecord
 	if err := json.Unmarshal(line, &rec); err != nil {
-		return ""
+		return claudePathCandidate{}
 	}
 
 	switch rec.Type {
 	case "file-history-snapshot":
-		return latestClaudeTrackedPath(rec.Snapshot.TrackedFileBackups)
+		return claudePathCandidate{Path: latestClaudeTrackedPath(rec.Snapshot.TrackedFileBackups)}
 	case "assistant":
 		return latestClaudeToolPath(rec.Message.Content)
 	default:
-		return ""
+		return claudePathCandidate{}
 	}
 }
 
@@ -724,17 +729,17 @@ func latestClaudeTrackedPath(backups map[string]json.RawMessage) string {
 	return paths[len(paths)-1]
 }
 
-func latestClaudeToolPath(content []json.RawMessage) string {
-	latest := ""
+func latestClaudeToolPath(content []json.RawMessage) claudePathCandidate {
+	latest := claudePathCandidate{}
 	for _, item := range content {
-		if path := claudeToolPath(item); path != "" {
+		if path := claudeToolPath(item); path.Path != "" {
 			latest = path
 		}
 	}
 	return latest
 }
 
-func claudeToolPath(raw json.RawMessage) string {
+func claudeToolPath(raw json.RawMessage) claudePathCandidate {
 	type toolUseContent struct {
 		Type  string          `json:"type"`
 		Name  string          `json:"name"`
@@ -749,27 +754,31 @@ func claudeToolPath(raw json.RawMessage) string {
 
 	var item toolUseContent
 	if err := json.Unmarshal(raw, &item); err != nil || item.Type != "tool_use" {
-		return ""
+		return claudePathCandidate{}
 	}
 
 	switch item.Name {
 	case "Read", "Edit", "Write", "MultiEdit", "NotebookEdit":
 		var input fileInput
 		if err := json.Unmarshal(item.Input, &input); err != nil {
-			return ""
+			return claudePathCandidate{}
 		}
 		if input.FilePath == "" || isClaudeAuxiliaryPath(input.FilePath) {
-			return ""
+			return claudePathCandidate{}
 		}
-		return input.FilePath
+		return claudePathCandidate{Path: input.FilePath}
 	case "Bash":
 		var input bashInput
 		if err := json.Unmarshal(item.Input, &input); err != nil {
-			return ""
+			return claudePathCandidate{}
 		}
-		return claudeBashCommandDir(input.Command)
+		path := claudeBashCommandDir(input.Command)
+		if path == "" {
+			return claudePathCandidate{}
+		}
+		return claudePathCandidate{Path: path, IsDir: true}
 	default:
-		return ""
+		return claudePathCandidate{}
 	}
 }
 

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -32,6 +32,7 @@ var readFileFn = os.ReadFile
 // This character allowlist is the sanitizer CodeQL requires for go/command-injection.
 var validShellPath = regexp.MustCompile(`^(/[a-zA-Z0-9._\-/]+)$`)
 var claudeBashCDPattern = regexp.MustCompile(`(?:^|&&)\s*cd\s+((?:"[^"]+"|'[^']+'|[^&|;]+))\s*&&`)
+var validClaudeSessionID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // LocalSession is a local PTY-based terminal session.
 type LocalSession struct {
@@ -381,6 +382,9 @@ func claudeSessionCWD(agentPID int) (string, error) {
 		return "", err
 	}
 	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
+		return "", nil
+	}
+	if !validClaudeSessionID.MatchString(sessionMeta.SessionID) {
 		return "", nil
 	}
 

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -706,6 +706,47 @@ func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T)
 	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
 }
 
+func TestGetActiveWorkdir_ClaudeSessionScanRejectsInvalidSessionID(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	sessionMetaPath := filepath.Join(homeDir, ".claude", "sessions", "220.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionMetaPath), 0755))
+	require.NoError(t, os.WriteFile(sessionMetaPath, []byte(
+		`{"pid":220,"sessionId":"../../etc/shadow","cwd":"/repo/main"}`,
+	), 0600))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main", cwd)
+}
+
 func TestValidateShell_InEtcShells_OK(t *testing.T) {
 	got, err := validateShell("/bin/sh")
 	assert.NoError(t, err)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha1" //nolint:gosec // G505: OpenSSH hashed known_hosts entries use HMAC-SHA1
+	"encoding/json"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -829,19 +830,19 @@ func activeRemoteWorkdirWithOutput(
 		log.Printf("%s selected interactive agent pid=%d command=%q", logScope, agentPID, proc.Command)
 	}
 
-	sessionCWD, sessionErr := remoteCodexSessionCWD(
+	sessionCWD, sessionErr := remoteInteractiveAgentSessionCWD(
 		run,
 		logScope,
 		processes,
 		agentPID,
 	)
 	if sessionErr == nil && sessionCWD != "" {
-		log.Printf("%s resolved active workdir from codex session log: %q", logScope, sessionCWD)
+		log.Printf("%s resolved active workdir from interactive agent session data: %q", logScope, sessionCWD)
 		return sessionCWD, nil
 	} else if sessionErr != nil {
-		log.Printf("%s codex session workdir lookup failed: %v", logScope, sessionErr)
+		log.Printf("%s interactive agent session workdir lookup failed: %v", logScope, sessionErr)
 	} else {
-		log.Printf("%s no codex session-log workdir found; falling back to descendant cwd scan", logScope)
+		log.Printf("%s no interactive agent session workdir found; falling back to descendant cwd scan", logScope)
 	}
 
 	cwd, err := resolveRemoteInteractiveAgentWorkdir(logScope, run, processes, agentPID, baseCWD)
@@ -949,6 +950,89 @@ func remoteCodexSessionCWD(
 	}
 	log.Printf("%s parsed codex session workdir path=%q cwd=%q", logScope, sessionPath, cwd)
 	return cwd, nil
+}
+
+func remoteInteractiveAgentSessionCWD(
+	run remoteOutputFunc,
+	logScope string,
+	processes []processInfo,
+	agentPID int,
+) (string, error) {
+	proc, ok := processByPID(processes, agentPID)
+	if !ok {
+		return "", nil
+	}
+
+	switch {
+	case isCodexCommand(proc.Command):
+		return remoteCodexSessionCWD(run, logScope, processes, agentPID)
+	case isClaudeCommand(proc.Command):
+		return remoteClaudeSessionCWD(run, logScope, processes, agentPID)
+	default:
+		return "", nil
+	}
+}
+
+func remoteClaudeSessionCWD(
+	run remoteOutputFunc,
+	logScope string,
+	processes []processInfo,
+	agentPID int,
+) (string, error) {
+	proc, ok := processByPID(processes, agentPID)
+	if !ok || !isClaudeCommand(proc.Command) {
+		return "", nil
+	}
+
+	sessionMeta, err := remoteClaudeSessionMeta(run, logScope, agentPID)
+	if err != nil {
+		return "", err
+	}
+	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
+		return "", nil
+	}
+
+	projectPath := remoteClaudeProjectPath(sessionMeta)
+	out, err := run("cat " + shellQuotePath(projectPath))
+	if err != nil {
+		log.Printf("%s reading claude transcript failed path=%q: %v", logScope, projectPath, err)
+		return "", err
+	}
+
+	cwd, err := parseClaudeProjectCWD(out)
+	if err != nil {
+		log.Printf("%s parsing claude transcript failed path=%q: %v", logScope, projectPath, err)
+		return "", err
+	}
+	log.Printf("%s parsed claude transcript path=%q cwd=%q", logScope, projectPath, cwd)
+	return cwd, nil
+}
+
+func remoteClaudeSessionMeta(run remoteOutputFunc, logScope string, agentPID int) (*claudeSessionMeta, error) {
+	sessionPath := fmt.Sprintf("~/.claude/sessions/%d.json", agentPID)
+	out, err := run("cat " + sessionPath)
+	if err != nil {
+		log.Printf("%s reading claude session metadata failed path=%q: %v", logScope, sessionPath, err)
+		return nil, err
+	}
+
+	var meta claudeSessionMeta
+	if err := json.Unmarshal(out, &meta); err != nil {
+		log.Printf("%s parsing claude session metadata failed path=%q: %v", logScope, sessionPath, err)
+		return nil, err
+	}
+	if meta.PID != agentPID {
+		return nil, nil
+	}
+	return &meta, nil
+}
+
+func remoteClaudeProjectPath(meta *claudeSessionMeta) string {
+	return filepath.Join(
+		"~/.claude/projects",
+		claudeProjectDirName(meta.CWD),
+		meta.SessionID+".jsonl",
+	)
 }
 
 func remoteGitContext(runner sshSessionRunner, cwd string) (GitContext, error) {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -993,7 +993,7 @@ func remoteClaudeSessionCWD(
 	}
 
 	projectPath := remoteClaudeProjectPath(sessionMeta)
-	out, err := run("cat " + shellQuotePath(projectPath))
+	out, err := run(remoteClaudeProjectReadCmd(sessionMeta))
 	if err != nil {
 		log.Printf("%s reading claude transcript failed path=%q: %v", logScope, projectPath, err)
 		return "", err
@@ -1032,6 +1032,12 @@ func remoteClaudeProjectPath(meta *claudeSessionMeta) string {
 		"~/.claude/projects",
 		claudeProjectDirName(meta.CWD),
 		meta.SessionID+".jsonl",
+	)
+}
+
+func remoteClaudeProjectReadCmd(meta *claudeSessionMeta) string {
+	return "cat ~/.claude/projects/" + shellQuotePath(
+		filepath.Join(claudeProjectDirName(meta.CWD), meta.SessionID+".jsonl"),
 	)
 }
 

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha1" //nolint:gosec // G505: OpenSSH hashed known_hosts entries use HMAC-SHA1
-	"encoding/json"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -991,6 +991,9 @@ func remoteClaudeSessionCWD(
 	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
 		return "", nil
 	}
+	if !validClaudeSessionID.MatchString(sessionMeta.SessionID) {
+		return "", nil
+	}
 
 	projectPath := remoteClaudeProjectPath(sessionMeta)
 	out, err := run(remoteClaudeProjectReadCmd(sessionMeta))

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -417,8 +417,8 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
-			sshListProcessesCmd:    []byte(" 100 1 sh\n 220 100 claude\n"),
-			"cat " + sessionPath:   []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
 			"cat " + shellQuotePath(projectPath): []byte(
 				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
 					worktreeFile +
@@ -438,11 +438,12 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
-			sshListProcessesCmd:    []byte(" 100 1 sh\n 220 100 claude\n"),
-			"cat " + sessionPath:   []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
 			"cat " + shellQuotePath(projectPath): []byte(
 				"{\"type\":\"assistant\",\"message\":{\"content\":[" +
-					"{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"cd /tmp/remote-bash-worktree && git status\"}}" +
+					"{\"type\":\"tool_use\",\"name\":\"Bash\"," +
+					"\"input\":{\"command\":\"cd /tmp/remote-bash-worktree && git status\"}}" +
 					"]}}\n",
 			),
 		},

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -454,6 +454,21 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
 	assert.Equal(t, "/tmp/remote-bash-worktree", cwd)
 }
 
+func TestActiveRemoteWorkdir_RejectsRemoteClaudeInvalidSessionID(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:                    []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath:                   []byte(`{"pid":220,"sessionId":"../../etc/shadow","cwd":"/repo/main"}`),
+			fmt.Sprintf(sshPIDCWDCmdTemplate, 220): []byte("/repo/main\n"),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main", cwd)
+}
+
 func TestRemoteShellPID_ParsesShellProcess(t *testing.T) {
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -410,6 +410,49 @@ func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 	assert.Equal(t, "/tmp/remote-worktree", cwd)
 }
 
+func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+	worktreeFile := "/tmp/remote-claude-worktree/AGENTS.md"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:    []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath:   []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			"cat " + shellQuotePath(projectPath): []byte(
+				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
+					worktreeFile +
+					"\":{}}}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
+}
+
+func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:    []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath:   []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			"cat " + shellQuotePath(projectPath): []byte(
+				"{\"type\":\"assistant\",\"message\":{\"content\":[" +
+					"{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"cd /tmp/remote-bash-worktree && git status\"}}" +
+					"]}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-bash-worktree", cwd)
+}
+
 func TestRemoteShellPID_ParsesShellProcess(t *testing.T) {
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
@@ -496,6 +539,29 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/remote-tmux-worktree-from-command", cwd)
+}
+
+func TestTmuxSSHActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
+	sessionPath := "~/.claude/sessions/230.json"
+	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+	worktreeFile := "/tmp/remote-tmux-claude-worktree/AGENTS.md"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			"tmux display-message -p -t 'demo' '#{pane_pid}\t#{pane_current_path}'": []byte("220\t/repo/main\n"),
+			sshListProcessesCmd:  []byte(" 220 1 zsh\n 230 220 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":230,"sessionId":"session-123","cwd":"/repo/main"}`),
+			"cat " + shellQuotePath(projectPath): []byte(
+				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
+					worktreeFile +
+					"\":{}}}}\n",
+			),
+		},
+	}
+
+	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-tmux-claude-worktree", cwd)
 }
 
 func TestTmuxSSHActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(t *testing.T) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -412,14 +412,14 @@ func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T) {
 	sessionPath := "~/.claude/sessions/220.json"
-	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
 	worktreeFile := "/tmp/remote-claude-worktree/AGENTS.md"
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
-			"cat " + shellQuotePath(projectPath): []byte(
+			projectCmd: []byte(
 				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
 					worktreeFile +
 					"\":{}}}}\n",
@@ -434,13 +434,13 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
 	sessionPath := "~/.claude/sessions/220.json"
-	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
-			"cat " + shellQuotePath(projectPath): []byte(
+			projectCmd: []byte(
 				"{\"type\":\"assistant\",\"message\":{\"content\":[" +
 					"{\"type\":\"tool_use\",\"name\":\"Bash\"," +
 					"\"input\":{\"command\":\"cd /tmp/remote-bash-worktree && git status\"}}" +
@@ -544,7 +544,7 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 
 func TestTmuxSSHActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 	sessionPath := "~/.claude/sessions/230.json"
-	projectPath := "~/.claude/projects/-repo-main/session-123.jsonl"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
 	worktreeFile := "/tmp/remote-tmux-claude-worktree/AGENTS.md"
 
 	runner := &fakeSSHRunner{
@@ -552,7 +552,7 @@ func TestTmuxSSHActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 			"tmux display-message -p -t 'demo' '#{pane_pid}\t#{pane_current_path}'": []byte("220\t/repo/main\n"),
 			sshListProcessesCmd:  []byte(" 220 1 zsh\n 230 220 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":230,"sessionId":"session-123","cwd":"/repo/main"}`),
-			"cat " + shellQuotePath(projectPath): []byte(
+			projectCmd: []byte(
 				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
 					worktreeFile +
 					"\":{}}}}\n",


### PR DESCRIPTION
## Summary

- resolve remote `claude` worktree detection for `ssh` and `ssh_tmux` panes
- keep pane header git branch and linked PR metadata aligned with the active Claude worktree
- document the remote Claude resolver behavior alongside the existing Codex notes

## Root Cause

Remote pane header worktree overrides had special handling for Codex session logs, but Claude only had a local-only transcript resolver. In `ssh` and `ssh_tmux` panes panemux therefore fell back to descendant process cwd scanning, which often stayed pinned to the base pane directory instead of the active sibling worktree.

## Changes

- add remote Claude session metadata and transcript parsing in the SSH session resolver
- reuse Claude transcript path extraction for both local and remote flows
- add regression tests for remote SSH and SSH+tmux Claude worktree resolution
- update architecture and behavior docs to describe the remote Claude path

## Validation

- `go test ./internal/session ./internal/api`
- `make test-go`
