### PR TITLE
ci: add renovate for scheduled dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on Monday"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "pinDigests": true,
+      "automerge": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the pinned golangci-lint tool version in sync.",
+      "managerFilePatterns": ["/(^|/)Makefile$/"],
+      "matchStrings": [
+        "GOLANGCI_LINT_VERSION := (?<currentValue>v(?<version>\\d+\\.\\d+\\.\\d+))"
+      ],
+      "depNameTemplate": "github.com/golangci/golangci-lint/v2",
+      "datasourceTemplate": "go"
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on the first day of the month"]
+  }
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
       "description": "Keep the pinned golangci-lint tool version in sync.",
       "managerFilePatterns": ["/(^|/)Makefile$/"],
       "matchStrings": [
-        "GOLANGCI_LINT_VERSION := (?<currentValue>v(?<version>\\d+\\.\\d+\\.\\d+))"
+        "GOLANGCI_LINT_VERSION := (?<currentValue>v\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "github.com/golangci/golangci-lint/v2",
       "datasourceTemplate": "go"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,6 +108,7 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 - Coverage commands: `make coverage-go`, `make coverage-frontend`
 - Lint commands: `make lint-go`, `make lint-frontend`, `make lint`
 - Go lint includes `gofmt`, `go vet`, and `golangci-lint run ./...` using `.golangci.yml`.
+- `lint-go-deps` refreshes the pinned `golangci-lint` binary when the local version does not match `GOLANGCI_LINT_VERSION`, so local lint matches CI.
 - Run `make lint-go` or `make lint` after every Go code change before committing.
 
 ### Push protection

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
         coverage coverage-go coverage-frontend \
         check release-snapshot package
 
-GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT_VERSION := v2.12.2
 
 # ── Dependencies ──────────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,14 @@ fmt-check-go:
 lint: lint-go lint-frontend
 
 lint-go-deps:
-	@command -v golangci-lint >/dev/null 2>&1 || \
-	  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@expected_version="$$(printf '%s' '$(GOLANGCI_LINT_VERSION)' | sed 's/^v//')"; \
+	current_version="$$(command -v golangci-lint >/dev/null 2>&1 && golangci-lint --version 2>/dev/null | awk 'NR==1 {print $$4; exit}' || true)"; \
+	if [ "$$current_version" = "$$expected_version" ]; then \
+	  :; \
+	else \
+	  echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
+	  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	fi
 
 lint-go: fmt-check-go lint-go-deps
 	go vet ./...

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -6,12 +6,21 @@ This document captures repository maintenance rules that belong in durable proje
 
 - Pin GitHub Actions to full commit SHAs, not floating tags such as `@v4` or `@v5`.
 - When updating workflows, resolve the intended tag to its exact commit SHA first, then commit the SHA-pinned reference.
+- Renovate manages scheduled GitHub Actions updates for this repository. Keep workflow `uses:` entries SHA-pinned so Renovate can advance them as explicit reviewable changes.
 
 Why this matters:
 
 - it makes workflow execution reproducible
 - it narrows supply-chain drift
 - it keeps workflow changes explicit in code review
+
+## Dependency Updates
+
+- Renovate is the repository's scheduled dependency update mechanism.
+- Weekly update PRs run before 9am on Monday in the `Asia/Tokyo` timezone.
+- Monthly lockfile maintenance runs before 9am on the first day of the month.
+- Renovate covers Go modules, frontend npm dependencies, GitHub Actions, and the `GOLANGCI_LINT_VERSION` pin in `Makefile`.
+- Review Renovate PRs like any other dependency bump and keep automerge disabled unless project policy changes.
 
 ## Release Workflow
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -64,6 +64,8 @@ var gitExistsFn = func() error {
 
 var prLookupTimeout = 5 * time.Second
 
+const responseErrorKey = "error"
+
 type sshConnectionsResponse struct {
 	Names []string `json:"names"`
 }
@@ -152,7 +154,7 @@ func (h *Handler) PutLayout(w http.ResponseWriter, r *http.Request) {
 	if err := config.ValidateLayout(layout); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: err.Error()})
 		return
 	}
 
