### PR TITLE
chore: enforce make check before push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,6 +3,12 @@
 set -eu
 
 repo_root=$(git rev-parse --show-toplevel)
+git_local_env_vars=$(git rev-parse --local-env-vars)
+
+# Git exports repository-scoped environment variables into hooks. Clear them so
+# nested git commands during make check can target their own test repositories.
+# shellcheck disable=SC2086
+unset $git_local_env_vars
 
 echo "pre-push: running make check"
 cd "$repo_root"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+
+echo "pre-push: running make check"
+cd "$repo_root"
+make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,12 @@ Before building or running tests, always run:
 make install-deps
 ```
 
-This installs npm packages and downloads Go modules. Required once per environment.
+This installs npm packages, downloads Go modules, and configures the repo-local Git hooks. Required once per environment.
 
 ## Read This First
 
 1. Read [DEVELOPMENT.md](DEVELOPMENT.md) for build, test, branch, and PR workflow rules.
-   This includes the path-sanitization rule for tests, fixtures, PR bodies, PR comments, and review replies.
+   This includes the path-sanitization rule for tests, fixtures, PR bodies, PR comments, review replies, and the mandatory `make check` completion rule.
 2. Read [docs/overview.md](docs/overview.md) for the product purpose and current boundaries.
 3. Read [docs/architecture.md](docs/architecture.md) for implementation structure and security design.
 4. Read [docs/security.md](docs/security.md) before implementing changes that affect command execution, shell argument handling, SSH path handling, or `gosec` posture.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,6 +114,7 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 
 - `make install-deps` configures the repo-local Git hooks path to `.githooks`.
 - The tracked `pre-push` hook runs `make check` and blocks `git push` when it fails.
+- The hook clears Git's repository-scoped hook environment variables before running `make check` so nested test Git repositories behave the same way they do outside hook execution.
 - Do not bypass the hook for ordinary development. Fix the failing checks instead.
 
 ### Documentation updates

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,11 +102,19 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 ### Quality gate
 
 - `make check` must pass before `make build`.
+- `make check` must pass before reporting implementation complete.
+- There are no exceptions for frontend-only, docs-adjacent, or "small" code changes.
 - Test commands: `make test-go`, `make test-frontend`, `make test-e2e`, `make test`
 - Coverage commands: `make coverage-go`, `make coverage-frontend`
 - Lint commands: `make lint-go`, `make lint-frontend`, `make lint`
 - Go lint includes `gofmt`, `go vet`, and `golangci-lint run ./...` using `.golangci.yml`.
 - Run `make lint-go` or `make lint` after every Go code change before committing.
+
+### Push protection
+
+- `make install-deps` configures the repo-local Git hooks path to `.githooks`.
+- The tracked `pre-push` hook runs `make check` and blocks `git push` when it fails.
+- Do not bypass the hook for ordinary development. Fix the failing checks instead.
 
 ### Documentation updates
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci \
+.PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci install-hooks \
         test test-go test-frontend test-e2e \
         fmt fmt-go fmt-check-go \
         lint lint-go lint-go-deps lint-frontend \
@@ -9,13 +9,17 @@ GOLANGCI_LINT_VERSION := v2.11.4
 
 # ── Dependencies ──────────────────────────────────────────────────────────────
 
-install-deps: lint-go-deps
+install-deps: lint-go-deps install-hooks
 	cd frontend && npm install
 	go mod download
 
 install-deps-ci: lint-go-deps
 	cd frontend && npm ci
 	go mod download
+
+install-hooks:
+	chmod +x .githooks/pre-push
+	git config core.hooksPath .githooks
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Authentication is attempted in order: configured `key_file` → configured `pass
 ### Setup
 
 ```sh
-make install-deps   # first time: npm install + go mod download
+make install-deps   # first time: npm install + go mod download + repo-local pre-push hook setup
 ```
 
 ### Dev servers
@@ -233,6 +233,9 @@ make dev-frontend   # Vite dev server on :5173 (proxies /api and /ws to :8080)
 ```sh
 make check   # lint + test + coverage (must pass before build)
 ```
+
+`make install-deps` also configures the tracked `.githooks/pre-push` hook, which runs `make check`
+before every `git push`.
 
 Individual commands:
 
@@ -253,7 +256,8 @@ cd frontend && npx tsc --noEmit  # TypeScript type check
 1. Fork the repository and create a feature branch.
 2. Make your changes — write tests first, confirm they fail, then implement.
 3. Run `make check` and ensure all checks pass.
-4. Open a pull request against `main` with a description of what and why.
+4. Push only after the local `pre-push` hook passes.
+5. Open a pull request against `main` with a description of what and why.
 
 Please keep pull requests focused. One logical change per PR makes review faster and history cleaner.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.18.6",
+      "version": "0.18.7",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",


### PR DESCRIPTION
## Summary

- enforce `make check` as a required local completion gate
- install a tracked repo-local pre-push hook via `make install-deps`
- document the new hook and completion requirements for agents and contributors

## Why

Recent local changes have been reaching CI without a full `make check` pass, which causes avoidable lint and validation failures after push. This change moves that quality gate earlier by making it part of local completion rules and by blocking pushes when `make check` fails.

## Validation

- `make install-deps`
- `make check`
