### PR TITLE
fix: add cross-platform tmux selection modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Common uses:
 
 - A pane with `connection: my-host` can use either a named `ssh_connections` entry or a `Host my-host` entry from `~/.ssh/config`.
 - `tmux` and `ssh_tmux` panes automatically create the target tmux session if it does not already exist.
+- In `tmux` and `ssh_tmux` panes, plain drag continues to follow tmux mouse behavior. Use `Option` + drag on macOS or `Shift` + drag on Linux and Windows to force browser-side text selection.
 - Set `cwd` on `local`, `ssh`, or `ssh_tmux` panes when you want the shell to start in a specific directory.
 - In the pane settings dialog, `Working Directory` can be chosen from a browsable directory tree for both local and SSH-backed panes. Hidden directories are available through a toggle.
 - Pane headers resolve Git and PR metadata from the live working context, including interactive `codex` and `claude` worktrees for both local and SSH-backed panes. When a valid sibling worktree was detected recently, panemux keeps that worktree pinned after the agent exits until the pane moves to a different repository context. `tmux` and `ssh_tmux` use the currently active tmux pane only.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -155,6 +155,11 @@ Remote Git inspection currently depends on `git rev-parse --path-format=absolute
 on the SSH target, which requires Git 2.31 or newer. Older remote Git versions degrade to "no git
 info" in the pane header for SSH-backed panes.
 
+For terminal text selection, panemux keeps tmux mouse mode unchanged for `tmux` and `ssh_tmux`
+panes. Plain drag therefore continues to follow tmux mouse behavior, while macOS users can hold
+`Option` during drag to force browser-side xterm selection and copy text without changing tmux
+session settings.
+
 ## REST API
 
 ### `GET /api/layout`

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -156,9 +156,9 @@ on the SSH target, which requires Git 2.31 or newer. Older remote Git versions d
 info" in the pane header for SSH-backed panes.
 
 For terminal text selection, panemux keeps tmux mouse mode unchanged for `tmux` and `ssh_tmux`
-panes. Plain drag therefore continues to follow tmux mouse behavior, while macOS users can hold
-`Option` during drag to force browser-side xterm selection and copy text without changing tmux
-session settings.
+panes. Plain drag therefore continues to follow tmux mouse behavior. To force browser-side xterm
+selection while tmux mouse mode is active, hold `Option` during drag on macOS or `Shift` during
+drag on Linux and Windows.
 
 ## REST API
 

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -139,6 +139,16 @@ describe('useTerminal', () => {
     expect(TERMINAL_FONT_FAMILY).toContain('Hiragino Sans')
   })
 
+  it('enables Option-drag selection when terminal apps turn on mouse mode', () => {
+    const container = makeContainer()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    expect(mockTerminalCtor).toHaveBeenCalledWith(expect.objectContaining({
+      macOptionClickForcesSelection: true,
+    }))
+  })
+
   it('loads all addons on init', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -139,7 +139,7 @@ describe('useTerminal', () => {
     expect(TERMINAL_FONT_FAMILY).toContain('Hiragino Sans')
   })
 
-  it('enables Option-drag selection when terminal apps turn on mouse mode', () => {
+  it('enables forced selection for tmux mouse mode across platforms', () => {
     const container = makeContainer()
 
     renderHook(() => useTerminal({ sessionId: 's1', container }))

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -279,6 +279,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     customGlyphs: true,
     fontSize: 14,
     fontFamily: TERMINAL_FONT_FAMILY,
+    macOptionClickForcesSelection: true,
     // Hide xterm.js accessibility textarea (still exists for IME/a11y but invisible)
     screenReaderMode: false,
     theme: {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -279,8 +279,8 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     customGlyphs: true,
     fontSize: 14,
     fontFamily: TERMINAL_FONT_FAMILY,
-    // xterm uses Shift-drag for forced selection on non-macOS and can be
-    // configured to use Option-drag on macOS while terminal mouse mode is active.
+    // xterm supports Shift-drag for forced selection by default; this option
+    // additionally enables Option-drag on macOS while terminal mouse mode is active.
     macOptionClickForcesSelection: true,
     // Hide xterm.js accessibility textarea (still exists for IME/a11y but invisible)
     screenReaderMode: false,

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -279,6 +279,8 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     customGlyphs: true,
     fontSize: 14,
     fontFamily: TERMINAL_FONT_FAMILY,
+    // xterm uses Shift-drag for forced selection on non-macOS and can be
+    // configured to use Option-drag on macOS while terminal mouse mode is active.
     macOptionClickForcesSelection: true,
     // Hide xterm.js accessibility textarea (still exists for IME/a11y but invisible)
     screenReaderMode: false,


### PR DESCRIPTION
## Summary

- enable xterm forced selection support for tmux-backed panes
- document the platform-specific modifier for browser-side selection
- keep tmux mouse mode unchanged while preserving a reliable copy path

## Why

tmux mouse mode intercepts plain drag selection in `tmux` and `ssh_tmux` panes. This keeps tmux mouse behavior intact while exposing the browser-side forced-selection path that xterm already supports.

## Impact

- plain drag in `tmux` and `ssh_tmux` panes still follows tmux mouse behavior
- macOS users can hold `Option` while dragging to force browser-side selection
- Linux and Windows users can hold `Shift` while dragging to force browser-side selection
- no backend, API, or config changes

## Validation

- [x] `make test-frontend`
- [x] `make check`
