### PR TITLE
fix: stop ssh/ssh+tmux panes from getting stuck reconnecting forever

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -248,14 +248,22 @@ replacement session is created first; the old session is only removed and swappe
 starts successfully.
 
 - `404`: no pane config exists for `id`
+- `409`: a restart for this `id` is already in progress. Session creation can block on a real SSH
+  dial, so concurrent restart requests for the same pane are serialized instead of each building a
+  session independently and racing to swap it in.
 - `500`: session creation failed (e.g. SSH dial/handshake error). The pane's prior session, if any,
   remains registered and servable — it is not removed on failure — so `/ws/{id}` and `/git-info` keep
   working against it instead of 404ing until a future restart succeeds.
 - `200`: the new session replaced the old one (or was created fresh if none existed)
 
 The SSH transport-dial step retries transient failures (such as a momentary DNS resolution error) a
-few times with a short backoff before this endpoint returns `500`; only the initial TCP/ProxyJump/
-ProxyCommand connection step is retried, not SSH handshake or authentication failures.
+bounded number of times with a short backoff before this endpoint returns `500`. Only the initial
+TCP/ProxyJump/ProxyCommand connection step is retried, not SSH handshake or authentication failures.
+The retry budget is a single wall-clock deadline shared across an entire ProxyJump chain (each hop
+reuses the same deadline rather than getting its own fresh budget), and each retried attempt's own
+timeout shrinks to whatever of that budget remains, so a hanging/unreachable host cannot make this
+endpoint wait dramatically longer than the ceiling a single dial attempt already tolerated before
+retries were introduced.
 
 ### `GET /api/ssh-connections`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -241,6 +241,22 @@ Current product use: the frontend uses this endpoint when the user splits a pane
 
 Closes the session, removes its pane from the layout, collapses redundant parent splits, normalizes sibling sizes, and returns `204`.
 
+### `POST /api/sessions/{id}/restart`
+
+Recreates the session for an existing pane from its config (e.g. after an SSH connection was lost). The
+replacement session is created first; the old session is only removed and swapped out once the new one
+starts successfully.
+
+- `404`: no pane config exists for `id`
+- `500`: session creation failed (e.g. SSH dial/handshake error). The pane's prior session, if any,
+  remains registered and servable — it is not removed on failure — so `/ws/{id}` and `/git-info` keep
+  working against it instead of 404ing until a future restart succeeds.
+- `200`: the new session replaced the old one (or was created fresh if none existed)
+
+The SSH transport-dial step retries transient failures (such as a momentary DNS resolution error) a
+few times with a short backoff before this endpoint returns `500`; only the initial TCP/ProxyJump/
+ProxyCommand connection step is retried, not SSH handshake or authentication failures.
+
 ### `GET /api/ssh-connections`
 
 Returns a sorted list of all known SSH connection names — the union of names defined in `ssh_connections` (YAML) and non-wildcard hosts from `~/.ssh/config`. Names present in both sources are deduplicated, with the YAML entry taking precedence.
@@ -298,7 +314,10 @@ Endpoint: `GET /ws/{sessionID}`
 
 Connection behavior:
 
-- `404` if the session ID does not exist
+- `404` if the session ID does not exist. After a successful `/restart` this cannot happen for a
+  pane that was previously running; if `/restart` itself fails, the pane's prior session stays
+  registered (see `POST /api/sessions/{id}/restart` below), so this 404 is limited to session IDs
+  that were never created in the first place.
 - initial text frame is a JSON status message with `type: "status"` and `state: "connected"`
 - if a reconnect has buffered output, the backend sends `{"type":"replay","state":"start"}`,
   replays up to the recent per-session output buffer as a binary frame, then sends
@@ -440,6 +459,13 @@ When an SSH-backed pane loses its transport unexpectedly, panemux classifies tha
 `disconnected` instead of `exited`. The frontend performs one automatic recovery attempt by
 recreating the session and reconnecting the pane. Deliberate remote shell termination such as
 `exit` remains `exited` and shows the restart action instead of auto-reconnecting.
+
+The same one-shot automatic recovery also triggers if the pane's WebSocket connection itself
+repeatedly fails to (re)establish and exhausts its own reconnect attempt budget, even if the
+backend never reported a `disconnected` status frame (e.g. during a prolonged network outage that
+prevents the WebSocket handshake from completing at all). Either way, if the automatic recovery
+attempt itself fails, the pane shows the manual "Reconnect Session" action instead of the
+"reconnecting..." indicator forever.
 
 ### Selection and copy behavior
 

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -751,6 +751,56 @@ describe('useTerminal', () => {
     expect(result.current.reconnectFailed).toBe(true)
   })
 