@@ -211,7 +213,7 @@ func (h *Handler) applyWorkspaceSettingUpdate(w http.ResponseWriter, updateErr e
 	if updateErr != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": updateErr.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: updateErr.Error()})
 		return
 	}
 	if err := h.cfg.SaveWorkspaces(); err != nil {
@@ -277,7 +279,7 @@ func (h *Handler) PutWorkspace(w http.ResponseWriter, r *http.Request) {
 	if title == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "workspace title must not be empty"})
+		_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: "workspace title must not be empty"})
 		return
 	}
 	if !h.cfg.RenameWorkspace(id, title) {
@@ -305,7 +307,7 @@ func (h *Handler) PutWorkspaceLayout(w http.ResponseWriter, r *http.Request) {
 	if err := config.ValidateLayout(layout); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: err.Error()})
 		return
 	}
 
@@ -363,7 +365,7 @@ func (h *Handler) PostSession(w http.ResponseWriter, r *http.Request) {
 	if err := config.ValidatePane(&pane); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: err.Error()})
 		return
 	}
 
@@ -530,7 +532,7 @@ func (h *Handler) PostSSHConfigHost(w http.ResponseWriter, r *http.Request) {
 		if host.Name == req.Name {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusConflict)
-			_ = json.NewEncoder(w).Encode(map[string]string{"error": "host already exists"})
+			_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: "host already exists"})
 			return
 		}
 	}
