### PR TITLE
fix: reduce git-info polling and session log reads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,6 +179,11 @@ cross-repository reuse.
 
 For interactive Codex sessions, all four session implementations (`local`, `ssh`, `tmux`, and `ssh_tmux`) may inspect the open Codex session log under `~/.codex/sessions/...jsonl` when the Codex process has that file open. Panemux currently prefers the latest `exec_command.arguments.workdir` recorded in `response_item` / `function_call` log entries, then falls back to `turn_context.cwd`, then `session_meta.cwd`.
 
+To avoid repeatedly reparsing unchanged agent logs, panemux caches the last resolved workdir per
+session-log path fingerprint. Local sessions use file size plus modtime; SSH-backed sessions ask
+the remote host for lightweight file metadata first and only transfer the full `jsonl` contents
+again when that fingerprint changes.
+
 This ordering is intentional and reflects observed Codex behavior as of `codex-tui` `0.130.0`:
 
 - the interactive Codex process may keep its OS-level process cwd at the original pane directory

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -145,11 +145,23 @@ For pane-header Git status, local and local tmux panes inspect the local filesys
 and `ssh_tmux` panes run the equivalent Git inspection on the remote host. This allows headers to
 show branch/repository info even when the repository exists only on the SSH target.
 
+Pane-header Git and PR metadata is fetched immediately when a pane becomes visible, then refreshed
+every 10 seconds only while both the browser tab and that pane remain visible.
+
+When a pane is hidden behind maximize, its header Git/PR polling stops until it becomes visible
+again. Restoring the browser tab or making a pane visible again triggers an immediate refresh so
+newly created PR links become clickable without waiting for the next steady-state poll.
+
 When panemux detects that an interactive `codex` or `claude` session is operating in a sibling Git
 worktree for the same repository, pane-header Git/PR metadata and the VS Code open action prefer
 that worktree. After the agent exits, panemux keeps the last valid sibling worktree pinned for that
 pane session until a newer valid sibling worktree is detected or the pane itself changes to a
 different repository.
+
+To avoid repeatedly transferring and parsing unchanged interactive-agent logs, panemux reuses the
+last parsed Codex or Claude worktree result while the underlying session-log or transcript file
+fingerprint remains unchanged. For SSH-backed panes this check uses remote file metadata first and
+only reads the full `jsonl` contents again when the fingerprint changes.
 
 Remote Git inspection currently depends on `git rev-parse --path-format=absolute --git-common-dir`
 on the SSH target, which requires Git 2.31 or newer. Older remote Git versions degrade to "no git

--- a/frontend/src/components/TerminalPane.test.tsx
+++ b/frontend/src/components/TerminalPane.test.tsx
@@ -12,12 +12,15 @@ vi.stubGlobal('ResizeObserver', ResizeObserverMock)
 const { mockUseTerminal } = vi.hoisted(() => ({
   mockUseTerminal: vi.fn(),
 }))
+const { mockUseGitInfo } = vi.hoisted(() => ({
+  mockUseGitInfo: vi.fn(),
+}))
 
 vi.mock('../hooks/useTerminal', () => ({
   useTerminal: mockUseTerminal,
 }))
 vi.mock('../hooks/useGitInfo', () => ({
-  useGitInfo: () => ({ is_git: false }),
+  useGitInfo: mockUseGitInfo,
 }))
 import { dropZoneStyle, PANE_DROP_ZONE_RATIO, resolvePaneDropEdge, TerminalPane } from './TerminalPane'
 import { LayoutActionsContext, type LayoutActionsContextValue } from './SplitContainer'
@@ -32,6 +35,7 @@ describe('TerminalPane drop zones', () => {
       reconnectFailed: false,
       restartSession: vi.fn(),
     })
