### PR TITLE
feat: preserve scroll and resize through mouse tracking mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.18.8",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.18.8",
+      "version": "0.20.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ export const App: React.FC = () => {
   } = useLayout()
   const [maximizedPaneIdsByWorkspace, setMaximizedPaneIdsByWorkspace] = useState<Record<string, string | null>>({})
   const [dragSourcePaneId, setDragSourcePaneId] = useState<string | null>(null)
+  const [isResizing, setIsResizing] = useState(false)
   const [activePaneId, setActivePaneId] = useState<string | null>(null)
   const [attentionPaneIds, setAttentionPaneIds] = useState<Set<string>>(() => new Set())
   const { isOpen, currentPane, sshConnectionNames, saveError, isSaving, openSettings, closeSettings, saveSettings, addSSHConfigHost, detectShell, browseDirectories } =
@@ -305,6 +306,8 @@ export const App: React.FC = () => {
       maximizedPaneId,
       dragSourcePaneId,
       setDragSourcePaneId,
+      isResizing,
+      setIsResizing,
       displayConfig: displayConfig ?? DEFAULT_DISPLAY,
       onPaneAttention: notifyAttention,
       clearPaneAttention,

--- a/frontend/src/components/SplitContainer.test.tsx
+++ b/frontend/src/components/SplitContainer.test.tsx
@@ -31,6 +31,8 @@ function makeCtx(maximizedPaneId: string | null): LayoutActionsContextValue {
     maximizedPaneId,
     dragSourcePaneId: null,
     setDragSourcePaneId: vi.fn(),
+    isResizing: false,
+    setIsResizing: vi.fn(),
     displayConfig: { show_header: false, show_status_bar: false },
     onPaneAttention: vi.fn(),
     clearPaneAttention: vi.fn(),

--- a/frontend/src/components/SplitContainer.tsx
+++ b/frontend/src/components/SplitContainer.tsx
@@ -20,6 +20,8 @@ export interface LayoutActionsContextValue {
   maximizedPaneId: string | null
   dragSourcePaneId: string | null
   setDragSourcePaneId: (id: string | null) => void
+  isResizing: boolean
+  setIsResizing: (v: boolean) => void
   displayConfig: DisplayConfig
   onPaneAttention: (paneId: string) => void
   clearPaneAttention: (paneId: string) => void
@@ -246,7 +248,12 @@ const DividerDropZone: React.FC<DividerDropZoneProps> = ({ direction, beforeChil
         }}
         style={dividerHitAreaStyle(direction, Boolean(ctx?.dragSourcePaneId))}
       />
-      <SplitDivider direction={direction} onDrag={onResize} />
+      <SplitDivider
+        direction={direction}
+        onDrag={onResize}
+        onResizeStart={() => ctx?.setIsResizing(true)}
+        onResizeEnd={() => ctx?.setIsResizing(false)}
+      />
       {ctx?.dragSourcePaneId && (
         <div
           style={dividerOverlayStyle(direction, hovered)}

--- a/frontend/src/components/SplitDivider.tsx
+++ b/frontend/src/components/SplitDivider.tsx
@@ -3,17 +3,24 @@ import React, { useCallback, useRef } from 'react'
 interface SplitDividerProps {
   direction: 'horizontal' | 'vertical'
   onDrag: (delta: number) => void
+  onResizeStart?: () => void
+  onResizeEnd?: () => void
 }
 
-export const SplitDivider: React.FC<SplitDividerProps> = ({ direction, onDrag }) => {
+export const SplitDivider: React.FC<SplitDividerProps> = ({ direction, onDrag, onResizeStart, onResizeEnd }) => {
   const startRef = useRef<number>(0)
   const onDragRef = useRef(onDrag)
   onDragRef.current = onDrag
+  const onResizeStartRef = useRef(onResizeStart)
+  onResizeStartRef.current = onResizeStart
+  const onResizeEndRef = useRef(onResizeEnd)
+  onResizeEndRef.current = onResizeEnd
   const isHorizontal = direction === 'horizontal'
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     startRef.current = isHorizontal ? e.clientX : e.clientY
+    onResizeStartRef.current?.()
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       const current = isHorizontal ? moveEvent.clientX : moveEvent.clientY
@@ -23,6 +30,7 @@ export const SplitDivider: React.FC<SplitDividerProps> = ({ direction, onDrag })
     }
 
     const handleMouseUp = () => {
+      onResizeEndRef.current?.()
       document.removeEventListener('mousemove', handleMouseMove)
       document.removeEventListener('mouseup', handleMouseUp)
       document.body.style.cursor = ''

--- a/frontend/src/components/TerminalPane.test.tsx
+++ b/frontend/src/components/TerminalPane.test.tsx
@@ -183,6 +183,8 @@ function makeCtx(overrides: Partial<LayoutActionsContextValue> = {}): LayoutActi
     maximizedPaneId: null,
     dragSourcePaneId: null,
     setDragSourcePaneId: vi.fn(),
+    isResizing: false,
+    setIsResizing: vi.fn(),
     displayConfig: { show_header: true, show_status_bar: false },
     onPaneAttention: vi.fn(),
     clearPaneAttention: vi.fn(),

--- a/frontend/src/components/TerminalPane.test.tsx
+++ b/frontend/src/components/TerminalPane.test.tsx
@@ -34,6 +34,7 @@ describe('TerminalPane drop zones', () => {
       sessionState: 'running',
       reconnectFailed: false,
       restartSession: vi.fn(),
+      scrollLines: vi.fn(),
     })
     mockUseGitInfo.mockReturnValue({
       gitInfo: { is_git: false },
@@ -167,6 +168,73 @@ describe('TerminalPane drop zones', () => {
     )
 
     expect(mockUseGitInfo).toHaveBeenCalledWith('pane-1', true)
+  })
+})
+
+describe('TerminalPane Shift+wheel handler', () => {
+  const scrollLinesMock = vi.fn()
+
+  beforeEach(() => {
+    scrollLinesMock.mockReset()
+    mockUseTerminal.mockReturnValue({
+      handleResize: vi.fn(),
+      connected: true,
+      dims: null,
+      sessionState: 'running',
+      reconnectFailed: false,
+      restartSession: vi.fn(),
+      scrollLines: scrollLinesMock,
+    })
+    mockUseGitInfo.mockReturnValue({
+      gitInfo: { is_git: false },
+      refreshIfStale: vi.fn(),
+      refreshNow: vi.fn(),
+    })
+  })
+
+  function renderPane() {
+    const { container } = render(
+      <LayoutActionsContext.Provider value={makeCtx()}>
+        <TerminalPane pane={{ id: 'pane-1', type: 'local', title: 'Pane 1' }} />
+      </LayoutActionsContext.Provider>,
+    )
+    return container.querySelector('[data-pane-id="pane-1"] > div:nth-child(2)') as HTMLElement
+  }
+
+  it('DOM_DELTA_PIXEL: scrolls lines from pixel delta', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: true, deltaY: 120, deltaMode: 0 })
+    expect(scrollLinesMock).toHaveBeenCalledWith(3)
+  })
+
+  it('DOM_DELTA_PIXEL: falls back to 1 when pixel delta rounds to zero', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: true, deltaY: 10, deltaMode: 0 })
+    expect(scrollLinesMock).toHaveBeenCalledWith(1)
+  })
+
+  it('DOM_DELTA_LINE: uses deltaY directly as line count', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: true, deltaY: 3, deltaMode: 1 })
+    expect(scrollLinesMock).toHaveBeenCalledWith(3)
+  })
+
+  it('DOM_DELTA_LINE: scrolls in reverse for negative delta', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: true, deltaY: -3, deltaMode: 1 })
+    expect(scrollLinesMock).toHaveBeenCalledWith(-3)
+  })
+
+  it('DOM_DELTA_PAGE: converts pages to lines by multiplying by 20', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: true, deltaY: 1, deltaMode: 2 })
+    expect(scrollLinesMock).toHaveBeenCalledWith(20)
+  })
+
+  it('does not scroll when Shift is not held', () => {
+    const el = renderPane()
+    fireEvent.wheel(el, { shiftKey: false, deltaY: 120, deltaMode: 0 })
+    expect(scrollLinesMock).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -30,18 +30,20 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
   const isActivePane = ctx?.activePaneId === pane.id
   const isDragSource = ctx?.dragSourcePaneId === pane.id
   const dragActive = Boolean(ctx?.dragSourcePaneId)
+  const isResizing = ctx?.isResizing ?? false
   const gitInfoEnabled = !ctx?.maximizedPaneId || ctx.maximizedPaneId === pane.id
 
   const { gitInfo, refreshIfStale, refreshNow } = useGitInfo(pane.id, gitInfoEnabled)
 
-  const { handleResize, connected, dims, sessionState, reconnectFailed, restartSession } = useTerminal({
+  const { handleResize, connected, dims, sessionState, reconnectFailed, restartSession, scrollLines } = useTerminal({
     sessionId: pane.id,
     container: containerEl,
     repoURL: gitInfo.repo_url,
     onInteraction: refreshIfStale,
   })
 
-  // Observe resize events for this pane
+  // Observe resize events for this pane. handleResize is stable (does not
+  // depend on connected), so the observer is never torn down during reconnects.
   useEffect(() => {
     if (!containerEl) return
     const observer = new ResizeObserver(() => {
@@ -50,6 +52,22 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
     observer.observe(containerEl)
     return () => observer.disconnect()
   }, [containerEl, handleResize])
+
+  // Shift+wheel scrolls the local xterm.js viewport without forwarding events
+  // to the remote session. This keeps scrolling usable when the remote app
+  // has mouse tracking enabled and SSH latency is high.
+  useEffect(() => {
+    if (!containerEl) return
+    const handleWheel = (e: WheelEvent) => {
+      if (!e.shiftKey) return
+      e.preventDefault()
+      e.stopPropagation()
+      const lines = Math.round(e.deltaY / 40) || (e.deltaY > 0 ? 1 : -1)
+      scrollLines(lines)
+    }
+    containerEl.addEventListener('wheel', handleWheel, { capture: true, passive: false })
+    return () => containerEl.removeEventListener('wheel', handleWheel, true)
+  }, [containerEl, scrollLines])
 
   const handleOpenVSCode = useCallback(() => {
     void refreshNow()
@@ -167,6 +185,10 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
           overflow: 'hidden',
           padding: '4px',
           position: 'relative',
+          // Suppress xterm.js mouse event forwarding during pane resize drags.
+          // This prevents spurious mouse-tracking escape sequences from congesting
+          // the SSH write path and delaying the window-change (PTY resize) request.
+          pointerEvents: isResizing ? 'none' : undefined,
         }}
         onDragOver={(e) => {
           if (!ctx?.dragSourcePaneId || ctx.dragSourcePaneId === pane.id) return

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -62,7 +62,13 @@ export const TerminalPane: React.FC<TerminalPaneProps> = ({ pane }) => {
       if (!e.shiftKey) return
       e.preventDefault()
       e.stopPropagation()
-      const lines = Math.round(e.deltaY / 40) || (e.deltaY > 0 ? 1 : -1)
+      const rawLines =
+        e.deltaMode === 1 /* DOM_DELTA_LINE */
+          ? Math.round(e.deltaY)
+          : e.deltaMode === 2 /* DOM_DELTA_PAGE */
+          ? Math.round(e.deltaY * 20)
+          : Math.round(e.deltaY / 40)
+      const lines = rawLines || (e.deltaY > 0 ? 1 : -1)
       scrollLines(lines)
     }
     containerEl.addEventListener('wheel', handleWheel, { capture: true, passive: false })

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -30,6 +30,7 @@ const { mockWrite, mockTerm, mockFitAddon, mockTerminalCtor } = vi.hoisted(() =>
       mockWrite(data)
       callback?.()
     }),
+    scrollLines: vi.fn(),
   }
   const mockFitAddon = { fit: vi.fn() }
   const mockTerminalCtor = vi.fn(function () { return mockTerm })
@@ -938,5 +939,28 @@ describe('useTerminal', () => {
     expect(written).not.toContain('\x1b[>1h')
     expect(written).toContain('hidden cursor')
     expect(written).toContain('text')
+  })
+
+  it('handleResize reference is stable when connected changes', () => {
+    const container = makeContainer()
+    const { result, rerender } = renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    const refBefore = result.current.handleResize
+    // Simulate connected changing by opening then closing the WebSocket
+    act(() => MockWebSocket.instances[0].simulateOpen())
+    rerender()
+    act(() => MockWebSocket.instances[0].close())
+    rerender()
+
+    expect(result.current.handleResize).toBe(refBefore)
+  })
+
+  it('scrollLines calls term.scrollLines', () => {
+    const container = makeContainer()
+    const { result } = renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    act(() => result.current.scrollLines(3))
+
+    expect(mockTerm.scrollLines).toHaveBeenCalledWith(3)
   })
 })

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -266,19 +266,28 @@ export function useTerminal({ sessionId, container, repoURL, onInteraction }: Us
     } catch { /* ignore network errors */ }
   }, [sessionId, reconnect, sessionState])
 
-  // Handle resize
+  // Keep a ref to connected so handleResize doesn't need it as a dep.
+  // This prevents ResizeObserver from being torn down on every WebSocket
+  // reconnect event, which would cause resize events to be missed.
+  const connectedRef = useRef(connected)
+  useEffect(() => { connectedRef.current = connected })
+
   const handleResize = useCallback(() => {
     const entry = entryRef.current
     if (!entry) return
 
     repaintTerminal(entry, setDims)
     const { cols, rows } = entry.term
-    if (connected && cols > 0 && rows > 0) {
+    if (connectedRef.current && cols > 0 && rows > 0) {
       send(JSON.stringify({ type: 'resize', cols, rows }))
     }
-  }, [send, connected])
+  }, [send])
 
-  return { handleResize, connected, dims, sessionState, reconnectFailed, restartSession }
+  const scrollLines = useCallback((lines: number) => {
+    entryRef.current?.term.scrollLines(lines)
+  }, [])
+
+  return { handleResize, connected, dims, sessionState, reconnectFailed, restartSession, scrollLines }
 }
 
 function flushPendingMessages(


### PR DESCRIPTION
## Summary

- **Shift+wheel for local scroll**: When a remote app (vim, tmux, etc.) enables mouse tracking mode, xterm.js routes wheel events to SSH instead of scrolling the local viewport. With high SSH latency this makes scrolling appear completely frozen. A new `wheel` event handler (capture phase) in `TerminalPane` intercepts `Shift+wheel` and calls `term.scrollLines()` directly, bypassing SSH forwarding regardless of mouse tracking state.

- **Suppress mouse events during resize drag**: `mousemove` events during `SplitDivider` drags pass through the terminal area, where xterm.js (in mouse tracking mode) forwards them as escape sequences to SSH. This congests the SSH write path and delays the `WindowChange` PTY resize request. Setting `pointer-events: none` on terminal containers while a drag is active (`isResizing` state on `LayoutActionsContext`) stops this forwarding entirely for the duration of the drag.

- **Stabilize `handleResize`**: `handleResize` previously closed over the React `connected` state, causing `useCallback` to return a new reference on every WebSocket reconnect. Because `TerminalPane`'s `ResizeObserver` effect depends on `handleResize`, this tore down and rebuilt the observer on every reconnect — creating a window where drag-resize and maximize events could be missed. Moving `connected` to a ref makes `handleResize` stable for the component lifetime.

## Test plan

- [x] `make test-frontend` passes (405 tests; 2 new: `handleResize reference is stable when connected changes`, `scrollLines calls term.scrollLines`)
- [x] `make lint-frontend` passes (TypeScript strict check)
- [x] `make test-go` passes for all `./internal/...` packages
- [x] `make lint-go` passes (0 issues)
- [x] `make check` passes end-to-end via pre-push hook
- [ ] Manual: ssh_tmux session with vim/tmux mouse mode — normal wheel sends to remote; Shift+wheel scrolls local viewport
- [ ] Manual: pane resize drag while mouse tracking active — terminal receives no spurious mousemove events during drag; PTY resize arrives sooner
- [ ] Manual: maximize button — terminal immediately resizes to fill workspace even during active WebSocket reconnects