### PR TITLE
fix: normalize claude transcript project dir names

### DIFF
--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -653,7 +653,8 @@ func parseExecCommandWorkdir(raw json.RawMessage) string {
 }
 
 func claudeProjectDirName(cwd string) string {
-	return strings.ReplaceAll(filepath.Clean(cwd), string(os.PathSeparator), "-")
+	name := strings.ReplaceAll(filepath.Clean(cwd), string(os.PathSeparator), "-")
+	return strings.ReplaceAll(name, ".", "-")
 }
 
 func readClaudeProjectCWD(path string) (string, error) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -644,6 +644,73 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
 }
 
+func TestClaudeProjectDirName_NormalizesDots(t *testing.T) {
+	assert.Equal(t, "-repo-main", claudeProjectDirName("/repo/main"))
+	assert.Equal(
+		t,
+		"-Users-tomo-chan-development-panemux",
+		claudeProjectDirName("/Users/tomo.chan/development/panemux"),
+	)
+}
+
+func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree_WithDotInCWD(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	sessionMetaPath := filepath.Join(homeDir, ".claude", "sessions", "220.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionMetaPath), 0755))
+	require.NoError(t, os.WriteFile(sessionMetaPath, []byte(
+		`{"pid":220,"sessionId":"session-123","cwd":"/Users/tomo.chan/development/panemux"}`,
+	), 0600))
+
+	transcriptPath := filepath.Join(
+		homeDir,
+		".claude",
+		"projects",
+		"-Users-tomo-chan-development-panemux",
+		"session-123.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
+	worktreeFile := filepath.Join(t.TempDir(), "panemux-worktree", "AGENTS.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
+	require.NoError(t, os.WriteFile(worktreeFile, []byte("test"), 0600))
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(
+		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\""+
+			worktreeFile+
+			"\":{}}}}\n",
+	), 0600))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwd, err := sess.GetActiveWorkdir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+}
+
 func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T) {
 	sess := &LocalSession{pid: 100}
 

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -432,6 +432,28 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
 }
 
+func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-home-tomo-chan-repo-main/session-123.jsonl'"
+	worktreeFile := "/tmp/remote-claude-worktree/AGENTS.md"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/home/tomo.chan/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
+					worktreeFile +
+					"\":{}}}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
+}
+
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
 	sessionPath := "~/.claude/sessions/220.json"
 	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"


### PR DESCRIPTION
## Summary
- normalize Claude transcript project directory names so paths with `.` match the actual `~/.claude/projects/...` layout
- add local and SSH regression tests for dot-containing Claude cwd paths

## Test plan
- [x] make install-deps
- [x] make build-frontend
- [x] make test-go
- [x] make lint-go