+    mockUseGitInfo.mockReturnValue({ is_git: false })
   })
 
   it('uses a top or bottom half-pane preview for horizontal edge drop zones', () => {
@@ -139,6 +143,26 @@ describe('TerminalPane drop zones', () => {
 
     expect(getByRole('button', { name: 'Reconnect Session' })).toBeInTheDocument()
     expect(queryByRole('button', { name: 'Restart Session' })).toBeNull()
+  })
+
+  it('disables git polling for panes hidden behind maximize', () => {
+    render(
+      <LayoutActionsContext.Provider value={makeCtx({ maximizedPaneId: 'other-pane' })}>
+        <TerminalPane pane={{ id: 'pane-1', type: 'local', title: 'Pane 1' }} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    expect(mockUseGitInfo).toHaveBeenCalledWith('pane-1', false)
+  })
+
+  it('keeps git polling enabled for the maximized pane', () => {
+    render(
+      <LayoutActionsContext.Provider value={makeCtx({ maximizedPaneId: 'pane-1' })}>
+        <TerminalPane pane={{ id: 'pane-1', type: 'local', title: 'Pane 1' }} />
+      </LayoutActionsContext.Provider>,
+    )
+
+    expect(mockUseGitInfo).toHaveBeenCalledWith('pane-1', true)
   })
 })
 

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -29,13 +29,14 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const hasAttention = ctx?.hasPaneAttention(pane.id) ?? false
   const isDragSource = ctx?.dragSourcePaneId === pane.id
   const dragActive = Boolean(ctx?.dragSourcePaneId)
+  const gitInfoEnabled = !ctx?.maximizedPaneId || ctx.maximizedPaneId === pane.id
 
   const { handleResize, connected, dims, sessionState, reconnectFailed, restartSession } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
   })
 
