### PR TITLE
fix: preserve maximize state across workspace switches

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -105,6 +105,7 @@ Persistence behavior:
 - layout and workspace changes are persisted immediately when a save path is available
 - pane resize, split, close, quick-add create, move, workspace add/delete/rename, active-workspace changes, and `tab_position` changes all follow the same immediate-save path
 - when no `--config` is given, the default save path is `~/.config/panemux/config.yaml`; the directory is created automatically on first save
+- pane maximize state is frontend-local, tracked per workspace, and restored when the user switches away from a workspace and then returns
 
 ## Agent Attention Notifications
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -183,6 +183,7 @@ describe('App workspace deletion', () => {
     expect(document.querySelector('[data-pane-id="main"]')).toHaveAttribute('data-attention', 'true')
     expect(document.querySelector('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
 
+    // Both visible panes render the same mock controls, so target the first one.
     fireEvent.click(screen.getAllByRole('button', { name: 'Clear main' })[0])
 
     expect(document.querySelector('[data-pane-id="main"]')).not.toHaveAttribute('data-attention')

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -159,10 +159,10 @@ describe('App workspace deletion', () => {
 
   it('keeps workspace attention while another pane in that workspace still needs attention', () => {
     currentWorkspaces = { ...workspaces, active: 'ops' }
-    mockTerminalPane.mockImplementation(() => {
+    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
       const ctx = useContext(LayoutActionsContext)
       return (
-        <div>
+        <div data-pane-id={pane.id} data-attention={ctx?.hasPaneAttention(pane.id) ? 'true' : undefined}>
           <button onClick={() => ctx?.onPaneAttention('main')}>Notify main</button>
           <button onClick={() => ctx?.onPaneAttention('side')}>Notify side</button>
           <button onClick={() => ctx?.clearPaneAttention('main')}>Clear main</button>
@@ -171,19 +171,26 @@ describe('App workspace deletion', () => {
       )
     })
 
-    render(<App />)
+    const { rerender } = render(<App />)
     fireEvent.click(screen.getByRole('button', { name: 'Notify main' }))
     fireEvent.click(screen.getByRole('button', { name: 'Notify side' }))
 
     expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear main' }))
+    currentWorkspaces = workspaces
+    rerender(<App />)
 
-    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
+    expect(document.querySelector('[data-pane-id="main"]')).toHaveAttribute('data-attention', 'true')
+    expect(document.querySelector('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Clear side' }))
+    fireEvent.click(screen.getAllByRole('button', { name: 'Clear main' })[0])
 
-    expect(screen.getByRole('tab', { name: 'Dev' })).not.toHaveAttribute('data-attention')
+    expect(document.querySelector('[data-pane-id="main"]')).not.toHaveAttribute('data-attention')
+    expect(document.querySelector('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Clear side' })[0])
+
+    expect(document.querySelector('[data-pane-id="side"]')).not.toHaveAttribute('data-attention')
   })
 
   it('confirms before deleting a workspace from edit-mode tabs', () => {
@@ -259,6 +266,39 @@ describe('App workspace deletion', () => {
     rerender(<App />)
 
     expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'true')
+  })
+
+  it('drops maximize state for workspaces that no longer exist', () => {
+    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
+      const ctx = useContext(LayoutActionsContext)
+      const maximized = ctx?.maximizedPaneId === pane.id
+      return (
+        <div data-pane-id={pane.id} data-maximized={maximized ? 'true' : 'false'}>
+          <button onClick={() => ctx?.onMaximize(maximized ? null : pane.id)}>
+            Toggle maximize {pane.id}
+          </button>
+        </div>
+      )
+    })
+
+    const { rerender } = render(<App />)
+
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    rerender(<App />)
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle maximize ops-main' }))
+    expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'true')
+
+    currentWorkspaces = {
+      ...workspaces,
+      active: 'dev',
+      items: [workspaces.items[0]],
+    }
+    rerender(<App />)
+
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    rerender(<App />)
+
+    expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'false')
   })
 
   it('shows a user-visible error when creating a pane fails', async () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -11,7 +11,7 @@ vi.mock('./components/TerminalPane', () => ({
   TerminalPane: mockTerminalPane,
 }))
 
-const layout: LayoutNode = {
+const devLayout: LayoutNode = {
   direction: 'horizontal',
   children: [
     { size: 50, pane: { id: 'main', type: 'local' } },
@@ -23,7 +23,7 @@ const workspaces: WorkspacesResponse = {
   active: 'dev',
   tab_position: 'top',
   items: [
-    { id: 'dev', title: 'Dev', layout },
+    { id: 'dev', title: 'Dev', layout: devLayout },
     {
       id: 'ops',
       title: 'Ops',
@@ -50,7 +50,7 @@ const mockUseBrowserNotificationPermission = vi.hoisted(() => vi.fn())
 
 vi.mock('./hooks/useLayout', () => ({
   useLayout: () => ({
-    layout,
+    layout: currentWorkspaces.items.find((workspace) => workspace.id === currentWorkspaces.active)?.layout ?? currentWorkspaces.items[0].layout,
     workspaces: currentWorkspaces,
     displayConfig: { show_header: false, show_status_bar: false },
     error: null,
@@ -159,12 +159,14 @@ describe('App workspace deletion', () => {
 
   it('keeps workspace attention while another pane in that workspace still needs attention', () => {
     currentWorkspaces = { ...workspaces, active: 'ops' }
-    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
+    mockTerminalPane.mockImplementation(() => {
       const ctx = useContext(LayoutActionsContext)
       return (
-        <div data-pane-id={pane.id} data-attention={ctx?.hasPaneAttention(pane.id) ? 'true' : undefined}>
-          <button onClick={() => ctx?.onPaneAttention(pane.id)}>Notify {pane.id}</button>
-          <button onClick={() => ctx?.clearPaneAttention(pane.id)}>Clear {pane.id}</button>
+        <div>
+          <button onClick={() => ctx?.onPaneAttention('main')}>Notify main</button>
+          <button onClick={() => ctx?.onPaneAttention('side')}>Notify side</button>
+          <button onClick={() => ctx?.clearPaneAttention('main')}>Clear main</button>
+          <button onClick={() => ctx?.clearPaneAttention('side')}>Clear side</button>
         </div>
       )
     })
@@ -174,14 +176,10 @@ describe('App workspace deletion', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Notify side' }))
 
     expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
-    expect(screen.getByText('Notify main').closest('[data-pane-id="main"]')).toHaveAttribute('data-attention', 'true')
-    expect(screen.getByText('Notify side').closest('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear main' }))
 
     expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute('data-attention', 'true')
-    expect(screen.getByText('Notify main').closest('[data-pane-id="main"]')).not.toHaveAttribute('data-attention')
-    expect(screen.getByText('Notify side').closest('[data-pane-id="side"]')).toHaveAttribute('data-attention', 'true')
 
     fireEvent.click(screen.getByRole('button', { name: 'Clear side' }))
 
@@ -224,6 +222,43 @@ describe('App workspace deletion', () => {
       expect.objectContaining({ type: 'local', id: expect.any(String) }),
       { type: 'pane-edge', targetPaneId: 'main', edge: 'right' },
     )
+  })
+
+  it('preserves maximize state per workspace when switching tabs', () => {
+    mockTerminalPane.mockImplementation(({ pane }: { pane: { id: string } }) => {
+      const ctx = useContext(LayoutActionsContext)
+      const maximized = ctx?.maximizedPaneId === pane.id
+      return (
+        <div data-pane-id={pane.id} data-maximized={maximized ? 'true' : 'false'}>
+          <button onClick={() => ctx?.onMaximize(maximized ? null : pane.id)}>
+            Toggle maximize {pane.id}
+          </button>
+        </div>
+      )
+    })
+
+    const { rerender } = render(<App />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle maximize main' }))
+    expect(screen.getByText('Toggle maximize main').closest('[data-pane-id="main"]')).toHaveAttribute('data-maximized', 'true')
+
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    rerender(<App />)
+
+    expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle maximize ops-main' }))
+    expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'true')
+
+    currentWorkspaces = workspaces
+    rerender(<App />)
+
+    expect(screen.getByText('Toggle maximize main').closest('[data-pane-id="main"]')).toHaveAttribute('data-maximized', 'true')
+
+    currentWorkspaces = { ...workspaces, active: 'ops' }
+    rerender(<App />)
+
+    expect(screen.getByText('Toggle maximize ops-main').closest('[data-pane-id="ops-main"]')).toHaveAttribute('data-maximized', 'true')
   })
 
   it('shows a user-visible error when creating a pane fails', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: tru
 
 export const App: React.FC = () => {
   const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, createPane, movePane, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition } = useLayout()
-  const [maximizedPaneId, setMaximizedPaneId] = useState<string | null>(null)
+  const [maximizedPaneIdsByWorkspace, setMaximizedPaneIdsByWorkspace] = useState<Record<string, string | null>>({})
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
   const [attentionPaneIds, setAttentionPaneIds] = useState<Set<string>>(() => new Set())
   const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell, browseDirectories } =
@@ -39,6 +39,22 @@ export const App: React.FC = () => {
 
     return metadata
   }, [workspaces])
+
+  const activeWorkspaceId = workspaces?.active ?? null
+  const maximizedPaneId = useMemo(() => {
+    if (!activeWorkspaceId || !layout) return null
+    const paneId = maximizedPaneIdsByWorkspace[activeWorkspaceId] ?? null
+    if (!paneId || !layoutContainsPane(layout, paneId)) return null
+    return paneId
+  }, [activeWorkspaceId, layout, maximizedPaneIdsByWorkspace])
+
+  const setMaximizedPaneId = useCallback((paneId: string | null) => {
+    if (!activeWorkspaceId) return
+    setMaximizedPaneIdsByWorkspace((current) => {
+      if ((current[activeWorkspaceId] ?? null) === paneId) return current
+      return { ...current, [activeWorkspaceId]: paneId }
+    })
+  }, [activeWorkspaceId])
 
   const findWorkspaceForPane = useCallback((paneId: string) => {
     return workspaces?.items.find((workspace) => layoutContainsPane(workspace.layout, paneId)) ?? null

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import { SplitContainer, LayoutActionsContext } from './components/SplitContainer'
 import { PaneSettingsDialog } from './components/PaneSettingsDialog'
 import { AddSSHHostDialog } from './components/AddSSHHostDialog'
@@ -47,6 +47,26 @@ export const App: React.FC = () => {
     if (!paneId || !layoutContainsPane(layout, paneId)) return null
     return paneId
   }, [activeWorkspaceId, layout, maximizedPaneIdsByWorkspace])
+
+  useEffect(() => {
+    if (!workspaces) return
+
+    const activeWorkspaceIDs = new Set(workspaces.items.map((workspace) => workspace.id))
+    setMaximizedPaneIdsByWorkspace((current) => {
+      let changed = false
+      const next: Record<string, string | null> = {}
+
+      for (const [workspaceID, paneID] of Object.entries(current)) {
+        if (!activeWorkspaceIDs.has(workspaceID)) {
+          changed = true
+          continue
+        }
+        next[workspaceID] = paneID
+      }
+
+      return changed ? next : current
+    })
+  }, [workspaces])
 
   const setMaximizedPaneId = useCallback((paneId: string | null) => {
     if (!activeWorkspaceId) return


### PR DESCRIPTION
## Summary

- preserve maximized pane state per workspace in the frontend
- restore the previous maximized pane when switching back to a workspace
- cover the behavior in `App` tests and document the workspace-scoped maximize rule

## Test Plan

- [x] `npm test -- --run src/App.test.tsx`
- [x] `make lint-frontend`
- [x] `make test-frontend`
- [x] `make check`
