### PR TITLE
fix: add cross-platform tmux selection modifier

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -155,6 +155,11 @@ Remote Git inspection currently depends on `git rev-parse --path-format=absolute
 on the SSH target, which requires Git 2.31 or newer. Older remote Git versions degrade to "no git
 info" in the pane header for SSH-backed panes.
 
+For terminal text selection, panemux keeps tmux mouse mode unchanged for `tmux` and `ssh_tmux`
+panes. Plain drag therefore continues to follow tmux mouse behavior. To force browser-side xterm
+selection while tmux mouse mode is active, hold `Option` during drag on macOS or `Shift` during
+drag on Linux and Windows.
+
 ## REST API
 
 ### `GET /api/layout`

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -139,6 +139,16 @@ describe('useTerminal', () => {
     expect(TERMINAL_FONT_FAMILY).toContain('Hiragino Sans')
   })
 
+  it('enables forced selection for tmux mouse mode across platforms', () => {
+    const container = makeContainer()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    expect(mockTerminalCtor).toHaveBeenCalledWith(expect.objectContaining({
+      macOptionClickForcesSelection: true,
+    }))
+  })
+
   it('loads all addons on init', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -279,6 +279,9 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     customGlyphs: true,
     fontSize: 14,
     fontFamily: TERMINAL_FONT_FAMILY,
+    // xterm uses Shift-drag for forced selection on non-macOS and can be
+    // configured to use Option-drag on macOS while terminal mouse mode is active.
+    macOptionClickForcesSelection: true,
     // Hide xterm.js accessibility textarea (still exists for IME/a11y but invisible)
     screenReaderMode: false,
     theme: {


### PR DESCRIPTION
## Summary

- enable xterm forced selection support for tmux-backed panes
- document the platform-specific modifier for browser-side selection
- keep tmux mouse mode unchanged while preserving a reliable copy path

## Why

tmux mouse mode was still intercepting plain drag selection. The previous change only documented the macOS `Option` path; this update makes the behavior explicit across platforms by documenting the matching non-macOS modifier path as well.

## Impact

- plain drag in `tmux` and `ssh_tmux` panes still follows tmux mouse behavior
- macOS users can hold `Option` while dragging to force browser-side selection
- Linux and Windows users can hold `Shift` while dragging to force browser-side selection
- no backend, API, or config changes

## Validation

- [x] `make test-frontend`
- [x] `make check`
