### PR TITLE
feat: resize vertical workspace bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Then open [http://localhost:8080](http://localhost:8080) in your browser.
 - Click a tab to switch workspaces without restarting the underlying sessions.
 - If a hidden workspace needs attention, its tab flashes until you open it.
 - You can add a workspace, rename it inline, delete it, or move the tab bar to the top, bottom, left, or right directly from the workspace bar.
+- When the bar is on the left or right, you can drag its inner edge to resize it. That shared vertical width is persisted with the workspace settings.
 - The workspace bar also shows per-workspace pane status at a glance. Each tab includes a compact pane-name summary, and each workspace can expose pane detail cards with connection state, SSH host alias, repository, branch, and PR number.
 - When the bar is on the top or bottom, pane detail cards appear as a hover/focus overlay attached to the workspace tab so the terminal area keeps its height.
 - When the bar is on the left or right, pane detail cards stay expanded inline under each workspace tab so the workspace-to-pane grouping remains visible without extra pointer travel.
@@ -153,6 +154,7 @@ ssh_connections:
 workspaces:
   active: dev
   tab_position: top           # top | bottom | left | right
+  vertical_bar_width: 280     # shared width in px when tab_position is left/right
   items:
     - id: dev
       title: "Development"
@@ -186,7 +188,7 @@ workspaces:
 
 Older config files with a top-level `layout:` are still accepted. When the config is next saved, panemux migrates that layout into a `default` workspace and writes the `workspaces:` format.
 
-The workspace bar is always available for workspace actions. Newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. The same bar also exposes inline workspace rename, workspace delete with confirmation, a `+` workspace action, and tab-position controls. It also acts as a cross-workspace operational overview: pane detail cards can be selected to focus that pane, and those same cards can be dragged onto another workspace to move the pane there. Switching the active workspace and changing `tab_position` are persisted so the same workspace and tab placement are restored after restart. Agent confirmation prompts, including Codex MCP allow menus, can mark inactive workspace tabs and trigger browser notifications after notification permission has been granted. Clicking the notification switches to the relevant workspace.
+The workspace bar is always available for workspace actions. Newly added workspaces start with a single local terminal pane, become active immediately, and are saved to the config. The same bar also exposes inline workspace rename, workspace delete with confirmation, a `+` workspace action, and tab-position controls. When the bar is vertical, its width is shared across all workspaces and is also persisted. It also acts as a cross-workspace operational overview: pane detail cards can be selected to focus that pane, and those same cards can be dragged onto another workspace to move the pane there. Switching the active workspace, changing `tab_position`, and resizing the vertical workspace bar are persisted so the same navigation chrome is restored after restart. Agent confirmation prompts, including Codex MCP allow menus, can mark inactive workspace tabs and trigger browser notifications after notification permission has been granted. Clicking the notification switches to the relevant workspace.
 
 ### Pane types
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,7 +53,8 @@ ssh_connections:
 # workspaces, or move workspace tabs. New workspaces start with one local
 # terminal pane. Deleting a workspace asks for confirmation, and the last
 # remaining workspace cannot be deleted. The active workspace selection and
-# tab_position are saved.
+# tab_position are saved. `vertical_bar_width` controls the shared width in
+# pixels when the workspace bar is on the left or right.
 #
 # Split node  — has `direction` and `children` (no `pane`)
 # Leaf node   — has `pane` (no `direction` / `children`)
@@ -72,6 +73,7 @@ ssh_connections:
 workspaces:
   active: dev
   tab_position: top
+  vertical_bar_width: 280
   items:
     - id: dev
       title: "Development"

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -103,7 +103,7 @@ Pane settings in the frontend expose a directory browser for `cwd`. Local and lo
 Persistence behavior:
 
 - layout and workspace changes are persisted immediately when a save path is available
-- pane resize, split, close, quick-add create, move, workspace add/delete/rename, active-workspace changes, and `tab_position` changes all follow the same immediate-save path
+- pane resize, split, close, quick-add create, move, workspace add/delete/rename, active-workspace changes, `tab_position` changes, and vertical workspace-bar width changes all follow the same immediate-save path
 - when no `--config` is given, the default save path is `~/.config/panemux/config.yaml`; the directory is created automatically on first save
 - pane maximize state is frontend-local, tracked per workspace, and restored when the user switches away from a workspace and then returns
 
@@ -159,7 +159,8 @@ panes across all workspaces without mounting hidden terminal instances. The inte
 marks the currently focused pane so the overview stays aligned with the live terminal focus state.
 For `top` and `bottom` workspace bars, pane cards are shown in a hover/focus overlay anchored to
 the workspace tab. For `left` and `right` workspace bars, pane cards stay expanded inline beneath
-their workspace tab.
+their workspace tab. In vertical mode, the workspace tabs and inline cards scroll inside the bar,
+while the `+` action and tab-position controls stay pinned at the bottom.
 
 When a pane is hidden behind maximize, its header Git/PR polling stops until it becomes visible
 again. Restoring the browser tab or making a pane visible again triggers an immediate refresh so
@@ -201,7 +202,7 @@ Accepts a layout JSON document, validates it, updates in-memory state, and persi
 
 ### `GET /api/workspaces`
 
-Returns the active workspace ID, `tab_position`, and all workspace layouts.
+Returns the active workspace ID, `tab_position`, `vertical_bar_width`, and all workspace layouts.
 
 ### `PUT /api/workspaces/tab-position`
 
@@ -209,6 +210,15 @@ Accepts `{ "tab_position": "top" | "bottom" | "left" | "right" }`, validates it,
 
 - `400`: invalid JSON
 - `422`: invalid tab position
+- `500`: unable to save the config
+- `200`: updated and returned
+
+### `PUT /api/workspaces/vertical-bar-width`
+
+Accepts `{ "vertical_bar_width": <int> }`, validates the shared vertical workspace-bar width in pixels, persists the workspace config, and returns the updated workspace response.
+
+- `400`: invalid JSON
+- `422`: invalid width
 - `500`: unable to save the config
 - `200`: updated and returned
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -66,6 +66,8 @@ The position cluster sits on the opposite end of the workspace tabs:
 
 This separation keeps workspace navigation and workspace-bar relocation visually distinct.
 
+For left/right bars, the bar width is user-resizable by dragging its inner edge. The chosen width is shared across workspaces and restored on reload, while the pane layout inside the remaining work area continues to use its own saved percentage splits.
+
 Workspace creation uses a single `+` control because it is now the only creation action in the bar and does not need extra wording to distinguish it from terminal creation.
 
 ### Integrated workspace summaries
@@ -88,6 +90,8 @@ Presentation depends on bar position:
 
 - top/bottom bars: pane cards appear as a hover/focus overlay attached to the tab
 - left/right bars: pane cards stay expanded inline under the tab
+
+When the bar is on the left or right, the tab list and inline pane groups live in a dedicated scroll region. The fixed footer below them keeps the `+` action and all four tab-position buttons visible even when the workspace list is taller than the viewport.
 
 Each pane group shows:
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.18.7",
+      "version": "0.18.8",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -22,6 +22,7 @@ const devLayout: LayoutNode = {
 const workspaces: WorkspacesResponse = {
   active: 'dev',
   tab_position: 'top',
+  vertical_bar_width: 280,
   items: [
     { id: 'dev', title: 'Dev', layout: devLayout },
     {
@@ -37,6 +38,7 @@ let currentWorkspaces = workspaces
 const mockDeleteWorkspace = vi.fn()
 const mockRenameWorkspace = vi.fn()
 const mockSetWorkspaceTabPosition = vi.fn()
+const mockSetWorkspaceVerticalBarWidth = vi.fn()
 const mockSetActiveWorkspace = vi.fn()
 const mockUpdateSizes = vi.fn()
 const mockSplitPane = vi.fn()
@@ -67,6 +69,7 @@ vi.mock('./hooks/useLayout', () => ({
     deleteWorkspace: mockDeleteWorkspace,
     renameWorkspace: mockRenameWorkspace,
     setWorkspaceTabPosition: mockSetWorkspaceTabPosition,
+    setWorkspaceVerticalBarWidth: mockSetWorkspaceVerticalBarWidth,
   }),
 }))
 
@@ -134,6 +137,7 @@ describe('App workspace deletion', () => {
     mockDeleteWorkspace.mockClear()
     mockRenameWorkspace.mockClear()
     mockSetWorkspaceTabPosition.mockClear()
+    mockSetWorkspaceVerticalBarWidth.mockClear()
     mockSetActiveWorkspace.mockClear()
     mockUpdateSizes.mockClear()
     mockSplitPane.mockClear()
@@ -453,6 +457,17 @@ describe('App workspace deletion', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Place workspace tabs on right' }))
 
     expect(mockSetWorkspaceTabPosition).toHaveBeenCalledWith('right')
+  })
+
+  it('passes vertical workspace bar width changes from the resizer', () => {
+    currentWorkspaces = { ...workspaces, tab_position: 'left' }
+    render(<App />)
+
+    fireEvent.mouseDown(screen.getByTestId('workspace-bar-resizer'), { clientX: 280 })
+    fireEvent.mouseMove(window, { clientX: 320 })
+    fireEvent.mouseUp(window)
+
+    expect(mockSetWorkspaceVerticalBarWidth).toHaveBeenCalledWith(320)
   })
 
   it('moves a dragged pane to another workspace tab', () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -464,9 +464,11 @@ describe('App workspace deletion', () => {
     render(<App />)
 
     const resizer = screen.getByTestId('workspace-bar-resizer')
-    fireEvent.keyDown(resizer, { key: 'ArrowRight' })
+    fireEvent.mouseDown(resizer, { clientX: 280 })
+    fireEvent.mouseMove(window, { clientX: 320 })
+    fireEvent.mouseUp(window)
 
-    expect(mockSetWorkspaceVerticalBarWidth).toHaveBeenCalledWith(292)
+    expect(mockSetWorkspaceVerticalBarWidth).toHaveBeenCalledWith(320)
   })
 
   it('moves a dragged pane to another workspace tab', () => {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -463,11 +463,10 @@ describe('App workspace deletion', () => {
     currentWorkspaces = { ...workspaces, tab_position: 'left' }
     render(<App />)
 
-    fireEvent.mouseDown(screen.getByTestId('workspace-bar-resizer'), { clientX: 280 })
-    fireEvent.mouseMove(window, { clientX: 320 })
-    fireEvent.mouseUp(window)
+    const resizer = screen.getByTestId('workspace-bar-resizer')
+    fireEvent.keyDown(resizer, { key: 'ArrowRight' })
 
-    expect(mockSetWorkspaceVerticalBarWidth).toHaveBeenCalledWith(320)
+    expect(mockSetWorkspaceVerticalBarWidth).toHaveBeenCalledWith(292)
   })
 
   it('moves a dragged pane to another workspace tab', () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,7 +19,24 @@ import type { GitInfo, LayoutChild, LayoutNode, SessionInfo, SSHConfigHost } fro
 const DEFAULT_DISPLAY: DisplayConfig = { show_header: true, show_status_bar: true }
 
 export const App: React.FC = () => {
-  const { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, createPane, movePane, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition } = useLayout()
+  const {
+    layout,
+    workspaces,
+    displayConfig,
+    error,
+    updateSizes,
+    splitPane,
+    closePane,
+    swapPanes,
+    createPane,
+    movePane,
+    setActiveWorkspace,
+    addWorkspace,
+    deleteWorkspace,
+    renameWorkspace,
+    setWorkspaceTabPosition,
+    setWorkspaceVerticalBarWidth,
+  } = useLayout()
   const [maximizedPaneIdsByWorkspace, setMaximizedPaneIdsByWorkspace] = useState<Record<string, string | null>>({})
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
   const [activePaneId, setActivePaneId] = useState<string | null>(null)
@@ -316,6 +333,7 @@ export const App: React.FC = () => {
             workspaces={workspaces.items}
             activeWorkspaceId={workspaces.active}
             tabPosition={workspaces.tab_position}
+            verticalBarWidth={workspaces.vertical_bar_width}
             dragSourcePaneId={dragSourcePaneId}
             onMovePaneToWorkspace={(sourcePaneId, workspaceId) => {
               handleMovePane(sourcePaneId, { type: 'workspace-tab', workspaceId })
@@ -332,6 +350,7 @@ export const App: React.FC = () => {
             onAdd={addWorkspace}
             onRename={renameWorkspace}
             onTabPositionChange={setWorkspaceTabPosition}
+            onVerticalBarWidthChange={setWorkspaceVerticalBarWidth}
             onDelete={(workspaceId) => {
               const workspace = workspaces.items.find((item) => item.id === workspaceId)
               if (!workspace) return

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -507,6 +507,7 @@ describe('WorkspaceTabs', () => {
     )
 
     expect(screen.getByTestId('workspace-bar-resizer')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-bar-resizer')).toHaveAttribute('tabindex', '0')
 
     rerender(
       <WorkspaceTabs
@@ -520,6 +521,27 @@ describe('WorkspaceTabs', () => {
     )
 
     expect(screen.queryByTestId('workspace-bar-resizer')).not.toBeInTheDocument()
+  })
+
+  it('supports keyboard resizing on the separator', () => {
+    const onVerticalBarWidthChange = vi.fn()
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="left"
+        verticalBarWidth={280}
+        onSelect={() => {}}
+        onVerticalBarWidthChange={onVerticalBarWidthChange}
+      />,
+    )
+
+    const resizer = screen.getByTestId('workspace-bar-resizer')
+    fireEvent.keyDown(resizer, { key: 'ArrowRight' })
+    fireEvent.keyDown(resizer, { key: 'End' })
+
+    expect(onVerticalBarWidthChange).toHaveBeenNthCalledWith(1, 292)
+    expect(onVerticalBarWidthChange).toHaveBeenNthCalledWith(2, 520)
   })
 
   it('hides tab position controls when the position change handler is omitted', () => {

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -544,6 +544,27 @@ describe('WorkspaceTabs', () => {
     expect(onVerticalBarWidthChange).toHaveBeenNthCalledWith(2, 520)
   })
 
+  it('commits the resized width after mouse dragging the separator', () => {
+    const onVerticalBarWidthChange = vi.fn()
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="left"
+        verticalBarWidth={280}
+        onSelect={() => {}}
+        onVerticalBarWidthChange={onVerticalBarWidthChange}
+      />,
+    )
+
+    const resizer = screen.getByTestId('workspace-bar-resizer')
+    fireEvent.mouseDown(resizer, { clientX: 280 })
+    fireEvent.mouseMove(window, { clientX: 320 })
+    fireEvent.mouseUp(window)
+
+    expect(onVerticalBarWidthChange).toHaveBeenCalledWith(320)
+  })
+
   it('hides tab position controls when the position change handler is omitted', () => {
     render(<WorkspaceTabs workspaces={workspaces} activeWorkspaceId="dev" tabPosition="top" onSelect={() => {}} />)
 

--- a/frontend/src/components/WorkspaceTabs.test.tsx
+++ b/frontend/src/components/WorkspaceTabs.test.tsx
@@ -466,11 +466,60 @@ describe('WorkspaceTabs', () => {
         activeWorkspaceId="dev"
         tabPosition="left"
         onSelect={() => {}}
+        onAdd={() => {}}
         onTabPositionChange={() => {}}
       />,
     )
 
-    expect(screen.getByRole('group', { name: 'Workspace tab position' })).toHaveStyle({ marginTop: 'auto' })
+    expect(screen.getByTestId('workspace-tabs-footer')).toContainElement(screen.getByRole('group', { name: 'Workspace tab position' }))
+    expect(screen.getByTestId('workspace-tabs-footer')).toContainElement(screen.getByRole('button', { name: 'Add workspace' }))
+  })
+
+  it('uses a dedicated scroll region above the fixed footer for vertical bars', () => {
+    render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="left"
+        onSelect={() => {}}
+        onAdd={() => {}}
+        onTabPositionChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('workspace-tabs-scroll-region')).toHaveStyle({
+      overflowY: 'auto',
+      overflowX: 'hidden',
+    })
+    expect(screen.getByTestId('workspace-tabs-footer')).toBeInTheDocument()
+  })
+
+  it('renders a resizer only for vertical bars when width changes are enabled', () => {
+    const { rerender } = render(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="left"
+        verticalBarWidth={280}
+        onSelect={() => {}}
+        onVerticalBarWidthChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('workspace-bar-resizer')).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceTabs
+        workspaces={workspaces}
+        activeWorkspaceId="dev"
+        tabPosition="top"
+        verticalBarWidth={280}
+        onSelect={() => {}}
+        onVerticalBarWidthChange={() => {}}
+      />,
+    )
+
+    expect(screen.queryByTestId('workspace-bar-resizer')).not.toBeInTheDocument()
   })
 
   it('hides tab position controls when the position change handler is omitted', () => {

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -149,9 +149,11 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const [draftTitle, setDraftTitle] = useState('')
   const [hoveredDropWorkspaceId, setHoveredDropWorkspaceId] = useState<string | null>(null)
   const [expandedWorkspaceId, setExpandedWorkspaceId] = useState<string | null>(null)
+  const [previewVerticalBarWidth, setPreviewVerticalBarWidth] = useState<number | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const renameFinalizedRef = useRef(false)
-  const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const resizeStateRef = useRef<{ startX: number; startWidth: number; pointerId: number | null } | null>(null)
+  const effectiveVerticalBarWidth = clampVerticalBarWidth(previewVerticalBarWidth ?? verticalBarWidth)
 
   useEffect(() => {
     if (editingWorkspaceId) {
@@ -173,30 +175,70 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   }, [editingWorkspaceId])
 
   useEffect(() => {
+    if (!vertical) {
+      setPreviewVerticalBarWidth(null)
+    }
+  }, [vertical])
+
+  useEffect(() => {
     if (!vertical || !onVerticalBarWidthChange) return
 
-    const handleMouseMove = (event: MouseEvent) => {
+    const handlePointerMove = (event: PointerEvent) => {
       const current = resizeStateRef.current
       if (!current) return
-      const delta = tabPosition === 'left' ? event.clientX - current.startX : current.startX - event.clientX
-      onVerticalBarWidthChange(clampVerticalBarWidth(current.startWidth + delta))
+      if (current.pointerId !== null && event.pointerId !== current.pointerId) return
+      updatePreviewWidth(event.clientX)
     }
 
-    const stopResizing = () => {
-      if (!resizeStateRef.current) return
-      resizeStateRef.current = null
-      document.body.style.userSelect = ''
-      document.body.style.cursor = ''
+    const handleMouseMove = (event: MouseEvent) => {
+      updatePreviewWidth(event.clientX)
     }
 
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', stopResizing)
+    window.addEventListener('pointercancel', stopResizing)
     window.addEventListener('mousemove', handleMouseMove)
     window.addEventListener('mouseup', stopResizing)
+    document.addEventListener('pointermove', handlePointerMove)
+    document.addEventListener('pointerup', stopResizing)
+    document.addEventListener('pointercancel', stopResizing)
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', stopResizing)
     return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', stopResizing)
+      window.removeEventListener('pointercancel', stopResizing)
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', stopResizing)
+      document.removeEventListener('pointermove', handlePointerMove)
+      document.removeEventListener('pointerup', stopResizing)
+      document.removeEventListener('pointercancel', stopResizing)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', stopResizing)
       stopResizing()
     }
-  }, [onVerticalBarWidthChange, tabPosition, vertical])
+  }, [onVerticalBarWidthChange, previewVerticalBarWidth, tabPosition, vertical, verticalBarWidth])
+
+  const updatePreviewWidth = (clientX: number) => {
+    const current = resizeStateRef.current
+    if (!current) return
+    const delta = tabPosition === 'left' ? clientX - current.startX : current.startX - clientX
+    setPreviewVerticalBarWidth(clampVerticalBarWidth(current.startWidth + delta))
+  }
+
+  const commitPreviewWidth = () => {
+    if (previewVerticalBarWidth === null || previewVerticalBarWidth === verticalBarWidth) return
+    onVerticalBarWidthChange?.(previewVerticalBarWidth)
+  }
+
+  const stopResizing = () => {
+    if (!resizeStateRef.current) return
+    resizeStateRef.current = null
+    commitPreviewWidth()
+    setPreviewVerticalBarWidth(null)
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }
 
   const startRename = (workspace: Workspace) => {
     if (!onRename) return
@@ -257,12 +299,50 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     onStartPaneDragFromSummary?.(paneId)
   }
 
-  const handleResizeMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+  const beginResize = (clientX: number, pointerId: number | null) => {
     if (!vertical || !onVerticalBarWidthChange) return
-    resizeStateRef.current = { startX: event.clientX, startWidth: verticalBarWidth }
+    resizeStateRef.current = { startX: clientX, startWidth: effectiveVerticalBarWidth, pointerId }
+    setPreviewVerticalBarWidth(effectiveVerticalBarWidth)
     document.body.style.userSelect = 'none'
     document.body.style.cursor = 'col-resize'
+  }
+
+  const handleResizePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    beginResize(event.clientX, event.pointerId)
     event.preventDefault()
+  }
+
+  const handleResizeMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    beginResize(event.clientX, null)
+    event.preventDefault()
+  }
+
+  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!vertical || !onVerticalBarWidthChange) return
+
+    let nextWidth: number | null = null
+    const step = event.shiftKey ? 24 : 12
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextWidth = clampVerticalBarWidth(effectiveVerticalBarWidth + (tabPosition === 'left' ? -step : step))
+        break
+      case 'ArrowRight':
+        nextWidth = clampVerticalBarWidth(effectiveVerticalBarWidth + (tabPosition === 'left' ? step : -step))
+        break
+      case 'Home':
+        nextWidth = MIN_VERTICAL_BAR_WIDTH
+        break
+      case 'End':
+        nextWidth = MAX_VERTICAL_BAR_WIDTH
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    if (nextWidth !== verticalBarWidth) {
+      onVerticalBarWidthChange(nextWidth)
+    }
   }
 
   if (!showBar) return null
@@ -637,7 +717,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
               ? '0 1px 0 0'
               : '0 0 0 1px',
         overflow: 'visible',
-        width: vertical ? clampVerticalBarWidth(verticalBarWidth) : undefined,
+        width: vertical ? effectiveVerticalBarWidth : undefined,
         minWidth: vertical ? MIN_VERTICAL_BAR_WIDTH : undefined,
         maxWidth: vertical ? MAX_VERTICAL_BAR_WIDTH : undefined,
         position: 'relative',
@@ -662,8 +742,19 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
             <div
               role="separator"
               aria-label="Resize workspace bar"
+              aria-orientation="vertical"
+              aria-valuemin={MIN_VERTICAL_BAR_WIDTH}
+              aria-valuemax={MAX_VERTICAL_BAR_WIDTH}
+              aria-valuenow={effectiveVerticalBarWidth}
               data-testid="workspace-bar-resizer"
+              tabIndex={0}
+              onPointerDown={handleResizePointerDown}
               onMouseDown={handleResizeMouseDown}
+              onPointerMove={(event) => updatePreviewWidth(event.clientX)}
+              onMouseMove={(event) => updatePreviewWidth(event.clientX)}
+              onPointerUp={stopResizing}
+              onMouseUp={stopResizing}
+              onKeyDown={handleResizeKeyDown}
               style={{
                 position: 'absolute',
                 top: 0,

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -153,6 +153,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const inputRef = useRef<HTMLInputElement | null>(null)
   const renameFinalizedRef = useRef(false)
   const resizeStateRef = useRef<{ startX: number; startWidth: number; pointerId: number | null } | null>(null)
+  const previewVerticalBarWidthRef = useRef<number | null>(null)
   const effectiveVerticalBarWidth = clampVerticalBarWidth(previewVerticalBarWidth ?? verticalBarWidth)
 
   useEffect(() => {
@@ -177,8 +178,33 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   useEffect(() => {
     if (!vertical) {
       setPreviewVerticalBarWidth(null)
+      previewVerticalBarWidthRef.current = null
     }
   }, [vertical])
+
+  const setPreviewWidth = (width: number | null) => {
+    previewVerticalBarWidthRef.current = width
+    setPreviewVerticalBarWidth(width)
+  }
+
+  const updatePreviewWidth = (clientX: number) => {
+    const current = resizeStateRef.current
+    if (!current) return
+    const delta = tabPosition === 'left' ? clientX - current.startX : current.startX - clientX
+    setPreviewWidth(clampVerticalBarWidth(current.startWidth + delta))
+  }
+
+  const stopResizing = () => {
+    if (!resizeStateRef.current) return
+    resizeStateRef.current = null
+    const committedWidth = previewVerticalBarWidthRef.current
+    if (committedWidth !== null && committedWidth !== verticalBarWidth) {
+      onVerticalBarWidthChange?.(committedWidth)
+    }
+    setPreviewWidth(null)
+    document.body.style.userSelect = ''
+    document.body.style.cursor = ''
+  }
 
   useEffect(() => {
     if (!vertical || !onVerticalBarWidthChange) return
@@ -199,46 +225,14 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     window.addEventListener('pointercancel', stopResizing)
     window.addEventListener('mousemove', handleMouseMove)
     window.addEventListener('mouseup', stopResizing)
-    document.addEventListener('pointermove', handlePointerMove)
-    document.addEventListener('pointerup', stopResizing)
-    document.addEventListener('pointercancel', stopResizing)
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', stopResizing)
     return () => {
       window.removeEventListener('pointermove', handlePointerMove)
       window.removeEventListener('pointerup', stopResizing)
       window.removeEventListener('pointercancel', stopResizing)
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', stopResizing)
-      document.removeEventListener('pointermove', handlePointerMove)
-      document.removeEventListener('pointerup', stopResizing)
-      document.removeEventListener('pointercancel', stopResizing)
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', stopResizing)
-      stopResizing()
     }
-  }, [onVerticalBarWidthChange, previewVerticalBarWidth, tabPosition, vertical, verticalBarWidth])
-
-  const updatePreviewWidth = (clientX: number) => {
-    const current = resizeStateRef.current
-    if (!current) return
-    const delta = tabPosition === 'left' ? clientX - current.startX : current.startX - clientX
-    setPreviewVerticalBarWidth(clampVerticalBarWidth(current.startWidth + delta))
-  }
-
-  const commitPreviewWidth = () => {
-    if (previewVerticalBarWidth === null || previewVerticalBarWidth === verticalBarWidth) return
-    onVerticalBarWidthChange?.(previewVerticalBarWidth)
-  }
-
-  const stopResizing = () => {
-    if (!resizeStateRef.current) return
-    resizeStateRef.current = null
-    commitPreviewWidth()
-    setPreviewVerticalBarWidth(null)
-    document.body.style.userSelect = ''
-    document.body.style.cursor = ''
-  }
+  }, [onVerticalBarWidthChange, tabPosition, vertical, verticalBarWidth])
 
   const startRename = (workspace: Workspace) => {
     if (!onRename) return
@@ -302,7 +296,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const beginResize = (clientX: number, pointerId: number | null) => {
     if (!vertical || !onVerticalBarWidthChange) return
     resizeStateRef.current = { startX: clientX, startWidth: effectiveVerticalBarWidth, pointerId }
-    setPreviewVerticalBarWidth(effectiveVerticalBarWidth)
+    setPreviewWidth(effectiveVerticalBarWidth)
     document.body.style.userSelect = 'none'
     document.body.style.cursor = 'col-resize'
   }

--- a/frontend/src/components/WorkspaceTabs.tsx
+++ b/frontend/src/components/WorkspaceTabs.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useRef, useState } from 'react'
 import type { TabPosition, Workspace } from '../types'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
+const MIN_VERTICAL_BAR_WIDTH = 180
+const MAX_VERTICAL_BAR_WIDTH = 520
+
 export interface WorkspacePaneSummary {
   id: string
   title: string
@@ -27,6 +30,7 @@ interface WorkspaceTabsProps {
   workspaces: Workspace[]
   activeWorkspaceId: string
   tabPosition: TabPosition
+  verticalBarWidth?: number
   onSelect: (workspaceId: string) => void
   dragSourcePaneId?: string | null
   onMovePaneToWorkspace?: (sourcePaneId: string, workspaceId: string) => void
@@ -34,6 +38,7 @@ interface WorkspaceTabsProps {
   onDelete?: (workspaceId: string) => void
   onRename?: (workspaceId: string, title: string) => void
   onTabPositionChange?: (position: TabPosition) => void
+  onVerticalBarWidthChange?: (width: number) => void
   attentionWorkspaceIds?: ReadonlySet<string>
   onClearAttention?: (workspaceId: string) => void
   workspaceSummaries?: Record<string, WorkspaceSummary>
@@ -120,6 +125,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   workspaces,
   activeWorkspaceId,
   tabPosition,
+  verticalBarWidth = 280,
   onSelect,
   dragSourcePaneId,
   onMovePaneToWorkspace,
@@ -127,6 +133,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   onDelete,
   onRename,
   onTabPositionChange,
+  onVerticalBarWidthChange,
   attentionWorkspaceIds,
   onClearAttention,
   workspaceSummaries,
@@ -144,6 +151,7 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   const [expandedWorkspaceId, setExpandedWorkspaceId] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
   const renameFinalizedRef = useRef(false)
+  const resizeStateRef = useRef<{ startX: number; startWidth: number } | null>(null)
 
   useEffect(() => {
     if (editingWorkspaceId) {
@@ -163,6 +171,32 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
       setExpandedWorkspaceId(editingWorkspaceId)
     }
   }, [editingWorkspaceId])
+
+  useEffect(() => {
+    if (!vertical || !onVerticalBarWidthChange) return
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const current = resizeStateRef.current
+      if (!current) return
+      const delta = tabPosition === 'left' ? event.clientX - current.startX : current.startX - event.clientX
+      onVerticalBarWidthChange(clampVerticalBarWidth(current.startWidth + delta))
+    }
+
+    const stopResizing = () => {
+      if (!resizeStateRef.current) return
+      resizeStateRef.current = null
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', stopResizing)
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', stopResizing)
+      stopResizing()
+    }
+  }, [onVerticalBarWidthChange, tabPosition, vertical])
 
   const startRename = (workspace: Workspace) => {
     if (!onRename) return
@@ -223,18 +257,25 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     onStartPaneDragFromSummary?.(paneId)
   }
 
+  const handleResizeMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!vertical || !onVerticalBarWidthChange) return
+    resizeStateRef.current = { startX: event.clientX, startWidth: verticalBarWidth }
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'col-resize'
+    event.preventDefault()
+  }
+
+  if (!showBar) return null
+
   const positionControls = onTabPositionChange ? (
     <div
       role="group"
       aria-label="Workspace tab position"
       style={{
         display: 'flex',
-        borderLeft: !vertical ? '1px solid #333842' : undefined,
-        borderTop: vertical ? '1px solid #333842' : undefined,
+        alignItems: 'center',
         flexShrink: 0,
         marginLeft: !vertical ? 'auto' : undefined,
-        marginTop: vertical ? 'auto' : undefined,
-        alignItems: 'center',
       }}
     >
       <div
@@ -286,12 +327,304 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
     </div>
   ) : null
 
-  if (!showBar) return null
+  const tabList = showTabs ? (
+    <div
+      role="tablist"
+      aria-orientation="horizontal"
+      style={{
+        display: 'flex',
+        flexDirection: vertical ? 'column' : 'row',
+        flexWrap: vertical ? 'nowrap' : 'wrap',
+        alignContent: 'flex-start',
+        flex: vertical ? undefined : 1,
+        minWidth: 0,
+        minHeight: 0,
+        width: vertical ? '100%' : undefined,
+      }}
+    >
+      {workspaces.map((workspace) => {
+        const active = workspace.id === activeWorkspaceId
+        const editing = editingWorkspaceId === workspace.id
+        const hasAttention = !active && (attentionWorkspaceIds?.has(workspace.id) ?? false)
+        const isWorkspaceDropTarget = Boolean(dragSourcePaneId) && !editing && workspace.id !== activeWorkspaceId
+        const summary = workspaceSummaries?.[workspace.id]
+        const overlaySummary = !vertical && expandedWorkspaceId === workspace.id && summary && !editing ? summary : null
+        const inlineSummary = vertical && summary && !editing ? summary : null
+        const dropHandlers = workspaceDropHandlers(workspace.id, isWorkspaceDropTarget)
+
+        return (
+          <div
+            key={workspace.id}
+            {...dropHandlers}
+            onMouseEnter={() => {
+              dropHandlers.onMouseEnter()
+              setExpandedWorkspaceId(workspace.id)
+            }}
+            onMouseLeave={() => {
+              dropHandlers.onMouseLeave()
+              setExpandedWorkspaceId((current) => current === workspace.id ? null : current)
+            }}
+            onFocusCapture={() => setExpandedWorkspaceId(workspace.id)}
+            onBlurCapture={(event) => {
+              const nextTarget = event.relatedTarget
+              if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return
+              setExpandedWorkspaceId((current) => current === workspace.id ? null : current)
+            }}
+            style={{
+              position: 'relative',
+              display: 'flex',
+              flexDirection: vertical ? 'column' : 'row',
+              flex: vertical ? '0 0 auto' : '0 1 auto',
+              minWidth: vertical ? '100%' : 200,
+            }}
+          >
+            <div
+              className={hasAttention ? 'panemux-workspace-tab-attention' : undefined}
+              style={{
+                borderRight: !vertical ? '1px solid #333842' : undefined,
+                borderBottom: vertical ? '1px solid #333842' : undefined,
+                borderTop: !vertical ? '1px solid #2a2f39' : undefined,
+                backgroundColor: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
+                  ? 'rgba(86, 156, 214, 0.24)'
+                  : active
+                    ? '#2f3540'
+                    : 'transparent',
+                boxShadow: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
+                  ? 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)'
+                  : 'none',
+                display: 'flex',
+                alignItems: 'stretch',
+                minHeight: vertical ? 44 : 48,
+                minWidth: '100%',
+                flex: '1 1 auto',
+              }}
+            >
+              {editing ? (
+                <input
+                  ref={inputRef}
+                  aria-label="Workspace name"
+                  value={draftTitle}
+                  onChange={(event) => setDraftTitle(event.target.value)}
+                  onBlur={() => commitRename(workspace)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      commitRename(workspace)
+                    } else if (event.key === 'Escape') {
+                      cancelRename()
+                    }
+                  }}
+                  style={{
+                    appearance: 'none',
+                    border: '1px solid #5f6b7a',
+                    borderRadius: 3,
+                    backgroundColor: '#15171a',
+                    color: '#ffffff',
+                    flex: 1,
+                    fontFamily: TERMINAL_FONT_FAMILY,
+                    fontSize: 14,
+                    height: vertical ? 28 : 34,
+                    margin: '10px 8px',
+                    minWidth: 0,
+                    padding: '0 8px',
+                  }}
+                />
+              ) : (
+                <InteractiveSurfaceButton
+                  role="tab"
+                  aria-selected={active}
+                  data-attention={hasAttention ? 'true' : undefined}
+                  onClick={() => {
+                    if (dragSourcePaneId) return
+                    onClearAttention?.(workspace.id)
+                    onSelect(workspace.id)
+                  }}
+                  onDoubleClick={() => startRename(workspace)}
+                  title={workspace.title}
+                  selected={active}
+                  style={{
+                    border: 'none',
+                    color: active ? '#ffffff' : '#b8beca',
+                    cursor: active ? 'default' : 'pointer',
+                    flex: 1,
+                    fontFamily: TERMINAL_FONT_FAMILY,
+                    fontSize: 13,
+                    minWidth: 0,
+                    padding: '8px 10px',
+                    textAlign: 'left',
+                  }}
+                >
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+                      <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: 700, fontSize: 13 }}>
+                        {workspace.title}
+                      </span>
+                      {summary && (
+                        <span style={{ color: active ? '#c4d0df' : '#8f98a8', fontSize: 10, whiteSpace: 'nowrap' }}>
+                          {formatWorkspaceCounts(summary)}
+                        </span>
+                      )}
+                    </div>
+                    {summary && (
+                      <span
+                        style={{
+                          color: active ? '#d7dce5' : '#9aa3b2',
+                          fontSize: 11,
+                          lineHeight: 1.3,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {summary.panes.map((pane) => pane.title).join(' · ')}
+                      </span>
+                    )}
+                  </div>
+                </InteractiveSurfaceButton>
+              )}
+              {onRename && !editing && (
+                <InteractiveSurfaceButton
+                  type="button"
+                  aria-label={`Rename ${workspace.title} workspace`}
+                  title="Rename workspace"
+                  onClick={() => startRename(workspace)}
+                  style={{
+                    border: 'none',
+                    color: active ? '#d7dce5' : '#8f96a3',
+                    cursor: 'pointer',
+                    flex: '0 0 32px',
+                    fontFamily: TERMINAL_FONT_FAMILY,
+                    fontSize: 13,
+                    padding: 0,
+                    textAlign: 'center',
+                  }}
+                >
+                  ✎
+                </InteractiveSurfaceButton>
+              )}
+              {onDelete && (
+                <InteractiveSurfaceButton
+                  type="button"
+                  aria-label={`Delete ${workspace.title} workspace`}
+                  title="Delete workspace"
+                  onClick={() => onDelete(workspace.id)}
+                  danger
+                  style={{
+                    border: 'none',
+                    cursor: 'pointer',
+                    flex: '0 0 32px',
+                    fontFamily: TERMINAL_FONT_FAMILY,
+                    fontSize: 16,
+                    padding: 0,
+                    textAlign: 'center',
+                  }}
+                >
+                  ×
+                </InteractiveSurfaceButton>
+              )}
+            </div>
+            {overlaySummary && (
+              <SummarySection
+                summary={overlaySummary}
+                workspace={workspace}
+                active={active}
+                vertical={vertical}
+                activePaneId={activePaneId}
+                dragSourcePaneId={dragSourcePaneId}
+                onSelectPaneFromSummary={onSelectPaneFromSummary}
+                onStartPaneDragFromSummary={handleSummaryPaneDragStart}
+                onEndPaneDragFromSummary={onEndPaneDragFromSummary}
+                overlay
+                tabPosition={tabPosition}
+              />
+            )}
+            {inlineSummary && (
+              <SummarySection
+                summary={inlineSummary}
+                workspace={workspace}
+                active={active}
+                vertical={vertical}
+                activePaneId={activePaneId}
+                dragSourcePaneId={dragSourcePaneId}
+                onSelectPaneFromSummary={onSelectPaneFromSummary}
+                onStartPaneDragFromSummary={handleSummaryPaneDragStart}
+                onEndPaneDragFromSummary={onEndPaneDragFromSummary}
+              />
+            )}
+          </div>
+        )
+      })}
+    </div>
+  ) : null
+
+  const horizontalActions = (
+    <>
+      {onAdd && (
+        <div
+          style={{
+            borderLeft: '1px solid #333842',
+            backgroundColor: 'transparent',
+            display: 'flex',
+            alignItems: 'center',
+            minWidth: 40,
+            maxWidth: 40,
+            flexShrink: 0,
+          }}
+        >
+          <InteractiveSurfaceButton
+            type="button"
+            aria-label="Add workspace"
+            title="Add workspace"
+            onClick={onAdd}
+            style={actionButtonStyle(false)}
+          >
+            +
+          </InteractiveSurfaceButton>
+        </div>
+      )}
+      {positionControls}
+    </>
+  )
+
+  const verticalFooter = (
+    <div
+      data-testid="workspace-tabs-footer"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '8px',
+        borderTop: '1px solid #333842',
+        background: '#1d1f23',
+        flexShrink: 0,
+      }}
+    >
+      {onAdd && (
+        <InteractiveSurfaceButton
+          type="button"
+          aria-label="Add workspace"
+          title="Add workspace"
+          onClick={onAdd}
+          style={{
+            ...actionButtonStyle(true),
+            minWidth: 40,
+            maxWidth: 40,
+            height: 34,
+            borderRadius: 6,
+            border: '1px solid #333842',
+          }}
+        >
+          +
+        </InteractiveSurfaceButton>
+      )}
+      {positionControls}
+    </div>
+  )
 
   return (
     <div
       style={{
         display: 'flex',
+        flexDirection: vertical ? 'column' : 'row',
         flexShrink: 0,
         backgroundColor: '#202124',
         borderColor: '#333842',
@@ -303,474 +636,215 @@ export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
             : tabPosition === 'left'
               ? '0 1px 0 0'
               : '0 0 0 1px',
-        flexDirection: vertical ? 'column' : 'row',
         overflow: 'visible',
-        maxWidth: vertical ? 360 : undefined,
-        minWidth: vertical ? 280 : undefined,
+        width: vertical ? clampVerticalBarWidth(verticalBarWidth) : undefined,
+        minWidth: vertical ? MIN_VERTICAL_BAR_WIDTH : undefined,
+        maxWidth: vertical ? MAX_VERTICAL_BAR_WIDTH : undefined,
         position: 'relative',
         zIndex: 20,
       }}
     >
-      {showTabs && (
-        <div
-          role="tablist"
-          aria-orientation="horizontal"
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            flexWrap: 'wrap',
-            alignContent: 'flex-start',
-            flex: 1,
-            minWidth: 0,
-            minHeight: 0,
-            overflow: 'visible',
-          }}
-        >
-          {workspaces.map((workspace) => {
-            const active = workspace.id === activeWorkspaceId
-            const editing = editingWorkspaceId === workspace.id
-            const hasAttention = !active && (attentionWorkspaceIds?.has(workspace.id) ?? false)
-            const isWorkspaceDropTarget = Boolean(dragSourcePaneId) && !editing && workspace.id !== activeWorkspaceId
-            const summary = workspaceSummaries?.[workspace.id]
-            const overlaySummary = !vertical && expandedWorkspaceId === workspace.id && summary && !editing ? summary : null
-            const inlineSummary = vertical && summary && !editing ? summary : null
-            const dropHandlers = workspaceDropHandlers(workspace.id, isWorkspaceDropTarget)
-
-            return (
-              <div
-                key={workspace.id}
-                {...dropHandlers}
-                onMouseEnter={() => {
-                  dropHandlers.onMouseEnter()
-                  setExpandedWorkspaceId(workspace.id)
-                }}
-                onMouseLeave={() => {
-                  dropHandlers.onMouseLeave()
-                  setExpandedWorkspaceId((current) => current === workspace.id ? null : current)
-                }}
-                onFocusCapture={() => setExpandedWorkspaceId(workspace.id)}
-                onBlurCapture={(event) => {
-                  const nextTarget = event.relatedTarget
-                  if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return
-                  setExpandedWorkspaceId((current) => current === workspace.id ? null : current)
-                }}
-                style={{
-                  position: 'relative',
-                  display: 'flex',
-                  flexDirection: vertical ? 'column' : 'row',
-                  flex: vertical ? '1 1 100%' : '0 1 auto',
-                  minWidth: vertical ? '100%' : 200,
-                }}
-              >
-                <div
-                  className={hasAttention ? 'panemux-workspace-tab-attention' : undefined}
-                  style={{
-                    borderRight: !vertical ? '1px solid #333842' : undefined,
-                    borderBottom: vertical ? '1px solid #333842' : undefined,
-                    borderTop: !vertical ? '1px solid #2a2f39' : undefined,
-                    backgroundColor: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
-                      ? 'rgba(86, 156, 214, 0.24)'
-                      : active
-                        ? '#2f3540'
-                        : 'transparent',
-                    boxShadow: dragSourcePaneId && hoveredDropWorkspaceId === workspace.id
-                      ? 'inset 0 0 0 1px rgba(137, 196, 244, 0.45)'
-                      : 'none',
-                    display: 'flex',
-                    alignItems: 'stretch',
-                    minHeight: vertical ? 44 : 48,
-                    minWidth: '100%',
-                    flex: '1 1 auto',
-                  }}
-                >
-                  {editing ? (
-                    <input
-                      ref={inputRef}
-                      aria-label="Workspace name"
-                      value={draftTitle}
-                      onChange={(event) => setDraftTitle(event.target.value)}
-                      onBlur={() => commitRename(workspace)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          commitRename(workspace)
-                        } else if (event.key === 'Escape') {
-                          cancelRename()
-                        }
-                      }}
-                      style={{
-                        appearance: 'none',
-                        border: '1px solid #5f6b7a',
-                        borderRadius: 3,
-                        backgroundColor: '#15171a',
-                        color: '#ffffff',
-                        flex: 1,
-                        fontFamily: TERMINAL_FONT_FAMILY,
-                        fontSize: 14,
-                        height: vertical ? 28 : 34,
-                        margin: '10px 8px',
-                        minWidth: 0,
-                        padding: '0 8px',
-                      }}
-                    />
-                  ) : (
-                    <InteractiveSurfaceButton
-                      role="tab"
-                      aria-selected={active}
-                      data-attention={hasAttention ? 'true' : undefined}
-                      onClick={() => {
-                        if (dragSourcePaneId) return
-                        onClearAttention?.(workspace.id)
-                        onSelect(workspace.id)
-                      }}
-                      onDoubleClick={() => startRename(workspace)}
-                      title={workspace.title}
-                      selected={active}
-                      style={{
-                        border: 'none',
-                        color: active ? '#ffffff' : '#b8beca',
-                        cursor: active ? 'default' : 'pointer',
-                        flex: 1,
-                        fontFamily: TERMINAL_FONT_FAMILY,
-                        fontSize: 13,
-                        minWidth: 0,
-                        padding: '8px 10px',
-                        textAlign: 'left',
-                      }}
-                    >
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 0 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
-                          <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontWeight: 700, fontSize: 13 }}>
-                            {workspace.title}
-                          </span>
-                          {summary && (
-                            <span style={{ color: active ? '#c4d0df' : '#8f98a8', fontSize: 10, whiteSpace: 'nowrap' }}>
-                              {formatWorkspaceCounts(summary)}
-                            </span>
-                          )}
-                        </div>
-                        {summary && (
-                          <span
-                            style={{
-                              color: active ? '#d7dce5' : '#9aa3b2',
-                              fontSize: 11,
-                              lineHeight: 1.3,
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            }}
-                          >
-                            {summary.panes.map((pane) => pane.title).join(' · ')}
-                          </span>
-                        )}
-                      </div>
-                    </InteractiveSurfaceButton>
-                  )}
-                  {onRename && !editing && (
-                    <InteractiveSurfaceButton
-                      type="button"
-                      aria-label={`Rename ${workspace.title} workspace`}
-                      title="Rename workspace"
-                      onClick={() => startRename(workspace)}
-                      style={{
-                        border: 'none',
-                        color: active ? '#d7dce5' : '#8f96a3',
-                        cursor: 'pointer',
-                        flex: '0 0 32px',
-                        fontFamily: TERMINAL_FONT_FAMILY,
-                        fontSize: 13,
-                        padding: 0,
-                        textAlign: 'center',
-                      }}
-                    >
-                      ✎
-                    </InteractiveSurfaceButton>
-                  )}
-                  {onDelete && (
-                    <InteractiveSurfaceButton
-                      type="button"
-                      aria-label={`Delete ${workspace.title} workspace`}
-                      title="Delete workspace"
-                      onClick={() => onDelete(workspace.id)}
-                      danger
-                      style={{
-                        border: 'none',
-                        cursor: 'pointer',
-                        flex: '0 0 32px',
-                        fontFamily: TERMINAL_FONT_FAMILY,
-                        fontSize: 16,
-                        padding: 0,
-                        textAlign: 'center',
-                      }}
-                    >
-                      ×
-                    </InteractiveSurfaceButton>
-                  )}
-                </div>
-                {overlaySummary && (
-                  <section
-                    aria-label={`${workspace.title} workspace details`}
-                    style={{
-                      position: 'absolute',
-                      ...overlayPositionStyle(tabPosition),
-                      width: vertical ? 320 : 360,
-                      maxWidth: 'min(360px, calc(100vw - 32px))',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 6,
-                      padding: '8px',
-                      border: '1px solid #30353f',
-                      borderRadius: 10,
-                      background: active ? 'linear-gradient(180deg, #212733 0%, #1a1f28 100%)' : 'linear-gradient(180deg, #181a1f 0%, #15171b 100%)',
-                      boxShadow: '0 14px 28px rgba(0, 0, 0, 0.38)',
-                      zIndex: 30,
-                    }}
-                  >
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <span style={workspaceMarkerStyle(active)} />
-                      <div style={{ color: active ? '#cfdced' : '#8f98a8', fontFamily: TERMINAL_FONT_FAMILY, fontSize: 10, lineHeight: 1.3 }}>
-                        {formatWorkspaceCounts(overlaySummary, true)}
-                      </div>
-                    </div>
-                    <div
-                      data-testid={`workspace-pane-group-${workspace.id}`}
-                      style={{
-                        display: 'grid',
-                        gridTemplateColumns: vertical ? 'minmax(0, 1fr)' : 'repeat(auto-fit, minmax(160px, 1fr))',
-                        gap: 6,
-                        alignItems: 'start',
-                        marginLeft: 10,
-                        paddingLeft: 12,
-                        borderLeft: '1px solid #364050',
-                      }}
-                    >
-                      {overlaySummary.panes.map((pane) => (
-                        <button
-                          key={pane.id}
-                          type="button"
-                          aria-label={`Open pane ${pane.title} in ${workspace.title}`}
-                          draggable
-                          onDragStart={(event) => handleSummaryPaneDragStart(event, pane.id)}
-                          onDragEnd={() => onEndPaneDragFromSummary?.()}
-                          onClick={() => {
-                            if (dragSourcePaneId) return
-                            onSelectPaneFromSummary?.(workspace.id, pane.id)
-                          }}
-                          style={{
-                            appearance: 'none',
-                            border: activePaneId === pane.id ? '1px solid rgba(137, 196, 244, 0.75)' : '1px solid #2d323c',
-                            borderRadius: 8,
-                            background: activePaneId === pane.id
-                              ? 'rgba(86, 156, 214, 0.16)'
-                              : pane.attention
-                                ? 'rgba(244, 191, 79, 0.08)'
-                                : '#1b1e24',
-                            color: '#d7dce5',
-                            padding: '7px 8px',
-                            textAlign: 'left',
-                            cursor: onSelectPaneFromSummary ? 'pointer' : 'default',
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 4,
-                            fontFamily: TERMINAL_FONT_FAMILY,
-                            boxShadow: activePaneId === pane.id ? '0 0 0 1px rgba(137, 196, 244, 0.18)' : 'none',
-                            minHeight: 0,
-                          }}
-                        >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
-                            <span style={statusDotStyle(pane.state)} />
-                            <span
-                              style={{
-                                fontSize: 11,
-                                fontWeight: 700,
-                                minWidth: 0,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                flex: '1 1 auto',
-                              }}
-                            >
-                              {pane.title}
-                            </span>
-                            {pane.connection && <span style={pillStyle('#2d253f', '#cbb3ff', true)}>{pane.connection}</span>}
-                            {pane.attention && <span style={pillStyle('#5a4311', '#f4bf4f', true)}>Input</span>}
-                          </div>
-                          <div
-                            style={{
-                              display: 'flex',
-                              gap: 6,
-                              flexWrap: 'nowrap',
-                              color: '#8f98a8',
-                              fontSize: 10,
-                              minWidth: 0,
-                              overflow: 'hidden',
-                            }}
-                          >
-                            {pane.repo && (
-                              <span style={{ color: '#9fcbff', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                {pane.repo}
-                              </span>
-                            )}
-                            {pane.branch && (
-                              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.branch}</span>
-                            )}
-                            {pane.connection && !pane.repo && (
-                              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.type}</span>
-                            )}
-                            {!pane.repo && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{pane.state}</span>}
-                            {pane.prNumber && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>PR #{pane.prNumber}</span>}
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  </section>
-                )}
-                {inlineSummary && (
-                  <section
-                    aria-label={`${workspace.title} workspace details`}
-                    style={{
-                      flexBasis: 'auto',
-                      width: '100%',
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 6,
-                      padding: '6px 8px 8px',
-                      borderTop: '1px solid #30353f',
-                      borderBottom: '1px solid #333842',
-                      background: active ? 'linear-gradient(180deg, #212733 0%, #1a1f28 100%)' : 'linear-gradient(180deg, #181a1f 0%, #15171b 100%)',
-                    }}
-                  >
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                      <span style={workspaceMarkerStyle(active)} />
-                      <div style={{ color: active ? '#cfdced' : '#8f98a8', fontFamily: TERMINAL_FONT_FAMILY, fontSize: 10, lineHeight: 1.3 }}>
-                        {formatWorkspaceCounts(inlineSummary, true)}
-                      </div>
-                    </div>
-                    <div
-                      data-testid={`workspace-pane-group-${workspace.id}`}
-                      style={{
-                        display: 'grid',
-                        gridTemplateColumns: vertical ? 'minmax(0, 1fr)' : 'repeat(auto-fit, minmax(160px, 1fr))',
-                        gap: 6,
-                        alignItems: 'start',
-                        marginLeft: 10,
-                        paddingLeft: 12,
-                        borderLeft: '1px solid #364050',
-                      }}
-                    >
-                      {inlineSummary.panes.map((pane) => (
-                        <button
-                          key={pane.id}
-                          type="button"
-                          aria-label={`Open pane ${pane.title} in ${workspace.title}`}
-                          draggable
-                          onDragStart={(event) => handleSummaryPaneDragStart(event, pane.id)}
-                          onDragEnd={() => onEndPaneDragFromSummary?.()}
-                          onClick={() => {
-                            if (dragSourcePaneId) return
-                            onSelectPaneFromSummary?.(workspace.id, pane.id)
-                          }}
-                          style={{
-                            appearance: 'none',
-                            border: activePaneId === pane.id ? '1px solid rgba(137, 196, 244, 0.75)' : '1px solid #2d323c',
-                            borderRadius: 8,
-                            background: activePaneId === pane.id
-                              ? 'rgba(86, 156, 214, 0.16)'
-                              : pane.attention
-                                ? 'rgba(244, 191, 79, 0.08)'
-                                : '#1b1e24',
-                            color: '#d7dce5',
-                            padding: '7px 8px',
-                            textAlign: 'left',
-                            cursor: onSelectPaneFromSummary ? 'pointer' : 'default',
-                            display: 'flex',
-                            flexDirection: 'column',
-                            gap: 4,
-                            fontFamily: TERMINAL_FONT_FAMILY,
-                            boxShadow: activePaneId === pane.id ? '0 0 0 1px rgba(137, 196, 244, 0.18)' : 'none',
-                            minHeight: 0,
-                          }}
-                        >
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
-                            <span style={statusDotStyle(pane.state)} />
-                            <span
-                              style={{
-                                fontSize: 11,
-                                fontWeight: 700,
-                                minWidth: 0,
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                whiteSpace: 'nowrap',
-                                flex: '1 1 auto',
-                              }}
-                            >
-                              {pane.title}
-                            </span>
-                            {pane.connection && <span style={pillStyle('#2d253f', '#cbb3ff', true)}>{pane.connection}</span>}
-                            {pane.attention && <span style={pillStyle('#5a4311', '#f4bf4f', true)}>Input</span>}
-                          </div>
-                          <div
-                            style={{
-                              display: 'flex',
-                              gap: 6,
-                              flexWrap: 'nowrap',
-                              color: '#8f98a8',
-                              fontSize: 10,
-                              minWidth: 0,
-                              overflow: 'hidden',
-                            }}
-                          >
-                            {pane.repo && (
-                              <span style={{ color: '#9fcbff', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                {pane.repo}
-                              </span>
-                            )}
-                            {pane.branch && (
-                              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.branch}</span>
-                            )}
-                            {pane.connection && !pane.repo && (
-                              <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.type}</span>
-                            )}
-                            {!pane.repo && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{pane.state}</span>}
-                            {pane.prNumber && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>PR #{pane.prNumber}</span>}
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  </section>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      )}
-      {onAdd && (
-        <div
-          style={{
-            borderLeft: !vertical ? '1px solid #333842' : undefined,
-            borderTop: vertical ? '1px solid #333842' : undefined,
-            backgroundColor: 'transparent',
-            display: 'flex',
-            alignItems: 'center',
-            height: vertical ? 40 : 'auto',
-            minWidth: vertical ? '100%' : 40,
-            maxWidth: vertical ? '100%' : 40,
-            flexShrink: 0,
-          }}
-        >
-          <InteractiveSurfaceButton
-            type="button"
-            aria-label="Add workspace"
-            title="Add workspace"
-            onClick={onAdd}
-            style={actionButtonStyle(vertical)}
+      {vertical ? (
+        <>
+          <div
+            data-testid="workspace-tabs-scroll-region"
+            style={{
+              flex: 1,
+              minHeight: 0,
+              overflowY: 'auto',
+              overflowX: 'hidden',
+            }}
           >
-            +
-          </InteractiveSurfaceButton>
-        </div>
+            {tabList}
+          </div>
+          {verticalFooter}
+          {onVerticalBarWidthChange && (
+            <div
+              role="separator"
+              aria-label="Resize workspace bar"
+              data-testid="workspace-bar-resizer"
+              onMouseDown={handleResizeMouseDown}
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                [tabPosition === 'left' ? 'right' : 'left']: -3,
+                width: 6,
+                cursor: 'col-resize',
+                zIndex: 35,
+              }}
+            />
+          )}
+        </>
+      ) : (
+        <>
+          {tabList}
+          {horizontalActions}
+        </>
       )}
-      {positionControls}
     </div>
   )
+}
+
+interface SummarySectionProps {
+  summary: WorkspaceSummary
+  workspace: Workspace
+  active: boolean
+  vertical: boolean
+  activePaneId?: string | null
+  dragSourcePaneId?: string | null
+  tabPosition?: TabPosition
+  overlay?: boolean
+  onSelectPaneFromSummary?: (workspaceId: string, paneId: string) => void
+  onStartPaneDragFromSummary?: (event: React.DragEvent<HTMLButtonElement>, paneId: string) => void
+  onEndPaneDragFromSummary?: () => void
+}
+
+function SummarySection({
+  summary,
+  workspace,
+  active,
+  vertical,
+  activePaneId,
+  dragSourcePaneId,
+  tabPosition = 'top',
+  overlay = false,
+  onSelectPaneFromSummary,
+  onStartPaneDragFromSummary,
+  onEndPaneDragFromSummary,
+}: SummarySectionProps) {
+  return (
+    <section
+      aria-label={`${workspace.title} workspace details`}
+      style={overlay ? {
+        position: 'absolute',
+        ...overlayPositionStyle(tabPosition),
+        width: vertical ? 320 : 360,
+        maxWidth: 'min(360px, calc(100vw - 32px))',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        padding: '8px',
+        border: '1px solid #30353f',
+        borderRadius: 10,
+        background: active ? 'linear-gradient(180deg, #212733 0%, #1a1f28 100%)' : 'linear-gradient(180deg, #181a1f 0%, #15171b 100%)',
+        boxShadow: '0 14px 28px rgba(0, 0, 0, 0.38)',
+        zIndex: 30,
+      } : {
+        flexBasis: 'auto',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        padding: '6px 8px 8px',
+        borderTop: '1px solid #30353f',
+        borderBottom: '1px solid #333842',
+        background: active ? 'linear-gradient(180deg, #212733 0%, #1a1f28 100%)' : 'linear-gradient(180deg, #181a1f 0%, #15171b 100%)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={workspaceMarkerStyle(active)} />
+        <div style={{ color: active ? '#cfdced' : '#8f98a8', fontFamily: TERMINAL_FONT_FAMILY, fontSize: 10, lineHeight: 1.3 }}>
+          {formatWorkspaceCounts(summary, true)}
+        </div>
+      </div>
+      <div
+        data-testid={`workspace-pane-group-${workspace.id}`}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: vertical ? 'minmax(0, 1fr)' : 'repeat(auto-fit, minmax(160px, 1fr))',
+          gap: 6,
+          alignItems: 'start',
+          marginLeft: 10,
+          paddingLeft: 12,
+          borderLeft: '1px solid #364050',
+        }}
+      >
+        {summary.panes.map((pane) => (
+          <button
+            key={pane.id}
+            type="button"
+            aria-label={`Open pane ${pane.title} in ${workspace.title}`}
+            draggable
+            onDragStart={(event) => onStartPaneDragFromSummary?.(event, pane.id)}
+            onDragEnd={() => onEndPaneDragFromSummary?.()}
+            onClick={() => {
+              if (dragSourcePaneId) return
+              onSelectPaneFromSummary?.(workspace.id, pane.id)
+            }}
+            style={{
+              appearance: 'none',
+              border: activePaneId === pane.id ? '1px solid rgba(137, 196, 244, 0.75)' : '1px solid #2d323c',
+              borderRadius: 8,
+              background: activePaneId === pane.id
+                ? 'rgba(86, 156, 214, 0.16)'
+                : pane.attention
+                  ? 'rgba(244, 191, 79, 0.08)'
+                  : '#1b1e24',
+              color: '#d7dce5',
+              padding: '7px 8px',
+              textAlign: 'left',
+              cursor: onSelectPaneFromSummary ? 'pointer' : 'default',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+              fontFamily: TERMINAL_FONT_FAMILY,
+              boxShadow: activePaneId === pane.id ? '0 0 0 1px rgba(137, 196, 244, 0.18)' : 'none',
+              minHeight: 0,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+              <span style={statusDotStyle(pane.state)} />
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  flex: '1 1 auto',
+                }}
+              >
+                {pane.title}
+              </span>
+              {pane.connection && <span style={pillStyle('#2d253f', '#cbb3ff', true)}>{pane.connection}</span>}
+              {pane.attention && <span style={pillStyle('#5a4311', '#f4bf4f', true)}>Input</span>}
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                gap: 6,
+                flexWrap: 'nowrap',
+                color: '#8f98a8',
+                fontSize: 10,
+                minWidth: 0,
+                overflow: 'hidden',
+              }}
+            >
+              {pane.repo && (
+                <span style={{ color: '#9fcbff', minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {pane.repo}
+                </span>
+              )}
+              {pane.branch && (
+                <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.branch}</span>
+              )}
+              {pane.connection && !pane.repo && (
+                <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{pane.type}</span>
+              )}
+              {!pane.repo && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{pane.state}</span>}
+              {pane.prNumber && <span style={{ whiteSpace: 'nowrap', flexShrink: 0 }}>PR #{pane.prNumber}</span>}
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function clampVerticalBarWidth(width: number) {
+  return Math.max(MIN_VERTICAL_BAR_WIDTH, Math.min(MAX_VERTICAL_BAR_WIDTH, Math.round(width)))
 }
 
 function actionButtonStyle(vertical: boolean): React.CSSProperties {

--- a/frontend/src/hooks/useLayout.test.ts
+++ b/frontend/src/hooks/useLayout.test.ts
@@ -13,6 +13,7 @@ const validDisplay = { show_header: true, show_status_bar: true }
 const validWorkspaces = {
   active: 'dev',
   tab_position: 'top',
+  vertical_bar_width: 280,
   items: [
     { id: 'dev', title: 'Dev', layout: validLayout },
     {
@@ -30,6 +31,7 @@ function workspacesForLayout(layout: LayoutNode) {
   return {
     active: 'dev',
     tab_position: 'top',
+    vertical_bar_width: 280,
     items: [{ id: 'dev', title: 'Dev', layout }],
   }
 }
@@ -153,6 +155,7 @@ describe('useLayout', () => {
     const remainingWorkspaces = {
       active: 'ops',
       tab_position: 'top',
+      vertical_bar_width: 280,
       items: [validWorkspaces.items[1]],
     }
     const fetchMock = vi.fn()
@@ -369,6 +372,56 @@ describe('useLayout', () => {
 
     expect(result.current.error).toContain('422')
     expect(result.current.workspaces?.tab_position).toBe('top')
+  })
+
+  it('updates workspace vertical bar width optimistically and persists it', async () => {
+    const updatedWorkspaces = { ...validWorkspaces, vertical_bar_width: 320 }
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(updatedWorkspaces) } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    act(() => {
+      result.current.setWorkspaceVerticalBarWidth(320)
+    })
+
+    expect(result.current.workspaces?.vertical_bar_width).toBe(320)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/workspaces/vertical-bar-width', expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ vertical_bar_width: 320 }),
+      }))
+    })
+    expect(result.current.workspaces?.vertical_bar_width).toBe(320)
+  })
+
+  it('sets error when updating workspace vertical bar width fails', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validWorkspaces) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(validDisplay) } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 422 } as Response)
+    window.fetch = fetchMock
+
+    const { result } = renderHook(() => useLayout())
+    await waitFor(() => expect(result.current.workspaces).not.toBeNull())
+
+    act(() => {
+      result.current.setWorkspaceVerticalBarWidth(120)
+    })
+    expect(result.current.error).toContain('greater than or equal to 180')
+
+    act(() => {
+      result.current.setWorkspaceVerticalBarWidth(320)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toContain('422')
+    })
   })
 
   it('fetches display config on mount', async () => {
@@ -995,6 +1048,7 @@ describe('useLayout', () => {
       const multiPaneWorkspaces = {
         active: 'dev',
         tab_position: 'top' as const,
+        vertical_bar_width: 280,
         items: [
           {
             id: 'dev',
@@ -1063,6 +1117,7 @@ describe('useLayout', () => {
       const multiPaneWorkspaces = {
         active: 'dev',
         tab_position: 'top' as const,
+        vertical_bar_width: 280,
         items: [
           {
             id: 'dev',
@@ -1113,6 +1168,7 @@ describe('useLayout', () => {
       const multiPaneWorkspaces = {
         active: 'dev',
         tab_position: 'top' as const,
+        vertical_bar_width: 280,
         items: [
           {
             id: 'dev',

--- a/frontend/src/hooks/useLayout.ts
+++ b/frontend/src/hooks/useLayout.ts
@@ -1,5 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { DetectShellResponseSchema, DisplayConfig, DisplayConfigSchema, LayoutNode, PaneConfig, TabPosition, WorkspacesResponse, WorkspacesResponseSchema, WorkspaceTabPositionRequestSchema } from '../schemas'
+import {
+  DetectShellResponseSchema,
+  DisplayConfig,
+  DisplayConfigSchema,
+  LayoutNode,
+  PaneConfig,
+  TabPosition,
+  WorkspacesResponse,
+  WorkspacesResponseSchema,
+  WorkspaceTabPositionRequestSchema,
+  WorkspaceVerticalBarWidthRequestSchema,
+} from '../schemas'
 import { PaneEdge, findPaneById, generatePaneId, generateTmuxSessionName, insertPaneAtWorkspaceEdge, insertPaneBesideTargetPane, layoutContainsPane, movePaneBesideTargetPane, movePaneToWorkspaceEdge, removePaneFromTree, splitPaneInTree, swapPanesInTree } from '../utils/layoutTree'
 
 type WorkspaceEdgePlacement = { type: 'workspace-edge'; edge: PaneEdge }
@@ -15,6 +26,7 @@ export function useLayout() {
   const [displayConfig, setDisplayConfig] = useState<DisplayConfig | null>(null)
   const [error, setError] = useState<string | null>(null)
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const workspaceBarWidthSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     fetch('/api/workspaces')
@@ -175,6 +187,33 @@ export function useLayout() {
     }
   }, [])
 
+  const setWorkspaceVerticalBarWidth = useCallback((width: number) => {
+    try {
+      setError(null)
+      const request = WorkspaceVerticalBarWidthRequestSchema.parse({ vertical_bar_width: width })
+      setWorkspaces((current) => current ? { ...current, vertical_bar_width: request.vertical_bar_width } : current)
+
+      if (workspaceBarWidthSaveTimerRef.current) clearTimeout(workspaceBarWidthSaveTimerRef.current)
+      workspaceBarWidthSaveTimerRef.current = setTimeout(() => {
+        fetch('/api/workspaces/vertical-bar-width', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(request),
+        })
+          .then(async (response) => {
+            if (!response.ok) throw new Error(`HTTP ${response.status}`)
+            const parsed = WorkspacesResponseSchema.parse(await response.json())
+            setWorkspaces((current) => current ? { ...parsed, items: current.items } : parsed)
+          })
+          .catch((err) => {
+            setError(err instanceof Error ? err.message : 'Failed to update workspace bar width')
+          })
+      }, 150)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update workspace bar width')
+    }
+  }, [])
+
   const splitPane = useCallback(
     async (targetPaneId: string, direction: 'horizontal' | 'vertical') => {
       if (!layout) return
@@ -316,7 +355,24 @@ export function useLayout() {
     await saveLayout(newLayout, true)
   }, [layout, saveLayout, workspaces])
 
-  return { layout, workspaces, displayConfig, error, updateSizes, splitPane, closePane, swapPanes, createPane, movePane, setActiveWorkspace, addWorkspace, deleteWorkspace, renameWorkspace, setWorkspaceTabPosition }
+  return {
+    layout,
+    workspaces,
+    displayConfig,
+    error,
+    updateSizes,
+    splitPane,
+    closePane,
+    swapPanes,
+    createPane,
+    movePane,
+    setActiveWorkspace,
+    addWorkspace,
+    deleteWorkspace,
+    renameWorkspace,
+    setWorkspaceTabPosition,
+    setWorkspaceVerticalBarWidth,
+  }
 }
 
 async function saveWorkspaceLayout(workspaceID: string, updatedLayout: LayoutNode) {

--- a/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
+++ b/frontend/src/hooks/useWorkspaceAttentionMonitor.test.ts
@@ -41,6 +41,7 @@ class MockWebSocket {
 const workspaces: WorkspacesResponse = {
   active: 'dev',
   tab_position: 'top',
+  vertical_bar_width: 280,
   items: [
     {
       id: 'dev',

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -12,6 +12,7 @@ import {
   SSHConfigHostsResponseSchema,
   DetectShellResponseSchema,
   WorkspaceTabPositionRequestSchema,
+  WorkspaceVerticalBarWidthRequestSchema,
   WorkspacesResponseSchema,
   DirectoryEntrySchema,
   DirectoryBrowserResponseSchema,
@@ -143,6 +144,7 @@ describe('WorkspacesResponseSchema', () => {
     const result = WorkspacesResponseSchema.safeParse({
       active: 'dev',
       tab_position: 'left',
+      vertical_bar_width: 280,
       items: [
         {
           id: 'dev',
@@ -161,6 +163,7 @@ describe('WorkspacesResponseSchema', () => {
     const result = WorkspacesResponseSchema.safeParse({
       active: 'dev',
       tab_position: 'diagonal',
+      vertical_bar_width: 280,
       items: [
         {
           id: 'dev',
@@ -177,6 +180,7 @@ describe('WorkspacesResponseSchema', () => {
       const result = WorkspacesResponseSchema.safeParse({
         active: 'dev',
         tab_position: tabPosition,
+        vertical_bar_width: 280,
         items: [
           {
             id: 'dev',
@@ -196,17 +200,37 @@ describe('WorkspacesResponseSchema', () => {
     expect(WorkspacesResponseSchema.safeParse({
       active: 'dev',
       tab_position: 'top',
+      vertical_bar_width: 280,
       items: [],
     }).success).toBe(false)
 
     expect(WorkspacesResponseSchema.safeParse({
       active: '',
       tab_position: 'top',
+      vertical_bar_width: 280,
       items: [
         {
           id: '',
           title: '',
           layout: { direction: 'horizontal', children: [] },
+        },
+      ],
+    }).success).toBe(false)
+  })
+
+  it('rejects out-of-range vertical bar widths', () => {
+    expect(WorkspacesResponseSchema.safeParse({
+      active: 'dev',
+      tab_position: 'left',
+      vertical_bar_width: 120,
+      items: [
+        {
+          id: 'dev',
+          title: 'Dev',
+          layout: {
+            direction: 'horizontal',
+            children: [{ size: 100, pane: { id: 'main', type: 'local' } }],
+          },
         },
       ],
     }).success).toBe(false)
@@ -224,6 +248,20 @@ describe('WorkspaceTabPositionRequestSchema', () => {
   it('rejects invalid or missing tab position', () => {
     expect(WorkspaceTabPositionRequestSchema.safeParse({ tab_position: 'diagonal' }).success).toBe(false)
     expect(WorkspaceTabPositionRequestSchema.safeParse({}).success).toBe(false)
+  })
+})
+
+describe('WorkspaceVerticalBarWidthRequestSchema', () => {
+  it('accepts valid widths', () => {
+    for (const width of [180, 280, 520]) {
+      const result = WorkspaceVerticalBarWidthRequestSchema.safeParse({ vertical_bar_width: width })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid or missing widths', () => {
+    expect(WorkspaceVerticalBarWidthRequestSchema.safeParse({ vertical_bar_width: 120 }).success).toBe(false)
+    expect(WorkspaceVerticalBarWidthRequestSchema.safeParse({}).success).toBe(false)
   })
 })
 

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -58,6 +58,14 @@ export const WorkspaceTabPositionRequestSchema = z.object({
 
 export type WorkspaceTabPositionRequest = z.infer<typeof WorkspaceTabPositionRequestSchema>
 
+export const WorkspaceVerticalBarWidthSchema = z.number().int().min(180).max(520)
+
+export const WorkspaceVerticalBarWidthRequestSchema = z.object({
+  vertical_bar_width: WorkspaceVerticalBarWidthSchema,
+})
+
+export type WorkspaceVerticalBarWidthRequest = z.infer<typeof WorkspaceVerticalBarWidthRequestSchema>
+
 export const WorkspaceSchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
@@ -69,6 +77,7 @@ export type Workspace = z.infer<typeof WorkspaceSchema>
 export const WorkspacesResponseSchema = z.object({
   active: z.string().min(1),
   tab_position: TabPositionSchema,
+  vertical_bar_width: WorkspaceVerticalBarWidthSchema,
   items: z.array(WorkspaceSchema).min(1),
 })
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -100,6 +100,10 @@ type workspaceTabPositionRequest struct {
 	TabPosition string `json:"tab_position"`
 }
 
+type workspaceVerticalBarWidthRequest struct {
+	VerticalBarWidth int `json:"vertical_bar_width"`
+}
+
 type directoryEntryResponse struct {
 	Name        string `json:"name"`
 	Path        string `json:"path"`
@@ -190,10 +194,24 @@ func (h *Handler) PutWorkspaceTabPosition(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if err := h.cfg.SetWorkspaceTabPosition(req.TabPosition); err != nil {
+	h.applyWorkspaceSettingUpdate(w, h.cfg.SetWorkspaceTabPosition(req.TabPosition))
+}
+
+// PutWorkspaceVerticalBarWidth updates the shared vertical workspace bar width.
+func (h *Handler) PutWorkspaceVerticalBarWidth(w http.ResponseWriter, r *http.Request) {
+	var req workspaceVerticalBarWidthRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	h.applyWorkspaceSettingUpdate(w, h.cfg.SetWorkspaceVerticalBarWidth(req.VerticalBarWidth))
+}
+
+func (h *Handler) applyWorkspaceSettingUpdate(w http.ResponseWriter, updateErr error) {
+	if updateErr != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": updateErr.Error()})
 		return
 	}
 	if err := h.cfg.SaveWorkspaces(); err != nil {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -95,6 +95,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Post("/api/workspaces", h.PostWorkspace)
 	r.Put("/api/workspaces/active", h.PutActiveWorkspace)
 	r.Put("/api/workspaces/tab-position", h.PutWorkspaceTabPosition)
+	r.Put("/api/workspaces/vertical-bar-width", h.PutWorkspaceVerticalBarWidth)
 	r.Put("/api/workspaces/{id}", h.PutWorkspace)
 	r.Delete("/api/workspaces/{id}", h.DeleteWorkspace)
 	r.Put("/api/workspaces/{id}/layout", h.PutWorkspaceLayout)
@@ -128,8 +129,9 @@ func workspaceTestConfig() *config.Config {
 	return &config.Config{
 		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
 		Workspaces: config.WorkspacesConfig{
-			Active:      "one",
-			TabPosition: "top",
+			Active:           "one",
+			TabPosition:      "top",
+			VerticalBarWidth: 280,
 			Items: []config.WorkspaceConfig{
 				{
 					ID:    "one",
@@ -162,6 +164,7 @@ server:
 workspaces:
   active: one
   tab_position: top
+  vertical_bar_width: 280
   items:
     - id: one
       title: One
@@ -186,6 +189,25 @@ workspaces:
 	cfg, err := config.Load(path)
 	require.NoError(t, err)
 	return cfg, path
+}
+
+func assertWorkspaceSettingRejected(
+	t *testing.T,
+	r *chi.Mux,
+	path string,
+	body string,
+	assertState func(t *testing.T),
+	wantError string,
+) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assertState(t)
+	assert.Contains(t, rec.Body.String(), wantError)
 }
 
 func TestGetLayout_ReturnsJSON(t *testing.T) {
@@ -228,6 +250,7 @@ func TestGetWorkspaces_ReturnsJSON(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&workspaces))
 	assert.Equal(t, "default", workspaces.Active)
 	assert.Equal(t, "top", workspaces.TabPosition)
+	assert.Equal(t, 280, workspaces.VerticalBarWidth)
 	require.Len(t, workspaces.Items, 1)
 	assert.Equal(t, "Default", workspaces.Items[0].Title)
 }
@@ -326,18 +349,67 @@ func TestPutWorkspaceTabPosition_InvalidPosition_Returns422AndKeepsExistingValue
 	cfg := workspaceTestConfig()
 	h := NewHandler(cfg, session.NewManager())
 	r := setupRouterWithHandler(h)
+	assertWorkspaceSettingRejected(
+		t,
+		r,
+		"/api/workspaces/tab-position",
+		`{"tab_position":"diagonal"}`,
+		func(t *testing.T) {
+			assert.Equal(t, "top", cfg.Workspaces.TabPosition)
+		},
+		"invalid tab_position",
+	)
+}
+
+func TestPutWorkspaceVerticalBarWidth_UpdatesAndPersists(t *testing.T) {
+	cfg, path := loadWorkspaceTestConfigFromFile(t)
+	h := NewHandler(cfg, session.NewManager())
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	r := setupRouterWithHandler(h)
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(
 		http.MethodPut,
-		"/api/workspaces/tab-position",
-		bytes.NewBufferString(`{"tab_position":"diagonal"}`),
+		"/api/workspaces/vertical-bar-width",
+		bytes.NewBufferString(`{"vertical_bar_width":320}`),
 	)
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
-	assert.Equal(t, "top", cfg.Workspaces.TabPosition)
-	assert.Contains(t, rec.Body.String(), "invalid tab_position")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var workspaces config.WorkspacesConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&workspaces))
+	assert.Equal(t, 320, workspaces.VerticalBarWidth)
+
+	loaded, err := config.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, 320, loaded.Workspaces.VerticalBarWidth)
+}
+
+func TestPutWorkspaceVerticalBarWidth_InvalidBody_Returns400(t *testing.T) {
+	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	r := setupRouterWithHandler(h)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/vertical-bar-width", bytes.NewBufferString("not json"))
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPutWorkspaceVerticalBarWidth_InvalidWidth_Returns422AndKeepsExistingValue(t *testing.T) {
+	cfg := workspaceTestConfig()
+	h := NewHandler(cfg, session.NewManager())
+	r := setupRouterWithHandler(h)
+	assertWorkspaceSettingRejected(
+		t,
+		r,
+		"/api/workspaces/vertical-bar-width",
+		`{"vertical_bar_width":120}`,
+		func(t *testing.T) {
+			assert.Equal(t, 280, cfg.Workspaces.VerticalBarWidth)
+		},
+		"invalid vertical_bar_width",
+	)
 }
 
 func TestPostWorkspace_AddsDefaultLocalWorkspaceAndPersists(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 const configFileMode os.FileMode = 0600
+const defaultWorkspaceVerticalBarWidth = 280
 
 var chmodConfigFile = os.Chmod
 
@@ -67,9 +68,10 @@ type WorkspaceConfig struct {
 }
 
 type WorkspacesConfig struct {
-	Active      string            `yaml:"active,omitempty"       json:"active"`
-	TabPosition string            `yaml:"tab_position,omitempty" json:"tab_position"`
-	Items       []WorkspaceConfig `yaml:"items,omitempty"       json:"items"`
+	Active           string            `yaml:"active,omitempty"             json:"active"`
+	TabPosition      string            `yaml:"tab_position,omitempty"       json:"tab_position"`
+	Items            []WorkspaceConfig `yaml:"items,omitempty"              json:"items"`
+	VerticalBarWidth int               `yaml:"vertical_bar_width,omitempty" json:"vertical_bar_width"`
 }
 
 // Config field order controls YAML serialization order for newly written
@@ -124,8 +126,9 @@ func Default() *Config {
 		},
 		Layout: defaultLayout(),
 		Workspaces: WorkspacesConfig{
-			Active:      "default",
-			TabPosition: "top",
+			Active:           "default",
+			TabPosition:      "top",
+			VerticalBarWidth: defaultWorkspaceVerticalBarWidth,
 			Items: []WorkspaceConfig{
 				{
 					ID:     "default",
@@ -165,8 +168,9 @@ func (c *Config) normalizedWorkspaces() WorkspacesConfig {
 	workspaces := c.Workspaces
 	if len(workspaces.Items) == 0 {
 		workspaces = WorkspacesConfig{
-			Active:      "default",
-			TabPosition: "top",
+			Active:           "default",
+			TabPosition:      "top",
+			VerticalBarWidth: defaultWorkspaceVerticalBarWidth,
 			Items: []WorkspaceConfig{
 				{
 					ID:     "default",
@@ -178,6 +182,9 @@ func (c *Config) normalizedWorkspaces() WorkspacesConfig {
 	}
 	if workspaces.TabPosition == "" {
 		workspaces.TabPosition = "top"
+	}
+	if workspaces.VerticalBarWidth == 0 {
+		workspaces.VerticalBarWidth = defaultWorkspaceVerticalBarWidth
 	}
 	if workspaces.Active == "" && len(workspaces.Items) > 0 {
 		workspaces.Active = workspaces.Items[0].ID
@@ -299,6 +306,15 @@ func (c *Config) SetWorkspaceTabPosition(position string) error {
 	}
 	c.normalizeWorkspaces()
 	c.Workspaces.TabPosition = position
+	return nil
+}
+
+func (c *Config) SetWorkspaceVerticalBarWidth(width int) error {
+	if err := ValidateWorkspaceVerticalBarWidth(width); err != nil {
+		return err
+	}
+	c.normalizeWorkspaces()
+	c.Workspaces.VerticalBarWidth = width
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -109,6 +110,17 @@ func TestValidate_WorkspaceTabPositions_AllValid(t *testing.T) {
 			cfg := validConfig()
 			cfg.normalizeWorkspaces()
 			cfg.Workspaces.TabPosition = position
+			require.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidate_WorkspaceVerticalBarWidth_Range(t *testing.T) {
+	for _, width := range []int{180, 280, 520} {
+		t.Run(strconv.Itoa(width), func(t *testing.T) {
+			cfg := validConfig()
+			cfg.normalizeWorkspaces()
+			cfg.Workspaces.VerticalBarWidth = width
 			require.NoError(t, cfg.Validate())
 		})
 	}
@@ -224,6 +236,25 @@ func TestSetWorkspaceTabPosition_InvalidPositionKeepsExistingValue(t *testing.T)
 	assert.Equal(t, "left", cfg.Workspaces.TabPosition)
 }
 
+func TestSetWorkspaceVerticalBarWidth_ValidWidth(t *testing.T) {
+	cfg := validConfig()
+
+	require.NoError(t, cfg.SetWorkspaceVerticalBarWidth(320))
+
+	assert.Equal(t, 320, cfg.Workspaces.VerticalBarWidth)
+}
+
+func TestSetWorkspaceVerticalBarWidth_InvalidWidthKeepsExistingValue(t *testing.T) {
+	cfg := validConfig()
+	require.NoError(t, cfg.SetWorkspaceVerticalBarWidth(280))
+
+	err := cfg.SetWorkspaceVerticalBarWidth(120)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid vertical_bar_width")
+	assert.Equal(t, 280, cfg.Workspaces.VerticalBarWidth)
+}
+
 func TestValidate_PaneEmptyID_Error(t *testing.T) {
 	cfg := validConfig()
 	cfg.Layout.Children[0].Pane.ID = ""
@@ -320,6 +351,7 @@ layout:
 	assert.Equal(t, "horizontal", cfg.Layout.Direction)
 	assert.Equal(t, "default", cfg.Workspaces.Active)
 	assert.Equal(t, "top", cfg.Workspaces.TabPosition)
+	assert.Equal(t, 280, cfg.Workspaces.VerticalBarWidth)
 	require.Len(t, cfg.Workspaces.Items, 1)
 	assert.Equal(t, "Default", cfg.Workspaces.Items[0].Title)
 }
@@ -332,6 +364,7 @@ server:
 workspaces:
   active: ops
   tab_position: left
+  vertical_bar_width: 320
   items:
     - id: dev
       title: Dev
@@ -357,6 +390,7 @@ workspaces:
 	require.NoError(t, err)
 	assert.Equal(t, "ops", cfg.Workspaces.Active)
 	assert.Equal(t, "left", cfg.Workspaces.TabPosition)
+	assert.Equal(t, 320, cfg.Workspaces.VerticalBarWidth)
 	assert.Equal(t, "vertical", cfg.ActiveLayout().Direction)
 }
 
@@ -375,6 +409,7 @@ layout:
 workspaces:
   active: dev
   tab_position: bottom
+  vertical_bar_width: 300
   items:
     - id: dev
       title: Dev
@@ -390,6 +425,7 @@ workspaces:
 	cfg, err := Load(f)
 	require.NoError(t, err)
 	assert.Equal(t, "bottom", cfg.Workspaces.TabPosition)
+	assert.Equal(t, 300, cfg.Workspaces.VerticalBarWidth)
 	assert.Equal(t, "horizontal", cfg.Layout.Direction)
 	require.Len(t, cfg.AllPanes(), 1)
 	assert.Equal(t, "dev-main", cfg.AllPanes()[0].ID)
@@ -417,6 +453,7 @@ workspaces:
 	require.NoError(t, err)
 	assert.Equal(t, "first", cfg.Workspaces.Active)
 	assert.Equal(t, "top", cfg.Workspaces.TabPosition)
+	assert.Equal(t, 280, cfg.Workspaces.VerticalBarWidth)
 	assert.Equal(t, "vertical", cfg.ActiveLayout().Direction)
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -12,16 +12,18 @@ import (
 var tmuxSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 const (
-	directionHorizontal = "horizontal"
-	directionVertical   = "vertical"
-	paneTypeLocal       = "local"
-	paneTypeSSH         = "ssh"
-	paneTypeTmux        = "tmux"
-	paneTypeSSHTmux     = "ssh_tmux"
-	tabPositionTop      = "top"
-	tabPositionBottom   = "bottom"
-	tabPositionLeft     = "left"
-	tabPositionRight    = "right"
+	directionHorizontal          = "horizontal"
+	directionVertical            = "vertical"
+	paneTypeLocal                = "local"
+	paneTypeSSH                  = "ssh"
+	paneTypeTmux                 = "tmux"
+	paneTypeSSHTmux              = "ssh_tmux"
+	tabPositionTop               = "top"
+	tabPositionBottom            = "bottom"
+	tabPositionLeft              = "left"
+	tabPositionRight             = "right"
+	minWorkspaceVerticalBarWidth = 180
+	maxWorkspaceVerticalBarWidth = 520
 )
 
 // Validate checks the configuration for correctness.
@@ -74,6 +76,11 @@ func validateWorkspaces(workspaces WorkspacesConfig, sshConns map[string]SSHConn
 			errs = append(errs, err.Error())
 		}
 	}
+	if workspaces.VerticalBarWidth != 0 {
+		if err := ValidateWorkspaceVerticalBarWidth(workspaces.VerticalBarWidth); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
 	if len(workspaces.Items) == 0 {
 		errs = append(errs, "workspaces.items must not be empty")
 		return errs
@@ -111,6 +118,18 @@ func ValidateWorkspaceTabPosition(position string) error {
 	default:
 		return fmt.Errorf("invalid tab_position %q: must be top, bottom, left, or right", position)
 	}
+}
+
+func ValidateWorkspaceVerticalBarWidth(width int) error {
+	if width < minWorkspaceVerticalBarWidth || width > maxWorkspaceVerticalBarWidth {
+		return fmt.Errorf(
+			"invalid vertical_bar_width %d: must be between %d and %d",
+			width,
+			minWorkspaceVerticalBarWidth,
+			maxWorkspaceVerticalBarWidth,
+		)
+	}
+	return nil
 }
 
 // ValidatePane validates a standalone PaneConfig without ssh_connections context.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,7 @@ func registerRoutes(r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler
 		r.Post("/workspaces", apiHandler.PostWorkspace)
 		r.Put("/workspaces/active", apiHandler.PutActiveWorkspace)
 		r.Put("/workspaces/tab-position", apiHandler.PutWorkspaceTabPosition)
+		r.Put("/workspaces/vertical-bar-width", apiHandler.PutWorkspaceVerticalBarWidth)
 		r.Put("/workspaces/{id}", apiHandler.PutWorkspace)
 		r.Delete("/workspaces/{id}", apiHandler.DeleteWorkspace)
 		r.Put("/workspaces/{id}/layout", apiHandler.PutWorkspaceLayout)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -24,8 +24,9 @@ func testConfig() *config.Config {
 			Host: "127.0.0.1",
 		},
 		Workspaces: config.WorkspacesConfig{
-			Active:      "default",
-			TabPosition: "top",
+			Active:           "default",
+			TabPosition:      "top",
+			VerticalBarWidth: 280,
 			Items: []config.WorkspaceConfig{
 				{
 					ID:    "default",
@@ -183,18 +184,30 @@ func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.
 	srv := New(cfg, mgr, emptyFS)
 	require.NotNil(t, srv)
 
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(
-		http.MethodPut,
-		"/api/workspaces/tab-position",
-		bytes.NewBufferString(`{"tab_position":"right"}`),
-	)
-	req.Header.Set("Content-Type", "application/json")
-	srv.httpSrv.Handler.ServeHTTP(rec, req)
-
-	assert.Equal(t, http.StatusOK, rec.Code)
+	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/tab-position", `{"tab_position":"right"}`)
 	assert.Equal(t, "right", cfg.Workspaces.TabPosition)
 	assert.Equal(t, "Default", cfg.Workspaces.Items[0].Title)
+}
+
+func TestServer_WorkspaceVerticalBarWidthRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
+	cfg := testConfig()
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, emptyFS)
+	require.NotNil(t, srv)
+
+	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/vertical-bar-width", `{"vertical_bar_width":320}`)
+	assert.Equal(t, 320, cfg.Workspaces.VerticalBarWidth)
+	assert.Equal(t, "Default", cfg.Workspaces.Items[0].Title)
+}
+
+func performWorkspaceSettingUpdate(t *testing.T, srv *Server, path string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	return rec
 }
 
 func TestServer_DirectoriesRouteWired(t *testing.T) {


### PR DESCRIPTION
## Summary

- add persisted `vertical_bar_width` workspace config and API support for vertical workspace bar resizing
- make left/right workspace bars resizable with a fixed footer for the `+` action and tab-position controls
- keep workspace tabs and inline summaries in a dedicated vertical scroll region so controls remain visible

## Test plan

- [x] `make check`
