### PR TITLE
refactor: reduce pane header git info refresh cost

### DIFF
--- a/frontend/src/components/TerminalPane.test.tsx
+++ b/frontend/src/components/TerminalPane.test.tsx
@@ -35,7 +35,11 @@ describe('TerminalPane drop zones', () => {
       reconnectFailed: false,
       restartSession: vi.fn(),
     })
-    mockUseGitInfo.mockReturnValue({ is_git: false })
+    mockUseGitInfo.mockReturnValue({
+      gitInfo: { is_git: false },
+      refreshIfStale: vi.fn(),
+      refreshNow: vi.fn(),
+    })
   })
 
   it('uses a top or bottom half-pane preview for horizontal edge drop zones', () => {

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -31,12 +31,14 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const dragActive = Boolean(ctx?.dragSourcePaneId)
   const gitInfoEnabled = !ctx?.maximizedPaneId || ctx.maximizedPaneId === pane.id
 
+  const { gitInfo, refreshIfStale, refreshNow } = useGitInfo(pane.id, gitInfoEnabled)
+
   const { handleResize, connected, dims, sessionState, reconnectFailed, restartSession } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
+    repoURL: gitInfo.repo_url,
+    onInteraction: refreshIfStale,
   })
-
-  const gitInfo = useGitInfo(pane.id, gitInfoEnabled)
 
   // Observe resize events for this pane
   useEffect(() => {
@@ -49,9 +51,10 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   }, [containerEl, handleResize])
 
   const handleOpenVSCode = useCallback(() => {
+    void refreshNow()
     fetch(`/api/sessions/${pane.id}/open-vscode`, { method: 'POST' })
       .catch((err) => console.error('open-vscode failed:', err))
-  }, [pane.id])
+  }, [pane.id, refreshNow])
 
   const handleDragStart = useCallback((e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move'
@@ -107,8 +110,14 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
       data-pane-id={pane.id}
       className={hasAttention ? 'panemux-pane-attention' : undefined}
       data-attention={hasAttention ? 'true' : undefined}
-      onMouseDown={() => ctx?.clearPaneAttention(pane.id)}
-      onFocusCapture={() => ctx?.clearPaneAttention(pane.id)}
+      onMouseDown={() => {
+        ctx?.clearPaneAttention(pane.id)
+        void refreshIfStale()
+      }}
+      onFocusCapture={() => {
+        ctx?.clearPaneAttention(pane.id)
+        void refreshIfStale()
+      }}
       style={{
         display: 'flex',
         flexDirection: 'column',

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -222,6 +222,7 @@ describe('useGitInfo', () => {
     })
 
     expect(window.fetch).toHaveBeenCalledTimes(1)
+    expect(result.current.gitInfo.is_git).toBe(false)
   })
 
   it('silently ignores fetch errors', async () => {

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { useGitInfo } from './useGitInfo'
+import { __resetGitInfoCacheForTests, useGitInfo } from './useGitInfo'
 
 describe('useGitInfo', () => {
   beforeEach(() => {
@@ -11,28 +11,17 @@ describe('useGitInfo', () => {
   })
 
   afterEach(() => {
+    __resetGitInfoCacheForTests()
     vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
   it('returns isGit false initially before fetch resolves', () => {
-    window.fetch = vi.fn().mockReturnValue(new Promise(() => {})) // never resolves
+    window.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
     const { result } = renderHook(() => useGitInfo('pane1'))
-    expect(result.current.is_git).toBe(false)
-    expect(result.current.branch).toBeUndefined()
-    expect(result.current.repo).toBeUndefined()
-  })
-
-  it('returns isGit false on non-git response', async () => {
-    window.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ is_git: false }),
-    } as Response)
-
-    const { result } = renderHook(() => useGitInfo('pane1'))
-    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
-    await act(async () => {})
-    expect(result.current.is_git).toBe(false)
+    expect(result.current.gitInfo.is_git).toBe(false)
+    expect(result.current.gitInfo.branch).toBeUndefined()
+    expect(result.current.gitInfo.repo).toBeUndefined()
   })
 
   it('returns branch and repo when in a git repo', async () => {
@@ -42,11 +31,11 @@ describe('useGitInfo', () => {
     } as Response)
 
     const { result } = renderHook(() => useGitInfo('pane1'))
-    await waitFor(() => expect(result.current.is_git).toBe(true))
-    expect(result.current.branch).toBe('main')
-    expect(result.current.repo).toBe('myrepo')
-    expect(result.current.pr_number).toBe(1)
-    expect(result.current.pr_url).toBe('https://github.com/example/repo/pull/1')
+    await waitFor(() => expect(result.current.gitInfo.is_git).toBe(true))
+    expect(result.current.gitInfo.branch).toBe('main')
+    expect(result.current.gitInfo.repo).toBe('myrepo')
+    expect(result.current.gitInfo.pr_number).toBe(1)
+    expect(result.current.gitInfo.pr_url).toBe('https://github.com/example/repo/pull/1')
   })
 
   it('calls /api/sessions/{id}/git-info with the correct session id', async () => {
@@ -58,16 +47,6 @@ describe('useGitInfo', () => {
     renderHook(() => useGitInfo('my-session-id'))
     await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
     expect(window.fetch).toHaveBeenCalledWith('/api/sessions/my-session-id/git-info')
-  })
-
-  it('registers a 10-second polling interval', () => {
-    vi.useFakeTimers()
-    const intervalSpy = vi.spyOn(window, 'setInterval')
-    window.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
-
-    renderHook(() => useGitInfo('pane1'))
-
-    expect(intervalSpy).toHaveBeenCalledWith(expect.any(Function), 10000)
   })
 
   it('does not fetch while disabled', () => {
@@ -95,17 +74,14 @@ describe('useGitInfo', () => {
     await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
   })
 
-  it('stops polling while the document is hidden and refetches on visibility restore', async () => {
-    vi.useFakeTimers()
+  it('does not refetch on visibility restore while data is still fresh', async () => {
     window.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ is_git: false }),
     } as Response)
 
     renderHook(() => useGitInfo('pane1'))
-
-    await act(async () => {})
-    expect(window.fetch).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -114,11 +90,6 @@ describe('useGitInfo', () => {
     await act(async () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
-    act(() => {
-      vi.advanceTimersByTime(10000)
-    })
-
-    expect(window.fetch).toHaveBeenCalledTimes(1)
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -128,41 +99,145 @@ describe('useGitInfo', () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
-    await act(async () => {})
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches on visibility restore after the cached data becomes stale', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    renderHook(() => useGitInfo('pane1'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(30001)
+    })
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
     expect(window.fetch).toHaveBeenCalledTimes(2)
   })
 
-  it('silently ignores fetch errors — state stays at default', async () => {
-    let resolveFetch!: () => void
-    const fetchPromise = new Promise<Response>((_, reject) => {
-      resolveFetch = () => reject(new Error('network error'))
-    })
-    window.fetch = vi.fn().mockReturnValue(fetchPromise)
+  it('throttles stale checks triggered in quick succession', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
 
     const { result } = renderHook(() => useGitInfo('pane1'))
-
     await act(async () => {
-      resolveFetch()
-      await fetchPromise.catch(() => {})
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(30001)
     })
 
-    expect(result.current.is_git).toBe(false)
+    await act(async () => {
+      await result.current.refreshIfStale()
+      await result.current.refreshIfStale()
+    })
+
+    expect(window.fetch).toHaveBeenCalledTimes(2)
   })
 
-  it('silently ignores non-ok responses — state stays at default', async () => {
-    let resolveFetch!: (r: Response) => void
+  it('refreshes immediately when refreshNow is called', async () => {
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    const { result } = renderHook(() => useGitInfo('pane1'))
+    await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      await result.current.refreshNow()
+    })
+
+    expect(window.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('reuses the in-flight request when refreshNow is called twice before the first fetch settles', async () => {
+    let resolveFetch!: (value: Response) => void
     const fetchPromise = new Promise<Response>((resolve) => {
       resolveFetch = resolve
     })
     window.fetch = vi.fn().mockReturnValue(fetchPromise)
 
+    const { result } = renderHook(() => useGitInfo('pane1', false))
+
+    const firstCall = result.current.refreshNow()
+    const secondCall = result.current.refreshNow()
+
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: () => Promise.resolve({ is_git: false }),
+      } as Response)
+      await Promise.all([firstCall, secondCall])
+    })
+
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles repeated stale checks after a non-ok response', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 } as Response)
+
+    const { result } = renderHook(() => useGitInfo('pane1', false))
+
+    await act(async () => {
+      await result.current.refreshIfStale()
+      await result.current.refreshIfStale()
+    })
+
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('silently ignores fetch errors', async () => {
+    let rejectFetch!: (error: Error) => void
+    const fetchPromise = new Promise<Response>((_, reject) => {
+      rejectFetch = reject
+    })
+    window.fetch = vi.fn().mockReturnValue(fetchPromise)
+
     const { result } = renderHook(() => useGitInfo('pane1'))
 
     await act(async () => {
-      resolveFetch({ ok: false, status: 404 } as Response)
-      await fetchPromise
+      rejectFetch(new Error('network error'))
+      await fetchPromise.catch(() => {})
     })
 
-    expect(result.current.is_git).toBe(false)
+    expect(result.current.gitInfo.is_git).toBe(false)
   })
 })

--- a/frontend/src/hooks/useGitInfo.ts
+++ b/frontend/src/hooks/useGitInfo.ts
@@ -1,22 +1,74 @@
 import { useState, useEffect, useCallback } from 'react'
 import { GitInfo, GitInfoSchema } from '../schemas'
 
-const GIT_INFO_POLL_INTERVAL_MS = 10000
+const GIT_INFO_STALE_MS = 30000
+const GIT_INFO_RECHECK_THROTTLE_MS = 5000
 
-export function useGitInfo(sessionId: string, enabled = true): GitInfo {
-  const [gitInfo, setGitInfo] = useState<GitInfo>({ is_git: false })
+interface GitInfoCacheEntry {
+  gitInfo: GitInfo
+  lastFetchedAt: number
+  lastCheckedAt: number
+  inFlight: Promise<void> | null
+}
+
+const DEFAULT_GIT_INFO: GitInfo = { is_git: false }
+const gitInfoCache = new Map<string, GitInfoCacheEntry>()
+
+export interface UseGitInfoResult {
+  gitInfo: GitInfo
+  refreshIfStale: () => Promise<void>
+  refreshNow: () => Promise<void>
+}
+
+export function useGitInfo(sessionId: string, enabled = true): UseGitInfoResult {
+  const [gitInfo, setGitInfo] = useState<GitInfo>(() => getOrCreateCacheEntry(sessionId).gitInfo)
   const [isVisible, setIsVisible] = useState(() => document.visibilityState === 'visible')
 
-  const fetchGitInfo = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/sessions/${sessionId}/git-info`)
-      if (!res.ok) return
-      const data = GitInfoSchema.parse(await res.json())
-      setGitInfo(data)
-    } catch {
-      // ignore errors silently — git info is best-effort
+  const refreshNow = useCallback(async () => {
+    const cacheEntry = getOrCreateCacheEntry(sessionId)
+    if (cacheEntry.inFlight) {
+      await cacheEntry.inFlight
+      return
     }
+
+    cacheEntry.lastCheckedAt = Date.now()
+    const request = (async () => {
+      try {
+        const res = await fetch(`/api/sessions/${sessionId}/git-info`)
+        if (!res.ok) return
+        const data = GitInfoSchema.parse(await res.json())
+        cacheEntry.gitInfo = data
+        cacheEntry.lastFetchedAt = Date.now()
+        setGitInfo(data)
+      } catch {
+        // ignore errors silently — git info is best-effort
+      } finally {
+        cacheEntry.inFlight = null
+      }
+    })()
+
+    cacheEntry.inFlight = request
+    await request
   }, [sessionId])
+
+  const refreshIfStale = useCallback(async () => {
+    const cacheEntry = getOrCreateCacheEntry(sessionId)
+    const now = Date.now()
+    if (
+      cacheEntry.lastFetchedAt > 0 &&
+      now-cacheEntry.lastFetchedAt < GIT_INFO_STALE_MS
+    ) {
+      return
+    }
+    if (
+      cacheEntry.lastCheckedAt > 0 &&
+      now-cacheEntry.lastCheckedAt < GIT_INFO_RECHECK_THROTTLE_MS
+    ) {
+      return
+    }
+
+    await refreshNow()
+  }, [refreshNow, sessionId])
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -29,11 +81,30 @@ export function useGitInfo(sessionId: string, enabled = true): GitInfo {
 
   useEffect(() => {
     if (!enabled || !isVisible) return
+    void refreshIfStale()
+  }, [enabled, isVisible, refreshIfStale])
 
-    fetchGitInfo()
-    const interval = setInterval(fetchGitInfo, GIT_INFO_POLL_INTERVAL_MS)
-    return () => clearInterval(interval)
-  }, [enabled, fetchGitInfo, isVisible])
+  useEffect(() => {
+    setGitInfo(getOrCreateCacheEntry(sessionId).gitInfo)
+  }, [sessionId])
 
-  return gitInfo
+  return { gitInfo, refreshIfStale, refreshNow }
+}
+
+function getOrCreateCacheEntry(sessionId: string): GitInfoCacheEntry {
+  const existing = gitInfoCache.get(sessionId)
+  if (existing) return existing
+
+  const created: GitInfoCacheEntry = {
+    gitInfo: DEFAULT_GIT_INFO,
+    lastFetchedAt: 0,
+    lastCheckedAt: 0,
+    inFlight: null,
+  }
+  gitInfoCache.set(sessionId, created)
+  return created
+}
+
+export function __resetGitInfoCacheForTests() {
+  gitInfoCache.clear()
 }

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { __resetTerminalEntriesForTests, useTerminal } from './useTerminal'
+import { __computePullRequestLinksForTests, __resetTerminalEntriesForTests, useTerminal } from './useTerminal'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
 // ── xterm.js mocks ───────────────────────────────────────────────────────────
@@ -10,12 +10,18 @@ const { mockWrite, mockTerm, mockFitAddon, mockTerminalCtor } = vi.hoisted(() =>
     options: { disableStdin: false },
     attachCustomKeyEventHandler: vi.fn(),
     element: undefined as HTMLElement | undefined,
+    registerLinkProvider: vi.fn(),
     hasSelection: vi.fn(() => false),
     getSelection: vi.fn(() => ''),
     loadAddon: vi.fn(),
     open: vi.fn(),
     onData: vi.fn(),
     onBinary: vi.fn(),
+    buffer: {
+      active: {
+        getLine: vi.fn(() => null),
+      },
+    },
     dispose: vi.fn(),
     cols: 80,
     rows: 24,
@@ -155,6 +161,66 @@ describe('useTerminal', () => {
     expect(mockTerm.loadAddon).toHaveBeenCalledTimes(2)
   })
 
+  it('registers a custom link provider for pull request numbers', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container, repoURL: 'https://github.com/example/panemux' }))
+
+    expect(mockTerm.registerLinkProvider).toHaveBeenCalledTimes(1)
+  })
+
+  it('turns visible #123 references into pull request links when repo metadata is available', () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+    const term = {
+      buffer: {
+        active: {
+          getLine: vi.fn(() => ({
+            translateToString: vi.fn(() => 'Reviewing #123 now'),
+          })),
+        },
+      },
+    } as unknown as typeof mockTerm
+
+    const links = __computePullRequestLinksForTests(term as never, 'https://github.com/example/panemux', 1)
+
+    expect(links).toHaveLength(1)
+    links[0].activate()
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://github.com/example/panemux/pull/123',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('skips pull request link generation when repo metadata is unavailable', () => {
+    const term = {
+      buffer: {
+        active: {
+          getLine: vi.fn(() => ({
+            translateToString: vi.fn(() => 'Reviewing #123 now'),
+          })),
+        },
+      },
+    } as unknown as typeof mockTerm
+
+    const links = __computePullRequestLinksForTests(term as never, null, 1)
+
+    expect(links).toHaveLength(0)
+  })
+
+  it('skips pull request link generation when the buffer line is missing', () => {
+    const term = {
+      buffer: {
+        active: {
+          getLine: vi.fn(() => null),
+        },
+      },
+    } as unknown as typeof mockTerm
+
+    const links = __computePullRequestLinksForTests(term as never, 'https://github.com/example/panemux', 1)
+
+    expect(links).toHaveLength(0)
+  })
+
   it('registers onData and onBinary handlers', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))
@@ -166,6 +232,20 @@ describe('useTerminal', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))
     expect(mockTerm.attachCustomKeyEventHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies the caller when the terminal container receives interaction', () => {
+    const container = makeContainer()
+    const onInteraction = vi.fn()
+
+    renderHook(() => useTerminal({ sessionId: 's1', container, onInteraction }))
+
+    act(() => {
+      container.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }))
+      container.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }))
+    })
+
+    expect(onInteraction).toHaveBeenCalledTimes(2)
   })
 
   it('copies selected text and suppresses terminal input on copy shortcut', () => {

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -183,6 +183,10 @@ describe('useTerminal', () => {
     const links = __computePullRequestLinksForTests(term as never, 'https://github.com/example/panemux', 1)
 
     expect(links).toHaveLength(1)
+    expect(links[0].range).toEqual({
+      start: { x: 10, y: 0 },
+      end: { x: 14, y: 0 },
+    })
     links[0].activate()
     expect(openSpy).toHaveBeenCalledWith(
       'https://github.com/example/panemux/pull/123',

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -11,6 +11,8 @@ const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 interface UseTerminalOptions {
   sessionId: string
   container: HTMLElement | null
+  repoURL?: string
+  onInteraction?: () => void | Promise<void>
 }
 
 interface TerminalEntry {
@@ -24,6 +26,7 @@ interface TerminalEntry {
   replayActive: boolean
   replayWriteDepth: number
   awaitingReplayEnd: boolean
+  repoURL: string | null
 }
 
 interface PendingTerminalMessage {
@@ -34,7 +37,7 @@ interface PendingTerminalMessage {
 const terminalEntries = new Map<string, TerminalEntry>()
 type TerminalLifecycleState = 'running' | 'disconnected' | 'exited'
 
-export function useTerminal({ sessionId, container }: UseTerminalOptions) {
+export function useTerminal({ sessionId, container, repoURL, onInteraction }: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const initializedRef = useRef(false)
@@ -181,6 +184,12 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
     scheduleConnectedResize(entry, setDims, send)
   }, [connected, send, sessionId])
 
+  useEffect(() => {
+    const entry = entryRef.current
+    if (!entry) return
+    entry.repoURL = repoURL ?? null
+  }, [repoURL, sessionId])
+
   // Initialize terminal
   useEffect(() => {
     if (!container || initializedRef.current) return
@@ -226,6 +235,24 @@ export function useTerminal({ sessionId, container }: UseTerminalOptions) {
       initializedRef.current = false
     }
   }, [container, sessionId])
+
+  useEffect(() => {
+    if (!container || !onInteraction) return
+
+    const handleInteraction = () => {
+      void onInteraction()
+    }
+
+    container.addEventListener('pointerdown', handleInteraction, true)
+    container.addEventListener('keydown', handleInteraction, true)
+    container.addEventListener('wheel', handleInteraction, { capture: true })
+
+    return () => {
+      container.removeEventListener('pointerdown', handleInteraction, true)
+      container.removeEventListener('keydown', handleInteraction, true)
+      container.removeEventListener('wheel', handleInteraction, true)
+    }
+  }, [container, onInteraction])
 
   const restartSession = useCallback(async () => {
     try {
@@ -321,10 +348,16 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
     replayActive: false,
     replayWriteDepth: 0,
     awaitingReplayEnd: false,
+    repoURL: null,
   }
 
   term.loadAddon(fitAddon)
   term.loadAddon(webLinksAddon)
+  term.registerLinkProvider({
+    provideLinks(y, callback) {
+      callback(computePullRequestLinks(term, entry.repoURL, y))
+    },
+  })
   term.attachCustomKeyEventHandler((event) => {
     if (!isCopyShortcut(event) || !term.hasSelection()) {
       return true
@@ -351,6 +384,36 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
   terminalEntries.set(sessionId, entry)
   return entry
 }
+
+function computePullRequestLinks(term: Terminal, repoURL: string | null, y: number) {
+  if (!repoURL) return []
+
+  const line = term.buffer.active.getLine(y - 1)
+  if (!line) return []
+
+  const text = line.translateToString(true)
+  const links = []
+  const pattern = /(^|[^\w])#(\d{1,8})(?![\w/])/g
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) {
+    const prefix = match[1] ?? ''
+    const number = match[2]
+    const hashIndex = match.index + prefix.length
+    links.push({
+      range: {
+        start: { x: hashIndex + 1, y },
+        end: { x: hashIndex + 1 + number.length + 1, y },
+      },
+      text: `#${number}`,
+      activate: () => {
+        window.open(`${repoURL}/pull/${number}`, '_blank', 'noopener,noreferrer')
+      },
+    })
+  }
+  return links
+}
+
+export const __computePullRequestLinksForTests = computePullRequestLinks
 
 function attachTerminal(entry: TerminalEntry, container: HTMLElement) {
   if (!entry.term.element) {

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -245,7 +245,7 @@ export function useTerminal({ sessionId, container, repoURL, onInteraction }: Us
 
     container.addEventListener('pointerdown', handleInteraction, true)
     container.addEventListener('keydown', handleInteraction, true)
-    container.addEventListener('wheel', handleInteraction, { capture: true })
+    container.addEventListener('wheel', handleInteraction, { capture: true, passive: true })
 
     return () => {
       container.removeEventListener('pointerdown', handleInteraction, true)
@@ -401,8 +401,8 @@ function computePullRequestLinks(term: Terminal, repoURL: string | null, y: numb
     const hashIndex = match.index + prefix.length
     links.push({
       range: {
-        start: { x: hashIndex + 1, y },
-        end: { x: hashIndex + 1 + number.length + 1, y },
+        start: { x: hashIndex, y: y - 1 },
+        end: { x: hashIndex + number.length + 1, y: y - 1 },
       },
       text: `#${number}`,
       activate: () => {


### PR DESCRIPTION
## Summary
- replace 10-second pane header git-info polling with stale-on-interaction refresh
- refresh git info when panes become visible, focused, clicked, or actively used
- link terminal-side PR references like `#123` to the repository pull request when repo metadata is known

## Test Plan
- [x] make test-frontend
- [x] make check