@@ -1210,7 +1212,7 @@ func repoHostAndPathFromOriginURLDetailed(origin string) (string, string, bool) 
 func writeValidationError(w http.ResponseWriter, msg string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnprocessableEntity)
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+	_ = json.NewEncoder(w).Encode(map[string]string{responseErrorKey: msg})
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,15 @@ import (
 const configFileMode os.FileMode = 0600
 const defaultWorkspaceVerticalBarWidth = 280
 
+const (
+	defaultServerHost      = "127.0.0.1"
+	defaultWorkspaceID     = "default"
+	defaultWorkspaceTitle  = "Default"
+	defaultTabPosition     = "top"
+	defaultLayoutDirection = "horizontal"
+	defaultPaneType        = "local"
+)
+
 var chmodConfigFile = os.Chmod
 
 type ServerConfig struct {
@@ -118,7 +127,7 @@ func Default() *Config {
 	return &Config{
 		Server: ServerConfig{
 			Port: 8080,
-			Host: "127.0.0.1",
+			Host: defaultServerHost,
 		},
 		Display: DisplayConfig{
 			ShowHeader:    true,
@@ -126,13 +135,13 @@ func Default() *Config {
 		},
 		Layout: defaultLayout(),
 		Workspaces: WorkspacesConfig{
-			Active:           "default",
-			TabPosition:      "top",
+			Active:           defaultWorkspaceID,
+			TabPosition:      defaultTabPosition,
 			VerticalBarWidth: defaultWorkspaceVerticalBarWidth,
 			Items: []WorkspaceConfig{
 				{
-					ID:     "default",
-					Title:  "Default",
+					ID:     defaultWorkspaceID,
+					Title:  defaultWorkspaceTitle,
 					Layout: defaultLayout(),
 				},
 			},
@@ -142,13 +151,13 @@ func Default() *Config {
 
 func defaultLayout() LayoutNode {
 	return LayoutNode{
-		Direction: "horizontal",
+		Direction: defaultLayoutDirection,
 		Children: []LayoutChild{
 			{
 				Size: 100.0,
 				Pane: &PaneConfig{
 					ID:    "local-main",
-					Type:  "local",
+					Type:  defaultPaneType,
 					Shell: os.Getenv("SHELL"),
 					Title: "Terminal",
 				},
@@ -168,20 +177,20 @@ func (c *Config) normalizedWorkspaces() WorkspacesConfig {
 	workspaces := c.Workspaces
 	if len(workspaces.Items) == 0 {
 		workspaces = WorkspacesConfig{
-			Active:           "default",
-			TabPosition:      "top",
+			Active:           defaultWorkspaceID,
+			TabPosition:      defaultTabPosition,
 			VerticalBarWidth: defaultWorkspaceVerticalBarWidth,
 			Items: []WorkspaceConfig{
 				{
-					ID:     "default",
-					Title:  "Default",
+					ID:     defaultWorkspaceID,
+					Title:  defaultWorkspaceTitle,
 					Layout: c.Layout,
 				},
 			},
 		}
 	}
 	if workspaces.TabPosition == "" {
-		workspaces.TabPosition = "top"
+		workspaces.TabPosition = defaultTabPosition
 	}
 	if workspaces.VerticalBarWidth == 0 {
 		workspaces.VerticalBarWidth = defaultWorkspaceVerticalBarWidth
@@ -242,7 +251,7 @@ func (c *Config) ActiveWorkspaceID() string {
 	if len(c.Workspaces.Items) > 0 {
 		return c.Workspaces.Items[0].ID
 	}
-	return "default"
+	return defaultWorkspaceID
 }
 
 func (c *Config) WorkspacesView() WorkspacesConfig {
@@ -349,13 +358,13 @@ func (c *Config) nextPaneID(base string) string {
 
 func singleLocalPaneLayout(paneID string) LayoutNode {
 	return LayoutNode{
-		Direction: "horizontal",
+		Direction: defaultLayoutDirection,
 		Children: []LayoutChild{
 			{
 				Size: 100.0,
 				Pane: &PaneConfig{
 					ID:    paneID,
-					Type:  "local",
+					Type:  defaultPaneType,
 					Shell: os.Getenv("SHELL"),
 					Title: "Terminal",
 				},

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -33,6 +33,11 @@ var validShellPath = regexp.MustCompile(`^(/[a-zA-Z0-9._\-/]+)$`)
 var claudeBashCDPattern = regexp.MustCompile(`(?:^|&&)\s*cd\s+((?:"[^"]+"|'[^']+'|[^&|;]+))\s*&&`)
 var validClaudeSessionID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
+const (
+	interactiveAgentCodex  = "codex"
+	interactiveAgentClaude = "claude"
+)
+
 // LocalSession is a local PTY-based terminal session.
 type LocalSession struct {
 	cmd   *exec.Cmd
@@ -447,9 +452,9 @@ func isInteractiveAgentCommand(command string) bool {
 
 	binary := strings.ToLower(filepath.Base(fields[0]))
 	switch binary {
-	case "codex":
+	case interactiveAgentCodex:
 		return !containsToken(fields[1:], "exec")
-	case "claude":
+	case interactiveAgentClaude:
 		return !containsAnyToken(fields[1:], "-p", "--print")
 	default:
 		return false
@@ -458,12 +463,12 @@ func isInteractiveAgentCommand(command string) bool {
 
 func isCodexCommand(command string) bool {
 	fields := strings.Fields(command)
-	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == "codex"
+	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == interactiveAgentCodex
 }
 
 func isClaudeCommand(command string) bool {
 	fields := strings.Fields(command)
-	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == "claude"
+	return len(fields) > 0 && strings.ToLower(filepath.Base(fields[0])) == interactiveAgentClaude
 }
 
 func containsToken(tokens []string, target string) bool {

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -17,6 +17,11 @@ import (
 
 const wsReadLimitBytes = 1 << 20 // 1 MB
 
+const (
+	controlMessageTypeResize = "resize"
+	controlMessageTypeReplay = "replay"
+)
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
@@ -226,7 +231,7 @@ func waitForTerminalPipe(done <-chan struct{}) {
 
 func (h *Handler) handleControl(conn *websocket.Conn, sess session.Session, msg ControlMessage) {
 	switch msg.Type {
-	case "resize":
+	case controlMessageTypeResize:
 		if msg.Cols > 0 && msg.Rows > 0 {
 			if err := sess.Resize(msg.Cols, msg.Rows); err != nil {
 				log.Printf("resize error: %v", err)
@@ -240,7 +245,7 @@ func (h *Handler) sendStatus(conn *websocket.Conn, state string) {
 }
 
 func (h *Handler) sendReplay(conn *websocket.Conn, state string) bool {
-	return writeControlMessage(conn, ControlMessage{Type: "replay", State: state})
+	return writeControlMessage(conn, ControlMessage{Type: controlMessageTypeReplay, State: state})
 }
 
 func writeControlMessage(conn messageWriter, msg ControlMessage) bool {


### PR DESCRIPTION
## Summary
- Upgrade `golangci-lint` to `v2.12.2`.
- Add Renovate scheduling for dependency updates, including the `golangci-lint` pin in `Makefile`.
- Document the scheduled dependency-update policy in `docs/maintenance.md`.

## Test Plan
- `make install-deps`
- `make check`