-  const gitInfo = useGitInfo(pane.id)
+  const gitInfo = useGitInfo(pane.id, gitInfoEnabled)
 
   // Observe resize events for this pane
   useEffect(() => {

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -1,9 +1,17 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { useGitInfo } from './useGitInfo'
 
 describe('useGitInfo', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+  })
+
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -52,13 +60,76 @@ describe('useGitInfo', () => {
     expect(window.fetch).toHaveBeenCalledWith('/api/sessions/my-session-id/git-info')
   })
 
-  it('registers a 5-second polling interval', () => {
+  it('registers a 10-second polling interval', () => {
+    vi.useFakeTimers()
     const intervalSpy = vi.spyOn(window, 'setInterval')
     window.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
 
     renderHook(() => useGitInfo('pane1'))
 
-    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
+    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 10000)
+  })
+
+  it('does not fetch while disabled', () => {
+    window.fetch = vi.fn()
+
+    renderHook(() => useGitInfo('pane1', false))
+
+    expect(window.fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches immediately when re-enabled', async () => {
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    const { rerender } = renderHook(({ enabled }) => useGitInfo('pane1', enabled), {
+      initialProps: { enabled: false },
+    })
+
+    expect(window.fetch).not.toHaveBeenCalled()
+
+    rerender({ enabled: true })
+
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
+  })
+
+  it('stops polling while the document is hidden and refetches on visibility restore', async () => {
+    vi.useFakeTimers()
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    renderHook(() => useGitInfo('pane1'))
+
+    await act(async () => {})
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    act(() => {
+      vi.advanceTimersByTime(10000)
+    })
+
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {})
+    expect(window.fetch).toHaveBeenCalledTimes(2)
   })
 
   it('silently ignores fetch errors — state stays at default', async () => {

--- a/frontend/src/hooks/useGitInfo.ts
+++ b/frontend/src/hooks/useGitInfo.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import { GitInfo, GitInfoSchema } from '../schemas'
 
-export function useGitInfo(sessionId: string): GitInfo {
+const GIT_INFO_POLL_INTERVAL_MS = 10000
+
+export function useGitInfo(sessionId: string, enabled = true): GitInfo {
   const [gitInfo, setGitInfo] = useState<GitInfo>({ is_git: false })
+  const [isVisible, setIsVisible] = useState(() => document.visibilityState === 'visible')
 
   const fetchGitInfo = useCallback(async () => {
     try {
@@ -16,10 +19,21 @@ export function useGitInfo(sessionId: string): GitInfo {
   }, [sessionId])
 
   useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsVisible(document.visibilityState === 'visible')
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }, [])
+
+  useEffect(() => {
+    if (!enabled || !isVisible) return
+
     fetchGitInfo()
-    const interval = setInterval(fetchGitInfo, 5000)
+    const interval = setInterval(fetchGitInfo, GIT_INFO_POLL_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [fetchGitInfo])
+  }, [enabled, fetchGitInfo, isVisible])
 
   return gitInfo
 }

--- a/internal/session/agent_log_cache.go
+++ b/internal/session/agent_log_cache.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+type agentLogFingerprint string
+
+type agentLogCacheEntry struct {
+	cwd         string
+	fingerprint agentLogFingerprint
+}
+
+var agentLogCache = struct {
+	mu      sync.Mutex
+	entries map[string]agentLogCacheEntry
+}{
+	entries: make(map[string]agentLogCacheEntry),
+}
+
+var statFileFn = os.Stat
+
+func resetAgentLogCache() {
+	agentLogCache.mu.Lock()
+	defer agentLogCache.mu.Unlock()
+
+	agentLogCache.entries = make(map[string]agentLogCacheEntry)
+}
+
+func cachedAgentLogCWD(
+	cacheKey string,
+	fingerprint agentLogFingerprint,
+	load func() (string, error),
+) (string, error) {
+	agentLogCache.mu.Lock()
+	entry, ok := agentLogCache.entries[cacheKey]
+	agentLogCache.mu.Unlock()
+
+	if ok && entry.fingerprint == fingerprint {
+		return entry.cwd, nil
+	}
+
+	cwd, err := load()
+	if err != nil {
+		return "", err
+	}
+
+	agentLogCache.mu.Lock()
+	agentLogCache.entries[cacheKey] = agentLogCacheEntry{
+		cwd:         cwd,
+		fingerprint: fingerprint,
+	}
+	agentLogCache.mu.Unlock()
+
+	return cwd, nil
+}
+
+func localFileFingerprint(path string) (agentLogFingerprint, error) {
+	info, err := statFileFn(path)
+	if err != nil {
+		return "", err
+	}
+	return agentLogFingerprint(fmt.Sprintf("%d:%d", info.Size(), info.ModTime().UnixNano())), nil
+}

--- a/internal/session/agent_log_cache.go
+++ b/internal/session/agent_log_cache.go
@@ -25,10 +25,7 @@ var agentLogCache = agentLogCacheStore{
 var statFileFn = os.Stat
 
 func resetAgentLogCache() {
-	agentLogCache.mu.Lock()
-	defer agentLogCache.mu.Unlock()
-
-	agentLogCache.entries = make(map[string]agentLogCacheEntry)
+	agentLogCache.reset()
 }
 
 func cachedAgentLogCWD(
@@ -36,10 +33,7 @@ func cachedAgentLogCWD(
 	fingerprint agentLogFingerprint,
 	load func() (string, error),
 ) (string, error) {
-	agentLogCache.mu.Lock()
-	entry, ok := agentLogCache.entries[cacheKey]
-	agentLogCache.mu.Unlock()
-
+	entry, ok := agentLogCache.load(cacheKey)
 	if ok && entry.fingerprint == fingerprint {
 		return entry.cwd, nil
 	}
@@ -49,12 +43,10 @@ func cachedAgentLogCWD(
 		return "", err
 	}
 
-	agentLogCache.mu.Lock()
-	agentLogCache.entries[cacheKey] = agentLogCacheEntry{
+	agentLogCache.store(cacheKey, agentLogCacheEntry{
 		cwd:         cwd,
 		fingerprint: fingerprint,
-	}
-	agentLogCache.mu.Unlock()
+	})
 
 	return cwd, nil
 }
@@ -65,4 +57,26 @@ func localFileFingerprint(path string) (agentLogFingerprint, error) {
 		return "", err
 	}
 	return agentLogFingerprint(fmt.Sprintf("%d:%d", info.Size(), info.ModTime().UnixNano())), nil
+}
+
+func (c *agentLogCacheStore) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries = make(map[string]agentLogCacheEntry)
+}
+
+func (c *agentLogCacheStore) load(cacheKey string) (agentLogCacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[cacheKey]
+	return entry, ok
+}
+
+func (c *agentLogCacheStore) store(cacheKey string, entry agentLogCacheEntry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[cacheKey] = entry
 }

--- a/internal/session/agent_log_cache.go
+++ b/internal/session/agent_log_cache.go
@@ -13,10 +13,12 @@ type agentLogCacheEntry struct {
 	fingerprint agentLogFingerprint
 }
 
-var agentLogCache = struct {
-	mu      sync.Mutex
+type agentLogCacheStore struct {
 	entries map[string]agentLogCacheEntry
-}{
+	mu      sync.Mutex
+}
+
+var agentLogCache = agentLogCacheStore{
 	entries: make(map[string]agentLogCacheEntry),
 }
 

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -552,11 +552,18 @@ func processIDArg(pid int) (string, error) {
 }
 
 func readCodexSessionCWD(path string) (string, error) {
-	data, err := readFileFn(path)
+	fingerprint, err := localFileFingerprint(path)
 	if err != nil {
-		return "", fmt.Errorf("read codex session log %q: %w", path, err)
+		return "", fmt.Errorf("stat codex session log %q: %w", path, err)
 	}
-	return parseCodexSessionCWD(data)
+
+	return cachedAgentLogCWD("local:codex:"+path, fingerprint, func() (string, error) {
+		data, err := readFileFn(path)
+		if err != nil {
+			return "", fmt.Errorf("read codex session log %q: %w", path, err)
+		}
+		return parseCodexSessionCWD(data)
+	})
 }
 
 type codexSessionRecord struct {
@@ -652,14 +659,24 @@ func claudeProjectDirName(cwd string) string {
 }
 
 func readClaudeProjectCWD(path string) (string, error) {
-	data, err := readFileFn(path)
+	fingerprint, err := localFileFingerprint(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", nil
 		}
-		return "", fmt.Errorf("read claude transcript %q: %w", path, err)
+		return "", fmt.Errorf("stat claude transcript %q: %w", path, err)
 	}
-	return parseClaudeProjectCWD(data)
+
+	return cachedAgentLogCWD("local:claude:"+path, fingerprint, func() (string, error) {
+		data, err := readFileFn(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return "", nil
+			}
+			return "", fmt.Errorf("read claude transcript %q: %w", path, err)
+		}
+		return parseClaudeProjectCWD(data)
+	})
 }
 
 func parseClaudeProjectCWD(data []byte) (string, error) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeFileInfo struct {
+	name        string
+	size        int64
+	modTimeUnix int64
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return f.size }
+func (f fakeFileInfo) Mode() os.FileMode  { return 0600 }
+func (f fakeFileInfo) ModTime() time.Time { return time.Unix(f.modTimeUnix, 0) }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
+
 func TestNewLocal_Default(t *testing.T) {
 	sess, err := NewLocal("test-id", "", "", "Test Title")
 	require.NoError(t, err)
@@ -672,6 +685,77 @@ func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 	cwd, err := sess.GetActiveWorkdir()
 	require.NoError(t, err)
 	assert.Equal(t, "/tmp/worktree-from-command", cwd)
+}
+
+func TestReadCodexSessionCWD_UsesCachedValueWhenFingerprintUnchanged(t *testing.T) {
+	originalReadFile := readFileFn
+	originalStatFile := statFileFn
+	t.Cleanup(func() {
+		readFileFn = originalReadFile
+		statFileFn = originalStatFile
+		resetAgentLogCache()
+	})
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	content := []byte("{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/tmp/worktree-a\"}}\n")
+	var readCount int
+	readFileFn = func(name string) ([]byte, error) {
+		readCount++
+		assert.Equal(t, path, name)
+		return content, nil
+	}
+	statFileFn = func(name string) (os.FileInfo, error) {
+		assert.Equal(t, path, name)
+		return fakeFileInfo{name: filepath.Base(name), size: int64(len(content)), modTimeUnix: 100}, nil
+	}
+
+	cwd, err := readCodexSessionCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-a", cwd)
+
+	cwd, err = readCodexSessionCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-a", cwd)
+	assert.Equal(t, 1, readCount)
+}
+
+func TestReadClaudeProjectCWD_ReReadsWhenFingerprintChanges(t *testing.T) {
+	originalReadFile := readFileFn
+	originalStatFile := statFileFn
+	t.Cleanup(func() {
+		readFileFn = originalReadFile
+		statFileFn = originalStatFile
+		resetAgentLogCache()
+	})
+
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	contents := [][]byte{
+		[]byte("{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n"),
+		[]byte("{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-b\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n"),
+	}
+	readCount := 0
+	statCall := 0
+	readFileFn = func(name string) ([]byte, error) {
+		assert.Equal(t, path, name)
+		data := contents[readCount]
+		readCount++
+		return data, nil
+	}
+	statFileFn = func(name string) (os.FileInfo, error) {
+		assert.Equal(t, path, name)
+		info := fakeFileInfo{name: filepath.Base(name), size: int64(len(contents[min(statCall, len(contents)-1)])), modTimeUnix: int64(100 + statCall)}
+		statCall++
+		return info, nil
+	}
+
+	cwd, err := readClaudeProjectCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-a", cwd)
+
+	cwd, err = readClaudeProjectCWD(path)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/worktree-b", cwd)
+	assert.Equal(t, 2, readCount)
 }
 
 func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -730,8 +730,14 @@ func TestReadClaudeProjectCWD_ReReadsWhenFingerprintChanges(t *testing.T) {
 
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	contents := [][]byte{
-		[]byte("{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n"),
-		[]byte("{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-b\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n"),
+		[]byte(
+			"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-a\"," +
+				"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+		),
+		[]byte(
+			"{\"type\":\"assistant\",\"cwd\":\"/tmp/worktree-b\"," +
+				"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+		),
 	}
 	readCount := 0
 	statCall := 0
@@ -743,7 +749,11 @@ func TestReadClaudeProjectCWD_ReReadsWhenFingerprintChanges(t *testing.T) {
 	}
 	statFileFn = func(name string) (os.FileInfo, error) {
 		assert.Equal(t, path, name)
-		info := fakeFileInfo{name: filepath.Base(name), size: int64(len(contents[min(statCall, len(contents)-1)])), modTimeUnix: int64(100 + statCall)}
+		info := fakeFileInfo{
+			name:        filepath.Base(name),
+			size:        int64(len(contents[min(statCall, len(contents)-1)])),
+			modTimeUnix: int64(100 + statCall),
+		}
 		statCall++
 		return info, nil
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1040,10 +1040,6 @@ func remoteClaudeProjectShellPath(meta *claudeSessionMeta) string {
 	)
 }
 
-func remoteClaudeProjectReadCmd(meta *claudeSessionMeta) string {
-	return "cat " + remoteClaudeProjectShellPath(meta)
-}
-
 func remoteFileFingerprintCmd(shellPath string) string {
 	return "if out=$(stat -c '%s %Y' " + shellPath + " 2>/dev/null); then " +
 		"printf '%s\\n' \"$out\"; " +
@@ -1068,16 +1064,16 @@ func remoteCachedAgentLogCWD(
 	fingerprint, err := remoteFileFingerprint(run, shellPath)
 	if err == nil {
 		return cachedAgentLogCWD(cacheKey, fingerprint, func() (string, error) {
-			out, err := run("cat " + shellPath)
-			if err != nil {
-				log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, err)
-				return "", err
+			out, readErr := run("cat " + shellPath)
+			if readErr != nil {
+				log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, readErr)
+				return "", readErr
 			}
 
-			cwd, err := parse(out)
-			if err != nil {
-				log.Printf("%s parsing %s failed path=%q: %v", logScope, label, displayPath, err)
-				return "", err
+			cwd, parseErr := parse(out)
+			if parseErr != nil {
+				log.Printf("%s parsing %s failed path=%q: %v", logScope, label, displayPath, parseErr)
+				return "", parseErr
 			}
 			log.Printf("%s parsed %s path=%q cwd=%q", logScope, label, displayPath, cwd)
 			return cwd, nil

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -1064,24 +1064,34 @@ func remoteCachedAgentLogCWD(
 	fingerprint, err := remoteFileFingerprint(run, shellPath)
 	if err == nil {
 		return cachedAgentLogCWD(cacheKey, fingerprint, func() (string, error) {
-			out, readErr := run("cat " + shellPath)
-			if readErr != nil {
-				log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, readErr)
-				return "", readErr
-			}
-
-			cwd, parseErr := parse(out)
-			if parseErr != nil {
-				log.Printf("%s parsing %s failed path=%q: %v", logScope, label, displayPath, parseErr)
-				return "", parseErr
-			}
-			log.Printf("%s parsed %s path=%q cwd=%q", logScope, label, displayPath, cwd)
-			return cwd, nil
+			return readAndParseRemoteAgentLog(
+				run,
+				logScope,
+				displayPath,
+				shellPath,
+				label,
+				parse,
+			)
 		})
 	}
 
 	log.Printf("%s fingerprint lookup failed for %s path=%q: %v", logScope, label, displayPath, err)
 
+	return readAndParseRemoteAgentLog(
+		run,
+		logScope,
+		displayPath,
+		shellPath,
+		label,
+		parse,
+	)
+}
+
+func readAndParseRemoteAgentLog(
+	run remoteOutputFunc,
+	logScope, displayPath, shellPath, label string,
+	parse func([]byte) (string, error),
+) (string, error) {
 	out, readErr := run("cat " + shellPath)
 	if readErr != nil {
 		log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, readErr)

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -941,19 +941,15 @@ func remoteCodexSessionCWD(
 	}
 	log.Printf("%s found codex session log for pid=%d path=%q", logScope, agentPID, sessionPath)
 
-	out, err := run("cat " + shellQuotePath(sessionPath))
-	if err != nil {
-		log.Printf("%s reading codex session log failed path=%q: %v", logScope, sessionPath, err)
-		return "", err
-	}
-
-	cwd, err := parseCodexSessionCWD(out)
-	if err != nil {
-		log.Printf("%s parsing codex session log failed path=%q: %v", logScope, sessionPath, err)
-		return "", err
-	}
-	log.Printf("%s parsed codex session workdir path=%q cwd=%q", logScope, sessionPath, cwd)
-	return cwd, nil
+	return remoteCachedAgentLogCWD(
+		run,
+		"ssh:"+logScope+":codex:"+sessionPath,
+		logScope,
+		sessionPath,
+		shellQuotePath(sessionPath),
+		"codex session log",
+		parseCodexSessionCWD,
+	)
 }
 
 func remoteInteractiveAgentSessionCWD(
@@ -1000,19 +996,15 @@ func remoteClaudeSessionCWD(
 	}
 
 	projectPath := remoteClaudeProjectPath(sessionMeta)
-	out, err := run(remoteClaudeProjectReadCmd(sessionMeta))
-	if err != nil {
-		log.Printf("%s reading claude transcript failed path=%q: %v", logScope, projectPath, err)
-		return "", err
-	}
-
-	cwd, err := parseClaudeProjectCWD(out)
-	if err != nil {
-		log.Printf("%s parsing claude transcript failed path=%q: %v", logScope, projectPath, err)
-		return "", err
-	}
-	log.Printf("%s parsed claude transcript path=%q cwd=%q", logScope, projectPath, cwd)
-	return cwd, nil
+	return remoteCachedAgentLogCWD(
+		run,
+		"ssh:"+logScope+":claude:"+projectPath,
+		logScope,
+		projectPath,
+		remoteClaudeProjectShellPath(sessionMeta),
+		"claude transcript",
+		parseClaudeProjectCWD,
+	)
 }
 
 func remoteClaudeSessionMeta(run remoteOutputFunc, logScope string, agentPID int) (*claudeSessionMeta, error) {
@@ -1042,10 +1034,71 @@ func remoteClaudeProjectPath(meta *claudeSessionMeta) string {
 	)
 }
 
-func remoteClaudeProjectReadCmd(meta *claudeSessionMeta) string {
-	return "cat ~/.claude/projects/" + shellQuotePath(
+func remoteClaudeProjectShellPath(meta *claudeSessionMeta) string {
+	return "~/.claude/projects/" + shellQuotePath(
 		filepath.Join(claudeProjectDirName(meta.CWD), meta.SessionID+".jsonl"),
 	)
+}
+
+func remoteClaudeProjectReadCmd(meta *claudeSessionMeta) string {
+	return "cat " + remoteClaudeProjectShellPath(meta)
+}
+
+func remoteFileFingerprintCmd(shellPath string) string {
+	return "if out=$(stat -c '%s %Y' " + shellPath + " 2>/dev/null); then " +
+		"printf '%s\\n' \"$out\"; " +
+		"elif out=$(stat -f '%z %m' " + shellPath + " 2>/dev/null); then " +
+		"printf '%s\\n' \"$out\"; " +
+		"else bytes=$(wc -c < " + shellPath + " 2>/dev/null) || exit 1; printf '%s -\\n' \"$bytes\"; fi"
+}
+
+func remoteFileFingerprint(run remoteOutputFunc, shellPath string) (agentLogFingerprint, error) {
+	out, err := run(remoteFileFingerprintCmd(shellPath))
+	if err != nil {
+		return "", err
+	}
+	return agentLogFingerprint(strings.TrimSpace(string(out))), nil
+}
+
+func remoteCachedAgentLogCWD(
+	run remoteOutputFunc,
+	cacheKey, logScope, displayPath, shellPath, label string,
+	parse func([]byte) (string, error),
+) (string, error) {
+	fingerprint, err := remoteFileFingerprint(run, shellPath)
+	if err == nil {
+		return cachedAgentLogCWD(cacheKey, fingerprint, func() (string, error) {
+			out, err := run("cat " + shellPath)
+			if err != nil {
+				log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, err)
+				return "", err
+			}
+
+			cwd, err := parse(out)
+			if err != nil {
+				log.Printf("%s parsing %s failed path=%q: %v", logScope, label, displayPath, err)
+				return "", err
+			}
+			log.Printf("%s parsed %s path=%q cwd=%q", logScope, label, displayPath, cwd)
+			return cwd, nil
+		})
+	}
+
+	log.Printf("%s fingerprint lookup failed for %s path=%q: %v", logScope, label, displayPath, err)
+
+	out, readErr := run("cat " + shellPath)
+	if readErr != nil {
+		log.Printf("%s reading %s failed path=%q: %v", logScope, label, displayPath, readErr)
+		return "", readErr
+	}
+
+	cwd, parseErr := parse(out)
+	if parseErr != nil {
+		log.Printf("%s parsing %s failed path=%q: %v", logScope, label, displayPath, parseErr)
+		return "", parseErr
+	}
+	log.Printf("%s parsed %s path=%q cwd=%q", logScope, label, displayPath, cwd)
+	return cwd, nil
 }
 
 func remoteGitContext(runner sshSessionRunner, cwd string) (GitContext, error) {

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -395,6 +395,69 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) 
 	assert.Equal(t, "/tmp/remote-worktree-from-command", cwd)
 }
 
+func TestActiveRemoteWorkdir_SkipsRemoteCodexLogReadWhenFingerprintUnchanged(t *testing.T) {
+	resetAgentLogCache()
+	t.Cleanup(resetAgentLogCache)
+
+	sessionPath := "/home/user/.codex/sessions/2026/05/17/session.jsonl"
+	shellPath := shellQuotePath(sessionPath)
+	fingerprintCmd := remoteFileFingerprintCmd(shellPath)
+	catCmd := "cat " + shellQuotePath(sessionPath)
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:                       []byte(" 100 1 sh\n 220 100 codex resume --last\n"),
+			fmt.Sprintf(sshOpenFilesCmdTemplate, 220): []byte(sessionPath + "\n"),
+			fingerprintCmd:                            []byte("42 1700000000\n"),
+			catCmd: []byte(
+				"{\"type\":\"session_meta\",\"payload\":{\"cwd\":\"/repo/main\"}}\n" +
+					"{\"type\":\"turn_context\",\"payload\":{\"cwd\":\"/tmp/remote-worktree\"}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-worktree", cwd)
+
+	delete(runner.outputs, catCmd)
+	cwd, err = activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-worktree", cwd)
+}
+
+func TestActiveRemoteWorkdir_ReReadsRemoteClaudeTranscriptWhenFingerprintChanges(t *testing.T) {
+	resetAgentLogCache()
+	t.Cleanup(resetAgentLogCache)
+
+	projectShellPath := "~/.claude/projects/'-repo-main/session-123.jsonl'"
+	projectCmd := "cat " + projectShellPath
+	fingerprintCmd := remoteFileFingerprintCmd(projectShellPath)
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:               []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat ~/.claude/sessions/220.json": []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			fingerprintCmd:                    []byte("100 1700000000\n"),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree-a\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+		},
+	}
+
+	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-claude-worktree-a", cwd)
+
+	runner.outputs[fingerprintCmd] = []byte("101 1700000001\n")
+	runner.outputs[projectCmd] = []byte(
+		"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree-b\"," +
+			"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+	)
+	cwd, err = activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/remote-claude-worktree-b", cwd)
+}
+
 func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{


### PR DESCRIPTION
## Summary

- reduce pane git-info polling to visible panes only and pause polling while the browser tab is hidden
- cache Codex/Claude session-log workdir resolution so unchanged local and remote jsonl files are not re-read
- document the new polling and session-log fingerprint behavior

## Test Plan

- [x] make build-frontend
- [x] make test-frontend
- [x] make test-go
- [x] make check
