### PR TITLE
fix: prefer claude transcript cwd for workdir detection

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -482,7 +482,10 @@ When a pane moves to a different parent node, the component may be remounted by 
 - This ordering exists because the interactive Codex process and its thread metadata may stay on the original pane directory even while tool calls are executing inside a sibling Git worktree.
 - If future Codex versions change their session-log schema or start updating `turn_context.cwd` to the active worktree reliably, compare the three fields above before changing panemux's resolver order.
 - For interactive Claude flows across all four pane types, panemux may derive the active worktree from `~/.claude/sessions/<pid>.json` plus the matching transcript under `~/.claude/projects/...`.
-- Claude transcript resolution prefers the latest non-auxiliary tracked file path or `Bash` tool `cd ... &&` target recorded in that transcript.
+- Claude session metadata is used only to identify the matching transcript (`sessionId`) and project directory key.
+- Claude transcript resolution prefers the latest top-level `cwd` recorded on transcript entries such as `user`, `assistant`, `attachment`, and `system`.
+- When a Claude transcript entry does not expose top-level `cwd`, panemux falls back to the latest non-auxiliary tool file path, then the latest `Bash` tool `cd ... &&` target, then file-history snapshot paths.
+- This resolver intentionally does not depend on Claude `hooks` or `statusLine` configuration, so no extra Claude-side setup is required for pane-header Git or PR detection.
 - If the agent exits, no longer has an eligible worktree, or the resolved worktree is not a sibling worktree of the pane's current repository, panemux falls back to the pane's own working directory immediately.
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
 - For SSH+tmux panes, panemux resolves interactive agent processes only from the currently active remote tmux pane.

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -670,26 +670,35 @@ func readClaudeProjectCWD(path string) (string, error) {
 
 func parseClaudeProjectCWD(data []byte) (string, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
-	var latest claudePathCandidate
+	var latestCWD string
+	var latestPath claudePathCandidate
 	for scanner.Scan() {
-		if candidate := claudeRecordPath(scanner.Bytes()); candidate.Path != "" {
-			latest = candidate
+		cwd, candidate := claudeRecordPath(scanner.Bytes())
+		if cwd != "" {
+			latestCWD = cwd
+		}
+		if candidate.Path != "" {
+			latestPath = candidate
 		}
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("scan claude transcript: %w", err)
 	}
-	if latest.Path == "" {
+	if latestCWD != "" {
+		return latestCWD, nil
+	}
+	if latestPath.Path == "" {
 		return "", nil
 	}
-	if latest.IsDir {
-		return latest.Path, nil
+	if latestPath.IsDir {
+		return latestPath.Path, nil
 	}
-	return filepath.Dir(latest.Path), nil
+	return filepath.Dir(latestPath.Path), nil
 }
 
 type claudeProjectRecord struct {
 	Type     string `json:"type"`
+	CWD      string `json:"cwd"`
 	Snapshot struct {
 		TrackedFileBackups map[string]json.RawMessage `json:"trackedFileBackups"`
 	} `json:"snapshot"`
@@ -703,19 +712,19 @@ type claudePathCandidate struct {
 	IsDir bool
 }
 
-func claudeRecordPath(line []byte) claudePathCandidate {
+func claudeRecordPath(line []byte) (string, claudePathCandidate) {
 	var rec claudeProjectRecord
 	if err := json.Unmarshal(line, &rec); err != nil {
-		return claudePathCandidate{}
+		return "", claudePathCandidate{}
 	}
 
 	switch rec.Type {
 	case "file-history-snapshot":
-		return claudePathCandidate{Path: latestClaudeTrackedPath(rec.Snapshot.TrackedFileBackups)}
+		return rec.CWD, claudePathCandidate{Path: latestClaudeTrackedPath(rec.Snapshot.TrackedFileBackups)}
 	case "assistant":
-		return latestClaudeToolPath(rec.Message.Content)
+		return rec.CWD, latestClaudeToolPath(rec.Message.Content)
 	default:
-		return claudePathCandidate{}
+		return rec.CWD, claudePathCandidate{}
 	}
 }
 

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -347,6 +347,49 @@ func TestParseClaudeProjectCWD_PrefersLatestTrackedFileBackup(t *testing.T) {
 	assert.Equal(t, worktreeDir, cwd)
 }
 
+func TestParseClaudeProjectCWD_PrefersLatestTopLevelCWD(t *testing.T) {
+	data := []byte("" +
+		"{\"type\":\"user\",\"cwd\":\"/repo/main\"}\n" +
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n" +
+		"{\"type\":\"system\",\"subtype\":\"turn_duration\",\"cwd\":\"/tmp/worktree-b\"}\n")
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-b", cwd)
+}
+
+func TestParseClaudeProjectCWD_PrefersTopLevelCWDOverToolPaths(t *testing.T) {
+	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
+	targetFile := filepath.Join(worktreeDir, "AGENTS.md")
+	require.NoError(t, os.WriteFile(targetFile, []byte("test"), 0600))
+
+	data := []byte("" +
+		"{\"type\":\"assistant\",\"cwd\":\"/repo/main\",\"message\":{\"content\":[" +
+		"{\"type\":\"tool_use\",\"name\":\"Read\",\"input\":{\"file_path\":\"" + targetFile + "\"}}" +
+		"]}}\n")
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main", cwd)
+}
+
+func TestParseClaudeProjectCWD_FallsBackWhenTopLevelCWDMissing(t *testing.T) {
+	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
+	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
+
+	data := []byte(
+		"{\"type\":\"assistant\",\"message\":{\"content\":[" +
+			"{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"cd " +
+			worktreeDir +
+			" && git status\"}}]}}\n",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, worktreeDir, cwd)
+}
+
 func TestParseClaudeProjectCWD_PrefersBashCDWorktree(t *testing.T) {
 	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
 	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
@@ -613,13 +656,8 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 
 	transcriptPath := filepath.Join(homeDir, ".claude", "projects", "-repo-main", "session-123.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
-	worktreeFile := filepath.Join(t.TempDir(), "panemux-worktree", "AGENTS.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
-	require.NoError(t, os.WriteFile(worktreeFile, []byte("test"), 0600))
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(
-		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\""+
-			worktreeFile+
-			"\":{}}}}\n",
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 	), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {
@@ -641,7 +679,7 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 
 	cwd, err := sess.GetActiveWorkdir()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+	assert.Equal(t, "/tmp/panemux-worktree", cwd)
 }
 
 func TestClaudeProjectDirName_NormalizesDots(t *testing.T) {
@@ -682,13 +720,8 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree_WithDotInCWD(t *testin
 		"session-123.jsonl",
 	)
 	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
-	worktreeFile := filepath.Join(t.TempDir(), "panemux-worktree", "AGENTS.md")
-	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeFile), 0755))
-	require.NoError(t, os.WriteFile(worktreeFile, []byte("test"), 0600))
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(
-		"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\""+
-			worktreeFile+
-			"\":{}}}}\n",
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 	), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {
@@ -708,7 +741,7 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree_WithDotInCWD(t *testin
 
 	cwd, err := sess.GetActiveWorkdir()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+	assert.Equal(t, "/tmp/panemux-worktree", cwd)
 }
 
 func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -350,7 +350,8 @@ func TestParseClaudeProjectCWD_PrefersLatestTrackedFileBackup(t *testing.T) {
 func TestParseClaudeProjectCWD_PrefersLatestTopLevelCWD(t *testing.T) {
 	data := []byte("" +
 		"{\"type\":\"user\",\"cwd\":\"/repo/main\"}\n" +
-		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n" +
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\"," +
+		"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n" +
 		"{\"type\":\"system\",\"subtype\":\"turn_duration\",\"cwd\":\"/tmp/worktree-b\"}\n")
 
 	cwd, err := parseClaudeProjectCWD(data)
@@ -657,7 +658,8 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 	transcriptPath := filepath.Join(homeDir, ".claude", "projects", "-repo-main", "session-123.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(
-		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\","+
+			"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 	), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {
@@ -721,7 +723,8 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree_WithDotInCWD(t *testin
 	)
 	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
 	require.NoError(t, os.WriteFile(transcriptPath, []byte(
-		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/panemux-worktree\","+
+			"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 	), 0600))
 
 	listProcessesFn = func() ([]processInfo, error) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -352,11 +352,12 @@ func TestParseClaudeProjectCWD_PrefersLatestTopLevelCWD(t *testing.T) {
 		"{\"type\":\"user\",\"cwd\":\"/repo/main\"}\n" +
 		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\"," +
 		"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}\n" +
-		"{\"type\":\"system\",\"subtype\":\"turn_duration\",\"cwd\":\"/tmp/worktree-b\"}\n")
+		"{\"type\":\"attachment\",\"cwd\":\"/tmp/worktree-b\"}\n" +
+		"{\"type\":\"system\",\"subtype\":\"turn_duration\",\"cwd\":\"/tmp/worktree-c\"}\n")
 
 	cwd, err := parseClaudeProjectCWD(data)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/worktree-b", cwd)
+	assert.Equal(t, "/tmp/worktree-c", cwd)
 }
 
 func TestParseClaudeProjectCWD_PrefersTopLevelCWDOverToolPaths(t *testing.T) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -419,7 +419,8 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
 			projectCmd: []byte(
-				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 			),
 		},
 	}
@@ -438,7 +439,8 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/home/tomo.chan/repo/main"}`),
 			projectCmd: []byte(
-				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 			),
 		},
 	}

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -413,16 +413,13 @@ func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T) {
 	sessionPath := "~/.claude/sessions/220.json"
 	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
-	worktreeFile := "/tmp/remote-claude-worktree/AGENTS.md"
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
 			projectCmd: []byte(
-				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
-					worktreeFile +
-					"\":{}}}}\n",
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 			),
 		},
 	}
@@ -435,16 +432,13 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(t *testing.T) {
 	sessionPath := "~/.claude/sessions/220.json"
 	projectCmd := "cat ~/.claude/projects/'-home-tomo-chan-repo-main/session-123.jsonl'"
-	worktreeFile := "/tmp/remote-claude-worktree/AGENTS.md"
 
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
 			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
 			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/home/tomo.chan/repo/main"}`),
 			projectCmd: []byte(
-				"{\"type\":\"file-history-snapshot\",\"snapshot\":{\"trackedFileBackups\":{\"" +
-					worktreeFile +
-					"\":{}}}}\n",
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 			),
 		},
 	}
@@ -452,6 +446,28 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(
 	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
+}
+
+func TestActiveRemoteWorkdir_PrefersRemoteClaudeTopLevelCWDOverToolPaths(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/main\",\"message\":{\"content\":[" +
+					"{\"type\":\"tool_use\",\"name\":\"Bash\"," +
+					"\"input\":{\"command\":\"cd /tmp/remote-bash-worktree && git status\"}}" +
+					"]}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main", cwd)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {


### PR DESCRIPTION
## Summary

- prefer Claude transcript top-level `cwd` when resolving active agent workdir
- keep tracked file paths and `Bash` `cd ... &&` parsing as fallback for older transcripts
- document the updated Claude workdir resolution behavior

## Testing

- `go test ./internal/session`
- `make test-go`
