### PR TITLE
fix: improve git context error diagnostics

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -944,9 +944,9 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	}, nil
 }
 
-func localGitOptionalMetadata(cwd string) ([]byte, []byte) {
+func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
 	branchCmd := exec.Command("git", "branch", "--show-current")
-	branchCmd.Dir = cwd
+	branchCmd.Dir = safeCWD
 	branchOut, err := branchCmd.Output()
 	if err != nil {
 		// Detached HEAD returns non-zero for --show-current. Treat that as
@@ -956,7 +956,7 @@ func localGitOptionalMetadata(cwd string) ([]byte, []byte) {
 	branchOut = bytes.TrimSpace(branchOut)
 
 	originCmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	originCmd.Dir = cwd
+	originCmd.Dir = safeCWD
 	originOut, err := originCmd.Output()
 	if err != nil {
 		originOut = nil
@@ -1021,6 +1021,8 @@ func formatGitContextLookupError(logScope, source string, err error) string {
 		)
 	}
 
+	// Keep a defensive fallback here so future callers that wrap a non-GitContextError
+	// still produce an actionable log instead of regressing to a raw `%v` message.
 	return fmt.Sprintf(
 		`%s git context lookup failed: source=%q cause=%q remediation=%q raw_error=%q`,
 		logScope,

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -782,7 +782,7 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 
 	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
-		log.Printf("%s base context lookup failed: %v", logScope, err)
+		log.Printf("%s", formatGitContextLookupError(logScope, "base context lookup", err))
 		return cwd
 	}
 
@@ -801,7 +801,7 @@ func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
 
 	ctx, err := h.inspectGitContextForSession(sess, candidate)
 	if err != nil {
-		log.Printf("%s active workdir candidate context lookup failed: %v", logScope, err)
+		log.Printf("%s", formatGitContextLookupError(logScope, "active workdir candidate context lookup", err))
 		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
 	}
 	if ctx.CommonDir == baseCtx.CommonDir && ctx.Root != baseCtx.Root {
@@ -898,27 +898,55 @@ func (h *Handler) inspectGitContextForSession(sess session.Session, cwd string) 
 func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error) {
 	safeCWD, err := sanitizeGitExecDir(cwd)
 	if err != nil {
-		return session.GitContext{}, err
+		return session.GitContext{}, session.NewGitContextError(
+			"local",
+			"validate local working directory",
+			cwd,
+			session.GitContextCauseInvalidCWD,
+			err,
+			"",
+		)
 	}
 
-	toplevelCmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	toplevelCmd.Dir = safeCWD
-	toplevelOut, err := toplevelCmd.Output()
+	toplevelOut, err := runLocalGitContextCommand(
+		safeCWD,
+		cwd,
+		"git rev-parse --show-toplevel",
+		"rev-parse",
+		"--show-toplevel",
+	)
 	if err != nil {
-		return session.GitContext{}, fmt.Errorf("git show toplevel for %q: %w", cwd, err)
+		return session.GitContext{}, err
 	}
 	toplevelOut = bytes.TrimSpace(toplevelOut)
 
-	commonDirCmd := exec.Command("git", "rev-parse", "--path-format=absolute", "--git-common-dir")
-	commonDirCmd.Dir = safeCWD
-	commonDirOut, err := commonDirCmd.Output()
+	commonDirOut, err := runLocalGitContextCommand(
+		safeCWD,
+		cwd,
+		"git rev-parse --path-format=absolute --git-common-dir",
+		"rev-parse",
+		"--path-format=absolute",
+		"--git-common-dir",
+	)
 	if err != nil {
-		return session.GitContext{}, fmt.Errorf("git show common dir for %q: %w", cwd, err)
+		return session.GitContext{}, err
 	}
 	commonDirOut = bytes.TrimSpace(commonDirOut)
 
+	branchOut, originOut := localGitOptionalMetadata(safeCWD)
+	root := string(toplevelOut)
+	return session.GitContext{
+		Branch:    string(branchOut),
+		CommonDir: string(commonDirOut),
+		OriginURL: string(originOut),
+		Repo:      filepath.Base(root),
+		Root:      root,
+	}, nil
+}
+
+func localGitOptionalMetadata(cwd string) ([]byte, []byte) {
 	branchCmd := exec.Command("git", "branch", "--show-current")
-	branchCmd.Dir = safeCWD
+	branchCmd.Dir = cwd
 	branchOut, err := branchCmd.Output()
 	if err != nil {
 		// Detached HEAD returns non-zero for --show-current. Treat that as
@@ -928,21 +956,38 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	branchOut = bytes.TrimSpace(branchOut)
 
 	originCmd := exec.Command("git", "config", "--get", "remote.origin.url")
-	originCmd.Dir = safeCWD
+	originCmd.Dir = cwd
 	originOut, err := originCmd.Output()
 	if err != nil {
 		originOut = nil
 	}
 	originOut = bytes.TrimSpace(originOut)
+	return branchOut, originOut
+}
 
-	root := string(toplevelOut)
-	return session.GitContext{
-		Branch:    string(branchOut),
-		CommonDir: string(commonDirOut),
-		OriginURL: string(originOut),
-		Repo:      filepath.Base(root),
-		Root:      root,
-	}, nil
+func runLocalGitContextCommand(safeCWD, originalCWD, operation string, args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = safeCWD
+	out, err := cmd.Output()
+	if err == nil {
+		return out, nil
+	}
+
+	stderr := ""
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
+	}
+
+	cause := session.ClassifyGitFailureCause(stderr, err)
+	if cause == session.GitContextCauseUnknown && errors.Is(err, exec.ErrNotFound) {
+		cause = session.GitContextCauseGitNotInstalled
+	}
+	if cause == session.GitContextCauseUnknown {
+		cause = session.GitContextCauseGitMetadata
+	}
+
+	return nil, session.NewGitContextError("local", operation, originalCWD, cause, err, stderr)
 }
 
 var validGitExecDir = regexp.MustCompile(`^(/[^[:cntrl:]\x00]*)+$`)
@@ -956,6 +1001,38 @@ func sanitizeGitExecDir(cwd string) (string, error) {
 		return "", fmt.Errorf("working directory contains invalid characters: %q", cwd)
 	}
 	return cleaned, nil
+}
+
+func formatGitContextLookupError(logScope, source string, err error) string {
+	var ctxErr *session.GitContextError
+	if errors.As(err, &ctxErr) {
+		return fmt.Sprintf(
+			"%s git context lookup failed: source=%q cause=%q remediation=%q transport=%q cwd=%q "+
+				`operation=%q stderr=%q raw_error=%q`,
+			logScope,
+			source,
+			ctxErr.CauseMessage,
+			ctxErr.Remediation,
+			ctxErr.Transport,
+			ctxErr.CWD,
+			ctxErr.Operation,
+			singleLineLogValue(ctxErr.Stderr),
+			singleLineLogValue(ctxErr.RawError),
+		)
+	}
+
+	return fmt.Sprintf(
+		`%s git context lookup failed: source=%q cause=%q remediation=%q raw_error=%q`,
+		logScope,
+		source,
+		"Git context lookup failed for an unknown reason",
+		"inspect the raw error details to determine the next action",
+		singleLineLogValue(err.Error()),
+	)
+}
+
+func singleLineLogValue(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
 }
 
 func (h *Handler) findGH() (string, error) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1253,6 +1253,7 @@ type mockRemoteGitSession struct {
 	cwd           string
 	cwdErr        error
 	gitContexts   map[string]session.GitContext
+	gitErrs       map[string]error
 }
 
 func (m *mockRemoteGitSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
@@ -1260,9 +1261,19 @@ func (m *mockRemoteGitSession) GetActiveWorkdir() (string, error) {
 	return m.activeWorkdir, m.activeErr
 }
 func (m *mockRemoteGitSession) InspectGitContext(cwd string) (session.GitContext, error) {
+	if err, ok := m.gitErrs[cwd]; ok {
+		return session.GitContext{}, err
+	}
 	ctx, ok := m.gitContexts[cwd]
 	if !ok {
-		return session.GitContext{}, errors.New("not a git repo")
+		return session.GitContext{}, session.NewGitContextError(
+			"ssh",
+			"git rev-parse --show-toplevel",
+			cwd,
+			session.GitContextCauseNotGitRepo,
+			errors.New("Process exited with status 128"),
+			"fatal: not a git repository (or any of the parent directories): .git",
+		)
 	}
 	return ctx, nil
 }
@@ -1680,6 +1691,43 @@ func TestGetGitInfo_NotAGitRepo_IsGitFalse(t *testing.T) {
 	var resp gitInfoResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.False(t, resp.IsGit)
+}
+
+func TestGetGitInfo_NotAGitRepo_LogsCauseAndRemediation(t *testing.T) {
+	dir := t.TempDir()
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "local-log", typ: session.TypeLocal},
+		cwd:         dir,
+	})
+
+	var buf bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-log/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, buf.String(), `source="base context lookup"`)
+	assert.Contains(t, buf.String(), `cause="current directory is outside a Git repository"`)
+	assert.Contains(
+		t,
+		buf.String(),
+		`remediation="move the pane to a Git repository or worktree directory, `+
+			`or update the pane cwd to the repository root"`,
+	)
+	assert.Contains(t, buf.String(), `operation="git rev-parse --show-toplevel"`)
 }
 
 func TestGetGitInfo_IsGitRepo_ReturnsBranchAndRepo(t *testing.T) {
@@ -2160,6 +2208,49 @@ func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 	assert.Equal(t, "main", resp.Branch)
 	assert.Equal(t, "panemux", resp.Repo)
 	assert.Empty(t, resp.RepoURL)
+}
+
+func TestGetGitInfo_RemoteGitContextFailure_LogsCauseAndRemediation(t *testing.T) {
+	const remoteDir = "/home/demo"
+
+	mgr := session.NewManager()
+	mgr.Add(&mockRemoteGitSession{
+		mockSession: mockSession{id: "ssh-log", typ: session.TypeSSH},
+		cwd:         remoteDir,
+		gitErrs: map[string]error{
+			remoteDir: session.NewGitContextError(
+				"ssh",
+				"git rev-parse --show-toplevel",
+				remoteDir,
+				session.GitContextCauseNotGitRepo,
+				errors.New("Process exited with status 128"),
+				"fatal: not a git repository (or any of the parent directories): .git",
+			),
+		},
+	})
+
+	var buf bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-log/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, buf.String(), `source="base context lookup"`)
+	assert.Contains(t, buf.String(), `transport="ssh"`)
+	assert.Contains(t, buf.String(), `cause="current directory is outside a Git repository"`)
+	assert.Contains(t, buf.String(), `stderr="fatal: not a git repository (or any of the parent directories): .git"`)
 }
 
 func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T) {

--- a/internal/session/git_context_error.go
+++ b/internal/session/git_context_error.go
@@ -1,0 +1,124 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+)
+
+type GitContextErrorCause string
+
+const (
+	GitContextCauseNotGitRepo       GitContextErrorCause = "not_git_repo"
+	GitContextCauseGitNotInstalled  GitContextErrorCause = "git_not_installed"
+	GitContextCauseInvalidCWD       GitContextErrorCause = "invalid_cwd"
+	GitContextCauseSSHSessionFailed GitContextErrorCause = "ssh_session_failure"
+	GitContextCauseGitMetadata      GitContextErrorCause = "git_metadata_failure"
+	GitContextCauseIncomplete       GitContextErrorCause = "incomplete_response"
+	GitContextCauseUnknown          GitContextErrorCause = "unknown"
+)
+
+type GitContextError struct {
+	err          error
+	Transport    string
+	Operation    string
+	CWD          string
+	Cause        GitContextErrorCause
+	CauseMessage string
+	Remediation  string
+	RawError     string
+	Stderr       string
+}
+
+func NewGitContextError(
+	transport, operation, cwd string,
+	cause GitContextErrorCause,
+	err error,
+	stderr string,
+) *GitContextError {
+	causeMessage, remediation := gitContextErrorDefaults(cause)
+	raw := ""
+	if err != nil {
+		raw = strings.TrimSpace(err.Error())
+	}
+	return &GitContextError{
+		Transport:    transport,
+		Operation:    operation,
+		CWD:          cwd,
+		Cause:        cause,
+		CauseMessage: causeMessage,
+		Remediation:  remediation,
+		RawError:     raw,
+		Stderr:       strings.TrimSpace(stderr),
+		err:          err,
+	}
+}
+
+func (e *GitContextError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.RawError != "" {
+		return e.RawError
+	}
+	return fmt.Sprintf("git context inspection failed: %s", e.Cause)
+}
+
+func (e *GitContextError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func gitContextErrorDefaults(cause GitContextErrorCause) (string, string) {
+	switch cause {
+	case GitContextCauseNotGitRepo:
+		return "current directory is outside a Git repository",
+			"move the pane to a Git repository or worktree directory, or update the pane cwd to the repository root"
+	case GitContextCauseGitNotInstalled:
+		return "git is not installed or not available in PATH",
+			"install Git on the target host and ensure it is available in PATH"
+	case GitContextCauseInvalidCWD:
+		return "working directory is invalid for Git inspection",
+			"set the pane cwd to a valid absolute path without invalid characters"
+	case GitContextCauseSSHSessionFailed:
+		return "SSH command execution failed before Git context could be resolved",
+			"check SSH connectivity, authentication, and remote shell availability"
+	case GitContextCauseGitMetadata:
+		return "Git repository metadata could not be resolved",
+			"verify the repository or worktree is intact and that .git metadata points to valid paths"
+	case GitContextCauseIncomplete:
+		return "remote Git context command returned incomplete output",
+			"check the remote shell environment and rerun Git inspection in the target directory"
+	default:
+		return "Git context lookup failed for an unknown reason",
+			"inspect the raw error and stderr details to determine the next action"
+	}
+}
+
+func ClassifyGitFailureCause(stderr string, err error) GitContextErrorCause {
+	lowerStderr := strings.ToLower(strings.TrimSpace(stderr))
+	lowerErr := ""
+	if err != nil {
+		lowerErr = strings.ToLower(err.Error())
+	}
+
+	switch {
+	case strings.Contains(lowerStderr, "not a git repository"),
+		strings.Contains(lowerStderr, "not git repository"):
+		return GitContextCauseNotGitRepo
+	case strings.Contains(lowerStderr, "command not found"),
+		strings.Contains(lowerStderr, "git: not found"),
+		strings.Contains(lowerErr, "command not found"),
+		strings.Contains(lowerErr, "git: not found"):
+		return GitContextCauseGitNotInstalled
+	case strings.Contains(lowerStderr, "not a gitdir"),
+		strings.Contains(lowerStderr, "not a git repository:"),
+		strings.Contains(lowerStderr, "bad object"),
+		strings.Contains(lowerStderr, "invalid gitfile format"),
+		strings.Contains(lowerStderr, "unable to read"):
+		return GitContextCauseGitMetadata
+	default:
+		return GitContextCauseUnknown
+	}
+}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1098,6 +1098,9 @@ func classifyRemoteGitContextError(cwd, output string, err error) error {
 	if len(lines) >= 3 && lines[0] == marker {
 		operation := strings.TrimSpace(lines[1])
 		stderr := strings.TrimSpace(strings.Join(lines[2:], "\n"))
+		// Keep SSH-side unknowns as unknown. Unlike the local path, we cannot
+		// reliably distinguish a remote repository metadata problem from shell or
+		// environment differences once we only have stderr text back.
 		return NewGitContextError(
 			"ssh",
 			sshGitOperationName(operation),

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -709,8 +709,12 @@ const sshOpenFilesCmdTemplate = `{ ls -1 /proc/%[1]d/fd 2>/dev/null | ` +
 const sshPIDCWDCmdTemplate = `{ readlink /proc/%[1]d/cwd 2>/dev/null || ` +
 	`lsof -a -p %[1]d -d cwd -Fn 2>/dev/null | awk '/^n/{print substr($0,2)}'; }`
 const sshGitContextCmdTemplate = `cd %[1]s && ` +
-	`root=$(git rev-parse --show-toplevel) && ` +
-	`common=$(git rev-parse --path-format=absolute --git-common-dir) && ` +
+	`root=$(git rev-parse --show-toplevel 2>&1); status=$?; ` +
+	`if [ $status -ne 0 ]; then ` +
+	`printf '__PANEMUX_GIT_CONTEXT_ERROR__\nshow-toplevel\n%%s\n' "$root"; exit $status; fi && ` +
+	`common=$(git rev-parse --path-format=absolute --git-common-dir 2>&1); status=$?; ` +
+	`if [ $status -ne 0 ]; then ` +
+	`printf '__PANEMUX_GIT_CONTEXT_ERROR__\ngit-common-dir\n%%s\n' "$common"; exit $status; fi && ` +
 	`branch=$(git branch --show-current 2>/dev/null || true) && ` +
 	`origin=$(git config --get remote.origin.url 2>/dev/null || true) && ` +
 	`printf '%%s\n%%s\n%%s\n%%s\n' "$root" "$common" "$branch" "$origin"`
@@ -1046,17 +1050,31 @@ func remoteClaudeProjectReadCmd(meta *claudeSessionMeta) string {
 
 func remoteGitContext(runner sshSessionRunner, cwd string) (GitContext, error) {
 	if err := validateRemotePath("working directory", cwd); err != nil {
-		return GitContext{}, err
+		return GitContext{}, NewGitContextError(
+			"ssh",
+			"validate remote working directory",
+			cwd,
+			GitContextCauseInvalidCWD,
+			err,
+			"",
+		)
 	}
 
 	out, err := runner.Output(fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)))
 	if err != nil {
-		return GitContext{}, fmt.Errorf("git context over ssh: %w", err)
+		return GitContext{}, classifyRemoteGitContextError(cwd, string(out), err)
 	}
 
 	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
 	if len(lines) < 4 {
-		return GitContext{}, errors.New("git context over ssh: incomplete response")
+		return GitContext{}, NewGitContextError(
+			"ssh",
+			"git context command",
+			cwd,
+			GitContextCauseIncomplete,
+			errors.New("git context over ssh: incomplete response"),
+			string(out),
+		)
 	}
 
 	root := strings.TrimSpace(lines[0])
@@ -1067,6 +1085,41 @@ func remoteGitContext(runner sshSessionRunner, cwd string) (GitContext, error) {
 		Repo:      filepath.Base(root),
 		Root:      root,
 	}, nil
+}
+
+func classifyRemoteGitContextError(cwd, output string, err error) error {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return NewGitContextError("ssh", "git context command", cwd, GitContextCauseSSHSessionFailed, err, "")
+	}
+
+	const marker = "__PANEMUX_GIT_CONTEXT_ERROR__"
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) >= 3 && lines[0] == marker {
+		operation := strings.TrimSpace(lines[1])
+		stderr := strings.TrimSpace(strings.Join(lines[2:], "\n"))
+		return NewGitContextError(
+			"ssh",
+			sshGitOperationName(operation),
+			cwd,
+			ClassifyGitFailureCause(stderr, err),
+			err,
+			stderr,
+		)
+	}
+
+	return NewGitContextError("ssh", "git context command", cwd, GitContextCauseSSHSessionFailed, err, trimmed)
+}
+
+func sshGitOperationName(operation string) string {
+	switch operation {
+	case "show-toplevel":
+		return "git rev-parse --show-toplevel"
+	case "git-common-dir":
+		return "git rev-parse --path-format=absolute --git-common-dir"
+	default:
+		return "git context command"
+	}
 }
 
 func remoteOpenFiles(run remoteOutputFunc, pid int) ([]string, error) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -336,7 +336,7 @@ type fakeSSHRunner struct {
 
 func (f *fakeSSHRunner) Output(cmd string) ([]byte, error) {
 	if err := f.errs[cmd]; err != nil {
-		return nil, err
+		return f.outputs[cmd], err
 	}
 	if out, ok := f.outputs[cmd]; ok {
 		return out, nil
@@ -673,5 +673,50 @@ func TestRemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 func TestRemoteGitContext_RejectsRelativePath(t *testing.T) {
 	_, err := remoteGitContext(&fakeSSHRunner{}, "panemux")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "working directory")
+	var gitErr *GitContextError
+	require.ErrorAs(t, err, &gitErr)
+	assert.Equal(t, GitContextCauseInvalidCWD, gitErr.Cause)
+	assert.Equal(t, "validate remote working directory", gitErr.Operation)
+}
+
+func TestRemoteGitContext_NotGitRepoReturnsDiagnosticError(t *testing.T) {
+	const cwd = "/home/user"
+
+	runner := &fakeSSHRunner{
+		errs: map[string]error{
+			fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)): errors.New("Process exited with status 128"),
+		},
+		outputs: map[string][]byte{
+			fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)): []byte(
+				"__PANEMUX_GIT_CONTEXT_ERROR__\n" +
+					"show-toplevel\n" +
+					"fatal: not a git repository (or any of the parent directories): .git\n",
+			),
+		},
+	}
+
+	_, err := remoteGitContext(runner, cwd)
+	require.Error(t, err)
+	var gitErr *GitContextError
+	require.ErrorAs(t, err, &gitErr)
+	assert.Equal(t, GitContextCauseNotGitRepo, gitErr.Cause)
+	assert.Equal(t, "git rev-parse --show-toplevel", gitErr.Operation)
+	assert.Equal(t, "fatal: not a git repository (or any of the parent directories): .git", gitErr.Stderr)
+}
+
+func TestRemoteGitContext_IncompleteResponseReturnsDiagnosticError(t *testing.T) {
+	const cwd = "/home/user/panemux"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			fmt.Sprintf(sshGitContextCmdTemplate, shellQuotePath(cwd)): []byte("/home/user/panemux\n"),
+		},
+	}
+
+	_, err := remoteGitContext(runner, cwd)
+	require.Error(t, err)
+	var gitErr *GitContextError
+	require.ErrorAs(t, err, &gitErr)
+	assert.Equal(t, GitContextCauseIncomplete, gitErr.Cause)
+	assert.Equal(t, "/home/user/panemux", gitErr.Stderr)
 }


### PR DESCRIPTION
## Summary
- improve git context lookup errors with structured cause, remediation, and execution details
- classify local and SSH git inspection failures and capture stderr for diagnostics
- add regression tests for local and remote git-info failure logging

## Test plan
- [x] `go test ./internal/session ./internal/api`
- [x] `make test-go`
- [x] `make lint-go`