+  it('WS reconnect exhaustion drives sessionState to disconnected and attempts recovery', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+
+    const container = makeContainer()
+    const { result } = renderHook(() =>
+      useTerminal({ sessionId: 'pane1', container, reconnectDelay: 10, maxReconnectAttempts: 1 })
+    )
+
+    await act(async () => {
+      // No simulateOpen(): the WebSocket itself keeps failing to establish,
+      // independent of any backend "disconnected" status frame.
+      MockWebSocket.instances[0].close()
+      await vi.advanceTimersByTimeAsync(20)
+    })
+
+    expect(result.current.sessionState).toBe('disconnected')
+    expect(fetchMock).toHaveBeenCalledWith('/api/sessions/pane1/restart', { method: 'POST' })
+
+    vi.useRealTimers()
+  })
+
+  // Regression test for the reported bug: an unstable ssh/ssh+tmux connection
+  // left panes showing "reconnecting..." forever with no way out, because the
+  // low-level WebSocket reconnect loop gave up silently after its attempt
+  // budget without ever producing a "disconnected" status frame, so the
+  // manual "Reconnect Session" button (driven by sessionState/reconnectFailed)
+  // never appeared.
+  it('manual Reconnect Session affordance is reachable after WS exhaustion without any status frame ever arriving', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network error'))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+
+    const container = makeContainer()
+    const { result } = renderHook(() =>
+      useTerminal({ sessionId: 'pane1', container, reconnectDelay: 10, maxReconnectAttempts: 1 })
+    )
+
+    await act(async () => {
+      MockWebSocket.instances[0].close()
+      await vi.advanceTimersByTimeAsync(20)
+    })
+
+    expect(result.current.sessionState).toBe('disconnected')
+    expect(result.current.reconnectFailed).toBe(true)
+
+    vi.useRealTimers()
+  })
+
   it('reuses the same terminal instance across remounts for the same session', () => {
     const firstContainer = makeContainer()
     const secondContainer = makeContainer()

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -13,6 +13,11 @@ interface UseTerminalOptions {
   container: HTMLElement | null
   repoURL?: string
   onInteraction?: () => void | Promise<void>
+  // Reconnect tuning, forwarded to useWebSocket. Only overridden in tests;
+  // production callers rely on useWebSocket's defaults.
+  reconnectDelay?: number
+  maxReconnectDelay?: number
+  maxReconnectAttempts?: number
 }
 
 interface TerminalEntry {
@@ -37,7 +42,15 @@ interface PendingTerminalMessage {
 const terminalEntries = new Map<string, TerminalEntry>()
 type TerminalLifecycleState = 'running' | 'disconnected' | 'exited'
 
-export function useTerminal({ sessionId, container, repoURL, onInteraction }: UseTerminalOptions) {
+export function useTerminal({
+  sessionId,
+  container,
+  repoURL,
+  onInteraction,
+  reconnectDelay,
+  maxReconnectDelay,
+  maxReconnectAttempts,
+}: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null)
   const fitAddonRef = useRef<FitAddon | null>(null)
   const initializedRef = useRef(false)
@@ -109,7 +122,7 @@ export function useTerminal({ sessionId, container, repoURL, onInteraction }: Us
   }, [applyMessageToTerminal])
 
   const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/${sessionId}`
-  const { send, connected, reconnect } = useWebSocket(wsUrl, {
+  const { send, connected, exhausted, reconnect } = useWebSocket(wsUrl, {
     onMessage: handleMessage,
     onOpen: () => {
       setSessionState('running')
@@ -118,6 +131,9 @@ export function useTerminal({ sessionId, container, repoURL, onInteraction }: Us
       const entry = entryRef.current
       if (entry) resetReplayState(entry)
     },
+    reconnectDelay,
+    maxReconnectDelay,
+    maxReconnectAttempts,
   })
 
   const recoverDisconnectedSession = useCallback(async () => {
@@ -142,6 +158,18 @@ export function useTerminal({ sessionId, container, repoURL, onInteraction }: Us
   // This ref is read from an async status-frame handler that can run before an
   // effect flushes, so keep it current during render rather than one commit later.
   recoverDisconnectedSessionRef.current = recoverDisconnectedSession
+
+  // A backend-reported "disconnected" status frame isn't the only way a pane
+  // can go bad: the WebSocket itself can repeatedly fail to (re)establish and
+  // exhaust its own retry budget without ever delivering a status frame (e.g.
+  // during a prolonged network outage). Route that case through the same
+  // recovery path so the pane doesn't get stuck showing "reconnecting..."
+  // forever with no way to reach the manual restart button.
+  useEffect(() => {
+    if (!exhausted) return
+    setSessionState('disconnected')
+    void recoverDisconnectedSessionRef.current?.()
+  }, [exhausted])
 
   // Keep sendRef in sync so onData closure always has the latest send
   useLayoutEffect(() => {

--- a/frontend/src/hooks/useWebSocket.test.ts
+++ b/frontend/src/hooks/useWebSocket.test.ts
@@ -146,13 +146,66 @@ describe('useWebSocket', () => {
 
   it('stops reconnecting after max attempts', () => {
     const onMessage = vi.fn()
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useWebSocket('ws://localhost/ws/s1', { onMessage, reconnectDelay: 100, maxReconnectAttempts: 1 })
     )
     act(() => MockWebSocket.instances[0].simulateClose())
     act(() => vi.advanceTimersByTime(200))
     // connect() was called but attemptsRef >= maxReconnectAttempts → no new instance
     expect(MockWebSocket.instances).toHaveLength(1)
+    expect(result.current.exhausted).toBe(true)
+  })
+
+  it('exhausted stays false while attempts remain', () => {
+    const onMessage = vi.fn()
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/ws/s1', { onMessage, reconnectDelay: 100, maxReconnectAttempts: 3 })
+    )
+    act(() => MockWebSocket.instances[0].simulateClose())
+    act(() => vi.advanceTimersByTime(100))
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(result.current.exhausted).toBe(false)
+  })
+
+  it('backs off exponentially between reconnect attempts', () => {
+    const onMessage = vi.fn()
+    renderHook(() =>
+      useWebSocket('ws://localhost/ws/s1', { onMessage, reconnectDelay: 100, maxReconnectAttempts: 5 })
+    )
+    act(() => MockWebSocket.instances[0].simulateClose())
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => vi.advanceTimersByTime(99))
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => vi.advanceTimersByTime(1))
+    expect(MockWebSocket.instances).toHaveLength(2) // first retry fires at 100ms
+
+    act(() => MockWebSocket.instances[1].simulateClose())
+    act(() => vi.advanceTimersByTime(199))
+    expect(MockWebSocket.instances).toHaveLength(2)
+    act(() => vi.advanceTimersByTime(1))
+    expect(MockWebSocket.instances).toHaveLength(3) // second retry fires at 200ms (doubled)
+  })
+
+  it('caps backoff at maxReconnectDelay', () => {
+    const onMessage = vi.fn()
+    renderHook(() =>
+      useWebSocket('ws://localhost/ws/s1', {
+        onMessage,
+        reconnectDelay: 1000,
+        maxReconnectAttempts: 10,
+        maxReconnectDelay: 1500,
+      })
+    )
+    act(() => MockWebSocket.instances[0].simulateClose())
+    act(() => vi.advanceTimersByTime(1000))
+    expect(MockWebSocket.instances).toHaveLength(2) // first retry at base delay (1000ms)
+
+    act(() => MockWebSocket.instances[1].simulateClose())
+    // Uncapped exponential delay would be 2000ms; capped delay is 1500ms.
+    act(() => vi.advanceTimersByTime(1499))
+    expect(MockWebSocket.instances).toHaveLength(2)
+    act(() => vi.advanceTimersByTime(1))
+    expect(MockWebSocket.instances).toHaveLength(3)
   })
 
   it('does not reconnect if component unmounts before reconnect delay fires', () => {
@@ -200,9 +253,11 @@ describe('useWebSocket', () => {
     act(() => MockWebSocket.instances[0].simulateClose())
     act(() => vi.advanceTimersByTime(200))
     expect(MockWebSocket.instances).toHaveLength(1) // stopped reconnecting
+    expect(result.current.exhausted).toBe(true)
 
     act(() => result.current.reconnect())
     expect(MockWebSocket.instances).toHaveLength(2)
+    expect(result.current.exhausted).toBe(false)
   })
 
   it('passes binary messages through without validation', () => {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -8,17 +8,21 @@ interface UseWebSocketOptions {
   onOpen?: () => void
   onClose?: () => void
   reconnectDelay?: number
+  maxReconnectDelay?: number
   maxReconnectAttempts?: number
 }
 
 export function useWebSocket(url: string, options: UseWebSocketOptions) {
-  const { reconnectDelay = 2000, maxReconnectAttempts = 10 } = options
+  const { reconnectDelay = 2000, maxReconnectDelay = 30000, maxReconnectAttempts = 10 } = options
 
   const wsRef = useRef<WebSocket | null>(null)
   const attemptsRef = useRef(0)
   const mountedRef = useRef(true)
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [connected, setConnected] = useState(false)
+  // Set once the reconnect budget is exhausted so callers can stop assuming
+  // automatic recovery will happen and surface a manual retry affordance.
+  const [exhausted, setExhausted] = useState(false)
 
   // Store callbacks in refs so connect() doesn't need them as deps
   // and won't recreate/reconnect on every render
@@ -38,7 +42,10 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
 
   const connect = useCallback(() => {
     if (!mountedRef.current) return
-    if (attemptsRef.current >= maxReconnectAttempts) return
+    if (attemptsRef.current >= maxReconnectAttempts) {
+      setExhausted(true)
+      return
+    }
 
     const ws = new WebSocket(url)
     ws.binaryType = 'arraybuffer'
@@ -69,19 +76,23 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
       setConnected(false)
       onCloseRef.current?.()
       if (mountedRef.current) {
+        // Exponential backoff (base delay doubles each attempt), capped at
+        // maxReconnectDelay so a long outage doesn't grow the wait unbounded.
+        const delay = Math.min(reconnectDelay * 2 ** attemptsRef.current, maxReconnectDelay)
         attemptsRef.current++
         clearReconnectTimer()
         reconnectTimerRef.current = setTimeout(() => {
           reconnectTimerRef.current = null
           connect()
-        }, reconnectDelay)
+        }, delay)
       }
     }
 
     ws.onerror = () => {
       ws.close()
     }
-  }, [url, reconnectDelay, maxReconnectAttempts, clearReconnectTimer]) // callbacks excluded via refs
+    // callbacks excluded via refs
+  }, [url, reconnectDelay, maxReconnectDelay, maxReconnectAttempts, clearReconnectTimer])
 
   useEffect(() => {
     mountedRef.current = true
@@ -112,10 +123,11 @@ export function useWebSocket(url: string, options: UseWebSocketOptions) {
       setConnected(false)
     }
     attemptsRef.current = 0
+    setExhausted(false)
     connect()
   }, [connect, clearReconnectTimer])
 
-  return { send, connected, reconnect }
+  return { send, connected, exhausted, reconnect }
 }
 
 function isArrayBuffer(value: unknown): value is ArrayBuffer {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -46,6 +46,8 @@ type Handler struct {
 	readDirFn               func(name string) ([]os.DirEntry, error)
 	preferredCWDMu          sync.Mutex
 	preferredCWDBySession   map[string]preferredCWDState
+	restartMu               sync.Mutex
+	restartInFlight         map[string]struct{}
 }
 
 type preferredCWDState struct {
@@ -126,6 +128,7 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 		manager:               manager,
 		sshConfigPath:         sshconfig.DefaultPath(),
 		preferredCWDBySession: make(map[string]preferredCWDState),
+		restartInFlight:       make(map[string]struct{}),
 	}
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
@@ -410,6 +413,18 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 // RestartSession recreates a session from its original config.
 func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
+
+	// Creating the replacement session happens outside the manager's lock (it
+	// can block on a real SSH dial), so two concurrent restarts for the same
+	// pane would otherwise each build their own session independently; the
+	// one that finishes last would win the manager swap while the other's
+	// session is silently discarded unused. Serialize per-id instead of
+	// letting that race play out.
+	if !h.beginRestart(id) {
+		http.Error(w, "a restart is already in progress for this session", http.StatusConflict)
+		return
+	}
+	defer h.endRestart(id)
 
 	var found *config.PaneConfig
 	for _, p := range h.cfg.AllPanes() {
@@ -902,6 +917,27 @@ func (h *Handler) clearPreferredCWD(sessionID string) {
 	defer h.preferredCWDMu.Unlock()
 
 	delete(h.preferredCWDBySession, sessionID)
+}
+
+// beginRestart claims the per-id restart guard, returning false if a restart
+// for id is already in progress.
+func (h *Handler) beginRestart(id string) bool {
+	h.restartMu.Lock()
+	defer h.restartMu.Unlock()
+
+	if _, ok := h.restartInFlight[id]; ok {
+		return false
+	}
+	h.restartInFlight[id] = struct{}{}
+	return true
+}
+
+// endRestart releases the per-id restart guard claimed by beginRestart.
+func (h *Handler) endRestart(id string) {
+	h.restartMu.Lock()
+	defer h.restartMu.Unlock()
+
+	delete(h.restartInFlight, id)
 }
 
 func (h *Handler) gitInfoLogScope(sess session.Session) string {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -423,14 +423,18 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.manager.Remove(id) //nolint:errcheck // ok if already gone
-	h.clearPreferredCWD(id)
-
+	// Create the replacement session before touching the manager. If this fails
+	// (e.g. a transient SSH dial error), the existing session for id stays
+	// registered instead of being orphaned, so /ws and /git-info keep working
+	// against it and the frontend's disconnected-status recovery path can retry.
 	sess, err := h.createSession(found, h.cfg.SSHConnections)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	h.manager.Remove(id) //nolint:errcheck // ok if already gone
+	h.clearPreferredCWD(id)
 	h.manager.Add(sess)
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1025,6 +1025,99 @@ func TestRestartSession_CreateFails_NoPanicWhenNoPriorSession(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestRestartSession_ConcurrentRequests_SecondReturns409 guards against a
+// race the create-first reordering (TestRestartSession_CreateFails_*) newly
+// exposed: two concurrent /restart calls for the same pane each build their
+// own replacement session independently, and whichever finishes last wins
+// the manager swap while the other's freshly-created (and never-used)
+// session is orphaned/leaked. A per-id in-flight guard rejects the second
+// concurrent call instead.
+func TestRestartSession_ConcurrentRequests_SecondReturns409(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+
+	started := make(chan struct{})
+	proceed := make(chan struct{})
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		close(started)
+		<-proceed
+		return newMockSession(pane.ID), nil
+	}
+	r := setupRouterWithHandler(h)
+
+	firstDone := make(chan int, 1)
+	go func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+		r.ServeHTTP(rec, req)
+		firstDone <- rec.Code
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first restart to start")
+	}
+
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusConflict, rec2.Code)
+
+	close(proceed)
+
+	select {
+	case code := <-firstDone:
+		assert.Equal(t, http.StatusOK, code)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first restart to finish")
+	}
+
+	_, ok := mgr.Get("main")
+	assert.True(t, ok)
+}
+
+// TestRestartSession_GuardReleasedAfterCompletion verifies the per-id
+// in-flight guard is released once a restart finishes (success or failure),
+// so it never permanently locks a pane out of future restarts.
+func TestRestartSession_GuardReleasedAfterCompletion(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		return nil, errors.New("dial failed")
+	}
+	r := setupRouterWithHandler(h)
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	}
+}
+
 func TestPutLayout_PersistsImmediately(t *testing.T) {
 	cfg := defaultTestConfig()
 	r := setupRouter(cfg, session.NewManager())

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -904,6 +904,127 @@ func TestRestartSession_NotFound_404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestRestartSession_CreateFails_OldSessionStaysRegistered(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	original := newMockSession("main")
+	mgr.Add(original)
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
+		return nil, errors.New("dial failed")
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	// The pre-existing session must still be registered under the same ID
+	// so subsequent /ws and /git-info requests do not 404 permanently.
+	got, ok := mgr.Get("main")
+	assert.True(t, ok)
+	assert.Same(t, session.Session(original), got)
+}
+
+func TestRestartSession_CreateFails_PreservesPreferredCWD(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.preferredCWDBySession["main"] = preferredCWDState{
+		CWD:       "/remote/home/demo",
+		CommonDir: "/remote/home/demo/.git",
+		Root:      "/remote/home/demo",
+	}
+	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
+		return nil, errors.New("dial failed")
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	_, ok := h.preferredCWDBySession["main"]
+	assert.True(t, ok)
+}
+
+func TestRestartSession_CreateFails_500Body(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
+		return nil, errors.New("dial tcp: lookup host.example: no such host")
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no such host")
+}
+
+func TestRestartSession_CreateFails_NoPanicWhenNoPriorSession(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
+		return nil, errors.New("dial failed")
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	assert.NotPanics(t, func() {
+		r.ServeHTTP(rec, req)
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	_, ok := mgr.Get("main")
+	assert.False(t, ok)
+}
+
 func TestPutLayout_PersistsImmediately(t *testing.T) {
 	cfg := defaultTestConfig()
 	r := setupRouter(cfg, session.NewManager())

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -92,6 +92,14 @@ func resolveKnownHostsFile(knownHostsFile string) (string, error) {
 // and ProxyCommand. Returns (client, jumpClient, error). jumpClient is non-nil only when
 // a ProxyJump is used; the caller must close jumpClient after closing client.
 func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
+	return dialSSHClientUntil(cfg, nowFn().Add(dialRetryBudget))
+}
+
+// dialSSHClientUntil is dialSSHClient with an explicit retry deadline. A
+// ProxyJump hop shares the outer call's deadline (see dialThroughJump) rather
+// than starting a fresh dialRetryBudget window, so a multi-hop chain's total
+// retry time stays bounded by a single budget instead of multiplying per hop.
+func dialSSHClientUntil(cfg SSHConfig, deadline time.Time) (*ssh.Client, *ssh.Client, error) {
 	authMethods, err := buildAuthMethods(cfg)
 	if err != nil {
 		return nil, nil, err
@@ -116,7 +124,7 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		Timeout:           30 * time.Second,
 	}
 
-	conn, jumpClient, err := dialTransportWithRetry(cfg, addr, port)
+	conn, jumpClient, err := dialTransportWithRetry(cfg, addr, port, deadline)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -143,10 +151,12 @@ const (
 	// dialRetryInitialBackoff is the delay before the second attempt; it
 	// doubles on each subsequent attempt (300ms, 600ms).
 	dialRetryInitialBackoff = 300 * time.Millisecond
-	// dialRetryBudget caps the total wall-clock time spent retrying at the
-	// same ceiling as a single dial attempt's own timeout, so a caller
-	// synchronously waiting on dialSSHClient (e.g. the /restart HTTP handler)
-	// never waits dramatically longer than it already tolerates today.
+	// dialRetryBudget caps the total wall-clock time spent retrying, shared
+	// across an entire ProxyJump chain via a single deadline (see
+	// dialSSHClientUntil), so a caller synchronously waiting on dialSSHClient
+	// (e.g. the /restart HTTP handler) never waits dramatically longer than
+	// the ceiling a single dial attempt already tolerated before retries were
+	// introduced.
 	dialRetryBudget = 30 * time.Second
 )
 
@@ -160,10 +170,10 @@ var (
 // dialTransportFn is the transport-dial step, injectable for tests. Assigned
 // in init (rather than at the var declaration) to avoid a spurious Go
 // initialization-cycle error: dialTransport transitively calls back into
-// dialTransportFn through dialThroughJump -> dialSSHClient, and Go's
+// dialTransportFn through dialThroughJump -> dialSSHClientUntil, and Go's
 // init-order analysis does not distinguish "referenced in a function body"
 // from "referenced at initialization time".
-var dialTransportFn func(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error)
+var dialTransportFn func(cfg SSHConfig, addr string, port int, deadline time.Time) (net.Conn, *ssh.Client, error)
 
 func init() {
 	dialTransportFn = dialTransport
@@ -171,26 +181,37 @@ func init() {
 
 // dialTransport establishes the raw transport (TCP, ProxyJump, or
 // ProxyCommand) for an SSH connection, without performing the SSH handshake.
-func dialTransport(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error) {
+// The direct-dial timeout is clamped to whatever of deadline remains, so a
+// retried attempt can never itself run past the shared retry budget.
+func dialTransport(cfg SSHConfig, addr string, port int, deadline time.Time) (net.Conn, *ssh.Client, error) {
 	switch {
 	case cfg.JumpHost != nil:
-		return dialThroughJump(*cfg.JumpHost, addr)
+		return dialThroughJump(*cfg.JumpHost, addr, deadline)
 	case cfg.ProxyCommand != "":
 		conn, err := dialViaProxyCommand(cfg.ProxyCommand, cfg.Host, port)
 		return conn, nil, err
 	default:
-		conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+		timeout := deadline.Sub(nowFn())
+		if timeout <= 0 {
+			return nil, nil, fmt.Errorf("dial %s: retry budget exhausted", addr)
+		}
+		conn, err := net.DialTimeout("tcp", addr, timeout)
 		return conn, nil, err
 	}
 }
 
 // dialTransportWithRetry retries dialTransport with a short backoff on
-// failure, bounded by dialRetryMaxAttempts and dialRetryBudget. Only the
-// transport step is retried; a successful transport dial followed by an SSH
+// failure, bounded by dialRetryMaxAttempts and deadline. Only the transport
+// step is retried; a successful transport dial followed by an SSH
 // handshake/auth failure is never retried by this function since that
-// happens in a separate step in dialSSHClient.
-func dialTransportWithRetry(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error) {
-	start := nowFn()
+// happens in a separate step in dialSSHClientUntil.
+//
+// Each attempt's own timeout is clamped to the time remaining until deadline
+// (see dialTransport), so a slow/hanging attempt that consumes the whole
+// budget leaves no room for further attempts — the retry loop's own
+// before-each-attempt deadline check alone cannot do this, since it can only
+// observe elapsed time between attempts, not interrupt one already in flight.
+func dialTransportWithRetry(cfg SSHConfig, addr string, port int, deadline time.Time) (net.Conn, *ssh.Client, error) {
 	backoff := dialRetryInitialBackoff
 
 	var conn net.Conn
@@ -198,11 +219,17 @@ func dialTransportWithRetry(cfg SSHConfig, addr string, port int) (net.Conn, *ss
 	var err error
 
 	for attempt := 1; attempt <= dialRetryMaxAttempts; attempt++ {
-		conn, jumpClient, err = dialTransportFn(cfg, addr, port)
+		if !nowFn().Before(deadline) {
+			if err == nil {
+				err = fmt.Errorf("dial %s: retry budget exhausted before attempt %d", addr, attempt)
+			}
+			break
+		}
+		conn, jumpClient, err = dialTransportFn(cfg, addr, port, deadline)
 		if err == nil {
 			return conn, jumpClient, nil
 		}
-		if attempt == dialRetryMaxAttempts || nowFn().Sub(start) >= dialRetryBudget {
+		if attempt == dialRetryMaxAttempts || !nowFn().Before(deadline) {
 			break
 		}
 		sleepFn(backoff)
@@ -213,9 +240,11 @@ func dialTransportWithRetry(cfg SSHConfig, addr string, port int) (net.Conn, *ss
 
 // dialThroughJump connects to targetAddr by tunneling through a ProxyJump host.
 // Returns (conn to target, jumpClient, error). The jumpClient must be kept open
-// as long as conn is in use and closed when the target session ends.
-func dialThroughJump(jumpCfg SSHConfig, targetAddr string) (net.Conn, *ssh.Client, error) {
-	jumpClient, nestedJump, err := dialSSHClient(jumpCfg)
+// as long as conn is in use and closed when the target session ends. The jump
+// hop reuses the caller's deadline rather than a fresh retry budget, so a
+// multi-hop chain's worst-case retry time doesn't multiply per hop.
+func dialThroughJump(jumpCfg SSHConfig, targetAddr string, deadline time.Time) (net.Conn, *ssh.Client, error) {
+	jumpClient, nestedJump, err := dialSSHClientUntil(jumpCfg, deadline)
 	if err != nil {
 		return nil, nil, fmt.Errorf("dial jump host: %w", err)
 	}

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -116,17 +116,7 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 		Timeout:           30 * time.Second,
 	}
 
-	var conn net.Conn
-	var jumpClient *ssh.Client
-
-	switch {
-	case cfg.JumpHost != nil:
-		conn, jumpClient, err = dialThroughJump(*cfg.JumpHost, addr)
-	case cfg.ProxyCommand != "":
-		conn, err = dialViaProxyCommand(cfg.ProxyCommand, cfg.Host, port)
-	default:
-		conn, err = net.DialTimeout("tcp", addr, 30*time.Second)
-	}
+	conn, jumpClient, err := dialTransportWithRetry(cfg, addr, port)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -141,6 +131,84 @@ func dialSSHClient(cfg SSHConfig) (*ssh.Client, *ssh.Client, error) {
 	}
 
 	return ssh.NewClient(sshConn, chans, reqs), jumpClient, nil
+}
+
+const (
+	// dialRetryMaxAttempts bounds how many times the transport-dial step (TCP
+	// dial / ProxyJump / ProxyCommand) is retried before giving up. Retrying
+	// here smooths over transient DNS blips (e.g. "no address associated with
+	// hostname") on unstable networks; it deliberately does not cover the SSH
+	// handshake/auth step, which fails fast on the first attempt.
+	dialRetryMaxAttempts = 3
+	// dialRetryInitialBackoff is the delay before the second attempt; it
+	// doubles on each subsequent attempt (300ms, 600ms).
+	dialRetryInitialBackoff = 300 * time.Millisecond
+	// dialRetryBudget caps the total wall-clock time spent retrying at the
+	// same ceiling as a single dial attempt's own timeout, so a caller
+	// synchronously waiting on dialSSHClient (e.g. the /restart HTTP handler)
+	// never waits dramatically longer than it already tolerates today.
+	dialRetryBudget = 30 * time.Second
+)
+
+// sleepFn and nowFn are package-level so tests can inject deterministic
+// timing without real delays or wall-clock dependence.
+var (
+	sleepFn = time.Sleep
+	nowFn   = time.Now
+)
+
+// dialTransportFn is the transport-dial step, injectable for tests. Assigned
+// in init (rather than at the var declaration) to avoid a spurious Go
+// initialization-cycle error: dialTransport transitively calls back into
+// dialTransportFn through dialThroughJump -> dialSSHClient, and Go's
+// init-order analysis does not distinguish "referenced in a function body"
+// from "referenced at initialization time".
+var dialTransportFn func(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error)
+
+func init() {
+	dialTransportFn = dialTransport
+}
+
+// dialTransport establishes the raw transport (TCP, ProxyJump, or
+// ProxyCommand) for an SSH connection, without performing the SSH handshake.
+func dialTransport(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error) {
+	switch {
+	case cfg.JumpHost != nil:
+		return dialThroughJump(*cfg.JumpHost, addr)
+	case cfg.ProxyCommand != "":
+		conn, err := dialViaProxyCommand(cfg.ProxyCommand, cfg.Host, port)
+		return conn, nil, err
+	default:
+		conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+		return conn, nil, err
+	}
+}
+
+// dialTransportWithRetry retries dialTransport with a short backoff on
+// failure, bounded by dialRetryMaxAttempts and dialRetryBudget. Only the
+// transport step is retried; a successful transport dial followed by an SSH
+// handshake/auth failure is never retried by this function since that
+// happens in a separate step in dialSSHClient.
+func dialTransportWithRetry(cfg SSHConfig, addr string, port int) (net.Conn, *ssh.Client, error) {
+	start := nowFn()
+	backoff := dialRetryInitialBackoff
+
+	var conn net.Conn
+	var jumpClient *ssh.Client
+	var err error
+
+	for attempt := 1; attempt <= dialRetryMaxAttempts; attempt++ {
+		conn, jumpClient, err = dialTransportFn(cfg, addr, port)
+		if err == nil {
+			return conn, jumpClient, nil
+		}
+		if attempt == dialRetryMaxAttempts || nowFn().Sub(start) >= dialRetryBudget {
+			break
+		}
+		sleepFn(backoff)
+		backoff *= 2
+	}
+	return nil, nil, err
 }
 
 // dialThroughJump connects to targetAddr by tunneling through a ProxyJump host.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -121,7 +121,16 @@ func dialSSHClientUntil(cfg SSHConfig, deadline time.Time) (*ssh.Client, *ssh.Cl
 		Auth:              authMethods,
 		HostKeyCallback:   hkCallback,
 		HostKeyAlgorithms: knownHostsAlgorithms(knownHostsPath, addr),
-		Timeout:           30 * time.Second,
+		// Timeout is documented as bounding TCP connection establishment, but
+		// golang.org/x/crypto/ssh only reads it inside ssh.Dial(); it has no
+		// effect on ssh.NewClientConn (called below), which is what this
+		// package actually uses since it always dials its own net.Conn first.
+		// The handshake itself is therefore currently unbounded regardless of
+		// this value, for every transport (TCP, ProxyJump, and ProxyCommand
+		// alike) — retrying the dial (dialTransportWithRetry, above) does not
+		// change that. Kept here only so a future switch to ssh.Dial-style
+		// usage picks up a sane default; do not rely on it as a real timeout.
+		Timeout: 30 * time.Second,
 	}
 
 	conn, jumpClient, err := dialTransportWithRetry(cfg, addr, port, deadline)

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -800,4 +802,156 @@ func TestRemoteGitContext_IncompleteResponseReturnsDiagnosticError(t *testing.T)
 	require.ErrorAs(t, err, &gitErr)
 	assert.Equal(t, GitContextCauseIncomplete, gitErr.Cause)
 	assert.Equal(t, "/home/user/panemux", gitErr.Stderr)
+}
+
+// stubDialTransport tracks how many times it was called and pops canned
+// results off the given queue, useful for exercising dialTransportWithRetry
+// without any real network I/O.
+func stubDialTransport(
+	t *testing.T, results ...error,
+) (func(SSHConfig, string, int) (net.Conn, *gossh.Client, error), *int) {
+	t.Helper()
+	calls := 0
+	fn := func(SSHConfig, string, int) (net.Conn, *gossh.Client, error) {
+		calls++
+		idx := calls - 1
+		require.Less(t, idx, len(results), "unexpected extra dial attempt")
+		if results[idx] != nil {
+			return nil, nil, results[idx]
+		}
+		return &net.TCPConn{}, nil, nil
+	}
+	return fn, &calls
+}
+
+func withStubbedSleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	var slept []time.Duration
+	origSleep := sleepFn
+	sleepFn = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { sleepFn = origSleep })
+	return &slept
+}
+
+func TestDialWithRetry_SucceedsFirstTry(t *testing.T) {
+	slept := withStubbedSleep(t)
+	origDial := dialTransportFn
+	fn, calls := stubDialTransport(t, nil)
+	dialTransportFn = fn
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	require.NoError(t, err)
+	assert.Equal(t, 1, *calls)
+	assert.Empty(t, *slept)
+}
+
+func TestDialWithRetry_SucceedsAfterTransientFailures(t *testing.T) {
+	slept := withStubbedSleep(t)
+	origDial := dialTransportFn
+	fn, calls := stubDialTransport(t,
+		errors.New("dial tcp: lookup host: no address associated with hostname"),
+		errors.New("dial tcp: lookup host: no address associated with hostname"),
+		nil,
+	)
+	dialTransportFn = fn
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	require.NoError(t, err)
+	assert.Equal(t, 3, *calls)
+	assert.Len(t, *slept, 2)
+}
+
+func TestDialWithRetry_ExhaustsAllRetries(t *testing.T) {
+	withStubbedSleep(t)
+	origDial := dialTransportFn
+	wantErr := errors.New("dial tcp: lookup host: no address associated with hostname")
+	fn, calls := stubDialTransport(t, errors.New("attempt 1"), errors.New("attempt 2"), wantErr)
+	dialTransportFn = fn
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	require.Error(t, err)
+	assert.Equal(t, dialRetryMaxAttempts, *calls)
+	assert.Equal(t, wantErr, err)
+}
+
+func TestDialWithRetry_StopsRetryingPastElapsedBudget(t *testing.T) {
+	withStubbedSleep(t)
+	origDial := dialTransportFn
+	fn, calls := stubDialTransport(t, errors.New("attempt 1"), errors.New("attempt 2"), nil)
+	dialTransportFn = fn
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	origNow := nowFn
+	callCount := 0
+	start := time.Now()
+	nowFn = func() time.Time {
+		callCount++
+		if callCount == 1 {
+			return start
+		}
+		// Every subsequent check already sees the budget exceeded.
+		return start.Add(dialRetryBudget + time.Second)
+	}
+	t.Cleanup(func() { nowFn = origNow })
+
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	require.Error(t, err)
+	assert.Equal(t, 1, *calls)
+}
+
+// TestDialSSHClient_HandshakeFailure_NotRetried verifies that a TCP connection
+// that succeeds but fails the SSH handshake is not retried by the transport
+// dial loop: only auth/handshake failures should fail fast, since retrying
+// them could look like automated credential-guessing.
+func TestDialSSHClient_HandshakeFailure_NotRetried(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	var accepted int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			accepted++
+			conn.Close()
+		}
+	}()
+
+	host, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	var port int
+	_, err = fmt.Sscanf(portStr, "%d", &port)
+	require.NoError(t, err)
+
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(knownHosts, nil, 0600))
+
+	cfg := SSHConfig{
+		Host:           host,
+		Port:           port,
+		User:           "test",
+		Password:       "wrong",
+		KnownHostsFile: knownHosts,
+	}
+
+	start := time.Now()
+	_, _, err = dialSSHClient(cfg)
+	elapsed := time.Since(start)
+	require.Error(t, err)
+
+	ln.Close()
+	<-done
+
+	// The transport itself connects fine every time; only the handshake
+	// fails, and handshake failures happen outside the dial-retry loop.
+	assert.Equal(t, int32(1), accepted)
+	assert.Less(t, elapsed, dialRetryInitialBackoff, "handshake failure should fail fast without dial-retry backoff")
 }

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -804,15 +805,38 @@ func TestRemoteGitContext_IncompleteResponseReturnsDiagnosticError(t *testing.T)
 	assert.Equal(t, "/home/user/panemux", gitErr.Stderr)
 }
 
+// fakeClock is a mutable clock so tests can simulate a dial attempt itself
+// consuming wall-clock time (as a slow/hanging attempt would), which a plain
+// injected nowFn sequence cannot express since the retry loop reads nowFn
+// independently of when dialTransportFn returns.
+type fakeClock struct {
+	t  time.Time
+	mu sync.Mutex
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Now()} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
 // stubDialTransport tracks how many times it was called and pops canned
 // results off the given queue, useful for exercising dialTransportWithRetry
 // without any real network I/O.
 func stubDialTransport(
 	t *testing.T, results ...error,
-) (func(SSHConfig, string, int) (net.Conn, *gossh.Client, error), *int) {
+) (func(SSHConfig, string, int, time.Time) (net.Conn, *gossh.Client, error), *int) {
 	t.Helper()
 	calls := 0
-	fn := func(SSHConfig, string, int) (net.Conn, *gossh.Client, error) {
+	fn := func(SSHConfig, string, int, time.Time) (net.Conn, *gossh.Client, error) {
 		calls++
 		idx := calls - 1
 		require.Less(t, idx, len(results), "unexpected extra dial attempt")
@@ -840,7 +864,7 @@ func TestDialWithRetry_SucceedsFirstTry(t *testing.T) {
 	dialTransportFn = fn
 	t.Cleanup(func() { dialTransportFn = origDial })
 
-	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, nowFn().Add(dialRetryBudget))
 	require.NoError(t, err)
 	assert.Equal(t, 1, *calls)
 	assert.Empty(t, *slept)
@@ -857,7 +881,7 @@ func TestDialWithRetry_SucceedsAfterTransientFailures(t *testing.T) {
 	dialTransportFn = fn
 	t.Cleanup(func() { dialTransportFn = origDial })
 
-	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, nowFn().Add(dialRetryBudget))
 	require.NoError(t, err)
 	assert.Equal(t, 3, *calls)
 	assert.Len(t, *slept, 2)
@@ -871,7 +895,7 @@ func TestDialWithRetry_ExhaustsAllRetries(t *testing.T) {
 	dialTransportFn = fn
 	t.Cleanup(func() { dialTransportFn = origDial })
 
-	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, nowFn().Add(dialRetryBudget))
 	require.Error(t, err)
 	assert.Equal(t, dialRetryMaxAttempts, *calls)
 	assert.Equal(t, wantErr, err)
@@ -884,22 +908,84 @@ func TestDialWithRetry_StopsRetryingPastElapsedBudget(t *testing.T) {
 	dialTransportFn = fn
 	t.Cleanup(func() { dialTransportFn = origDial })
 
+	clock := newFakeClock()
 	origNow := nowFn
-	callCount := 0
-	start := time.Now()
-	nowFn = func() time.Time {
-		callCount++
-		if callCount == 1 {
-			return start
-		}
-		// Every subsequent check already sees the budget exceeded.
-		return start.Add(dialRetryBudget + time.Second)
-	}
+	nowFn = clock.now
 	t.Cleanup(func() { nowFn = origNow })
 
-	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22)
+	deadline := clock.now().Add(dialRetryBudget)
+	// Advance past the deadline before the retry loop even starts its first
+	// pre-attempt check.
+	clock.advance(dialRetryBudget + time.Second)
+
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, deadline)
 	require.Error(t, err)
-	assert.Equal(t, 1, *calls)
+	assert.Equal(t, 0, *calls, "no attempt should be made once the deadline has already passed")
+}
+
+// TestDialWithRetry_HangingFirstAttemptConsumesWholeBudget is the regression
+// test for a reviewer-flagged gap: the retry loop only checked elapsed time
+// *between* attempts, so a target that fails slowly (hangs near its own
+// per-attempt timeout) rather than quickly (e.g. an instant DNS error) could
+// still cost up to dialRetryMaxAttempts full timeouts before the budget
+// check caught up. Each attempt must now be dialed with a timeout clamped to
+// the *remaining* budget, so one hanging attempt that consumes the whole
+// budget leaves no room for further attempts.
+func TestDialWithRetry_HangingFirstAttemptConsumesWholeBudget(t *testing.T) {
+	withStubbedSleep(t)
+	clock := newFakeClock()
+	origNow := nowFn
+	nowFn = clock.now
+	t.Cleanup(func() { nowFn = origNow })
+
+	origDial := dialTransportFn
+	calls := 0
+	var gotTimeouts []time.Duration
+	dialTransportFn = func(_ SSHConfig, _ string, _ int, deadline time.Time) (net.Conn, *gossh.Client, error) {
+		calls++
+		gotTimeouts = append(gotTimeouts, deadline.Sub(clock.now()))
+		// Simulate the attempt itself hanging for its entire allotted budget
+		// before finally failing, rather than failing instantly.
+		clock.advance(dialRetryBudget)
+		return nil, nil, errors.New("i/o timeout")
+	}
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	deadline := clock.now().Add(dialRetryBudget)
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, deadline)
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "a hanging attempt that consumes the whole budget must not be retried")
+	require.Len(t, gotTimeouts, 1)
+	assert.InDelta(t, dialRetryBudget, gotTimeouts[0], float64(50*time.Millisecond))
+}
+
+// TestDialWithRetry_ShrinksTimeoutForSubsequentAttempts verifies each retry's
+// own dial timeout is clamped to whatever budget remains, not a fresh
+// dialRetryBudget every time — otherwise attempts that each take just under
+// the full budget could cumulatively run far longer than dialRetryBudget.
+func TestDialWithRetry_ShrinksTimeoutForSubsequentAttempts(t *testing.T) {
+	withStubbedSleep(t)
+	clock := newFakeClock()
+	origNow := nowFn
+	nowFn = clock.now
+	t.Cleanup(func() { nowFn = origNow })
+
+	origDial := dialTransportFn
+	var gotTimeouts []time.Duration
+	dialTransportFn = func(_ SSHConfig, _ string, _ int, deadline time.Time) (net.Conn, *gossh.Client, error) {
+		gotTimeouts = append(gotTimeouts, deadline.Sub(clock.now()))
+		// Each attempt takes most, but not all, of what's currently left.
+		clock.advance(dialRetryBudget / 2)
+		return nil, nil, errors.New("attempt failed")
+	}
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	deadline := clock.now().Add(dialRetryBudget)
+	_, _, err := dialTransportWithRetry(SSHConfig{}, "host:22", 22, deadline)
+	require.Error(t, err)
+	require.Len(t, gotTimeouts, 2, "budget should be exhausted after two half-budget attempts")
+	assert.InDelta(t, dialRetryBudget, gotTimeouts[0], float64(50*time.Millisecond))
+	assert.InDelta(t, dialRetryBudget/2, gotTimeouts[1], float64(50*time.Millisecond))
 }
 
 // TestDialSSHClient_HandshakeFailure_NotRetried verifies that a TCP connection
@@ -954,4 +1040,37 @@ func TestDialSSHClient_HandshakeFailure_NotRetried(t *testing.T) {
 	// fails, and handshake failures happen outside the dial-retry loop.
 	assert.Equal(t, int32(1), accepted)
 	assert.Less(t, elapsed, dialRetryInitialBackoff, "handshake failure should fail fast without dial-retry backoff")
+}
+
+// TestDialTransport_JumpHostSharesRetryDeadlineWithOuterCall is the
+// regression test for a reviewer-flagged gap: dialThroughJump used to call
+// dialSSHClient (the public entry point), which computed its own fresh
+// dialRetryBudget window. That meant a ProxyJump chain could retry the jump
+// hop's own transport dial independently of the outer target dial's retry
+// loop, multiplying the worst-case wall-clock time for a hanging/unreachable
+// jump host. The jump hop must now reuse the exact same deadline as the
+// outer call.
+func TestDialTransport_JumpHostSharesRetryDeadlineWithOuterCall(t *testing.T) {
+	withStubbedSleep(t)
+	origDial := dialTransportFn
+	var gotDeadlines []time.Time
+	dialTransportFn = func(_ SSHConfig, _ string, _ int, deadline time.Time) (net.Conn, *gossh.Client, error) {
+		gotDeadlines = append(gotDeadlines, deadline)
+		return nil, nil, errors.New("jump dial failed")
+	}
+	t.Cleanup(func() { dialTransportFn = origDial })
+
+	knownHosts := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(knownHosts, nil, 0600))
+
+	jumpCfg := SSHConfig{Host: "jump.invalid", Port: 22, User: "jump", Password: "x", KnownHostsFile: knownHosts}
+	cfg := SSHConfig{Host: "target.invalid", Port: 22, JumpHost: &jumpCfg}
+
+	deadline := nowFn().Add(dialRetryBudget)
+	_, _, err := dialTransport(cfg, "target.invalid:22", 22, deadline)
+	require.Error(t, err)
+	require.NotEmpty(t, gotDeadlines)
+	for _, d := range gotDeadlines {
+		assert.True(t, d.Equal(deadline), "jump host dial must reuse the same deadline as the outer call, not a fresh budget")
+	}
 }


### PR DESCRIPTION
## Summary

Unstable ssh/ssh+tmux connections could leave a pane showing "reconnecting..." permanently, with `/git-info 404`s and `/restart 500`s recurring in the logs, and SSH connections frequently emitting a transient "no address associated with hostname" DNS error. Three compounding causes were found and fixed:

- **`RestartSession` orphaned panes on failure.** It removed a pane's session from the manager *before* attempting to recreate it, so a transient SSH dial failure (e.g. a momentary DNS blip) left the pane permanently orphaned until some later restart happened to succeed — explaining the recurring `/git-info` 404s and the pane's WebSocket 404ing forever. Now the replacement session is created first; the old session is only swapped out after success.
- **`dialSSHClient` made only one dial attempt.** A transient DNS error failed the whole connection (and thus `/restart`) immediately. The transport-dial step (not the SSH handshake/auth step) now retries a bounded number of times with a short backoff.
- **`useWebSocket`'s reconnect loop gave up silently.** After exhausting its fixed-count, fixed-delay retry budget, it left `connected=false` forever with no signal, so a pane could show "reconnecting..." indefinitely with no way to reach the manual restart button. It now uses exponential backoff and exposes an `exhausted` state that `useTerminal` routes into the existing disconnected-session recovery path (the same one-shot auto-restart + manual "Reconnect Session" button used for backend-reported disconnects).

The previously-reported workaround (opening the WorkingDirectory Browse dialog twice, then Save) worked because Save triggers `/restart` as a side effect — the user was unknowingly retrying the SSH dial until a transient blip cleared. No SSH connection caching/pooling exists anywhere in the codebase; that was a red herring.

## Test plan

- [x] `make check` passes (lint, tests, coverage) on the branch
- [x] New Go tests: `internal/api/handler_test.go` (`RestartSession` no longer orphans the session on `createSession` failure) and `internal/session/ssh_test.go` (dial retry succeeds/exhausts/respects budget; handshake failures are never retried)
- [x] New frontend tests: `useWebSocket.test.ts` (exponential backoff, `exhausted` state) and `useTerminal.test.ts` (WS exhaustion drives the same recovery path as a backend-reported disconnect, including the regression case where no status frame ever arrives)
- [x] Manually verified end-to-end: built the binary, pointed a pane at an unreachable SSH host, confirmed `/restart` returns 500 without removing the pane's prior session, confirmed `/git-info` keeps returning 200 instead of 404, and confirmed in the browser that ending a local shell surfaces the "Restart Session" button which successfully reconnects
- [x] `docs/behavior.md` updated to document `/restart`'s recreate-in-place semantics and the WS-exhaustion recovery path