### PR TITLE
fix: handle large interactive agent session logs

### DIFF
--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -566,15 +565,13 @@ type codexSessionRecord struct {
 }
 
 func parseCodexSessionCWD(data []byte) (string, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-
 	var latestTurnCWD string
 	var sessionMetaCWD string
 	var latestExecWorkdir string
-	for scanner.Scan() {
+	forEachJSONLRecord(data, func(line []byte) {
 		var rec codexSessionRecord
-		if err := json.Unmarshal(scanner.Bytes(), &rec); err != nil {
-			continue
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return
 		}
 		execWorkdir, turnCWD, metaCWD := codexSessionRecordCWD(rec)
 		if execWorkdir != "" {
@@ -586,10 +583,7 @@ func parseCodexSessionCWD(data []byte) (string, error) {
 		if metaCWD != "" && sessionMetaCWD == "" {
 			sessionMetaCWD = metaCWD
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("scan codex session log: %w", err)
-	}
+	})
 	// Codex may keep both process cwd and turn/session metadata pinned to the
 	// original pane directory while tool calls run inside a sibling worktree.
 	// The latest exec_command workdir is therefore the strongest signal.
@@ -669,21 +663,17 @@ func readClaudeProjectCWD(path string) (string, error) {
 }
 
 func parseClaudeProjectCWD(data []byte) (string, error) {
-	scanner := bufio.NewScanner(bytes.NewReader(data))
 	var latestCWD string
 	var latestPath claudePathCandidate
-	for scanner.Scan() {
-		cwd, candidate := claudeRecordPath(scanner.Bytes())
+	forEachJSONLRecord(data, func(line []byte) {
+		cwd, candidate := claudeRecordPath(line)
 		if cwd != "" {
 			latestCWD = cwd
 		}
 		if candidate.Path != "" {
 			latestPath = candidate
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("scan claude transcript: %w", err)
-	}
+	})
 	if latestCWD != "" {
 		return latestCWD, nil
 	}
@@ -694,6 +684,24 @@ func parseClaudeProjectCWD(data []byte) (string, error) {
 		return latestPath.Path, nil
 	}
 	return filepath.Dir(latestPath.Path), nil
+}
+
+func forEachJSONLRecord(data []byte, fn func([]byte)) {
+	for len(data) > 0 {
+		line := data
+		if idx := bytes.IndexByte(data, '\n'); idx >= 0 {
+			line = data[:idx]
+			data = data[idx+1:]
+		} else {
+			data = nil
+		}
+
+		line = bytes.TrimSuffix(line, []byte{'\r'})
+		if len(line) == 0 {
+			continue
+		}
+		fn(line)
+	}
 }
 
 type claudeProjectRecord struct {

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -686,6 +686,9 @@ func parseClaudeProjectCWD(data []byte) (string, error) {
 	return filepath.Dir(latestPath.Path), nil
 }
 
+// forEachJSONLRecord iterates over already-buffered JSONL data without using
+// bufio.Scanner, so it cannot surface Scanner's token-size limit.
+// It also preserves a final unterminated record.
 func forEachJSONLRecord(data []byte, fn func([]byte)) {
 	for len(data) > 0 {
 		line := data

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,6 +329,20 @@ func TestReadCodexSessionCWD_PrefersExecCommandWorkdirEvenWhenTurnContextAppears
 	assert.Equal(t, "/tmp/worktree-from-command", cwd)
 }
 
+func TestParseCodexSessionCWD_LargeExecCommandRecord(t *testing.T) {
+	data := []byte(
+		codexExecCommandRecord(
+			t,
+			"printf '%s' '"+strings.Repeat("x", 70_000)+"'",
+			"/tmp/worktree-from-large-command",
+		),
+	)
+
+	cwd, err := parseCodexSessionCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-from-large-command", cwd)
+}
+
 func TestParseClaudeProjectCWD_PrefersLatestTrackedFileBackup(t *testing.T) {
 	worktreeDir := filepath.Join(t.TempDir(), "panemux-worktree")
 	require.NoError(t, os.MkdirAll(worktreeDir, 0755))
@@ -407,6 +422,18 @@ func TestParseClaudeProjectCWD_PrefersBashCDWorktree(t *testing.T) {
 	cwd, err := parseClaudeProjectCWD(data)
 	require.NoError(t, err)
 	assert.Equal(t, worktreeDir, cwd)
+}
+
+func TestParseClaudeProjectCWD_LargeTopLevelCWDRecord(t *testing.T) {
+	data := []byte(
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-from-large-record\",\"message\":{\"content\":[" +
+			"{\"type\":\"text\",\"text\":\"" + strings.Repeat("x", 70_000) + "\"}" +
+			"]}}\n",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-from-large-record", cwd)
 }
 
 func TestLatestClaudeTrackedPath_IsDeterministic(t *testing.T) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -436,6 +436,18 @@ func TestParseClaudeProjectCWD_LargeTopLevelCWDRecord(t *testing.T) {
 	assert.Equal(t, "/tmp/worktree-from-large-record", cwd)
 }
 
+func TestParseClaudeProjectCWD_LargeTopLevelCWDRecord_WithoutTrailingNewline(t *testing.T) {
+	data := []byte(
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-without-trailing-newline\",\"message\":{\"content\":[" +
+			"{\"type\":\"text\",\"text\":\"" + strings.Repeat("x", 70_000) + "\"}" +
+			"]}}",
+	)
+
+	cwd, err := parseClaudeProjectCWD(data)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-without-trailing-newline", cwd)
+}
+
 func TestLatestClaudeTrackedPath_IsDeterministic(t *testing.T) {
 	backups := map[string]json.RawMessage{
 		"/tmp/repo-main/AGENTS.md":       {},


### PR DESCRIPTION
## Summary

- replace Scanner-based interactive agent session JSONL parsing with a size-safe line iterator
- apply the fix to both Codex session logs and Claude transcript parsing so large single-line records no longer fail workdir detection
- add regression tests covering records larger than 64 KiB for both parsers

## Root cause

Both parsers used bufio.Scanner, which aborts on tokens larger than its default limit and surfaced as token too long errors during interactive agent workdir lookup.

## Validation

- make build-frontend
- make test-go
- make lint-go
