### PR TITLE
fix: detect worktrees from Claude subagent transcripts, show multiple PRs

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -560,6 +560,8 @@ When a pane moves to a different parent node, the component may be remounted by 
 - Claude session metadata is used only to identify the matching transcript (`sessionId`) and project directory key.
 - Claude transcript resolution prefers the latest top-level `cwd` recorded on transcript entries such as `user`, `assistant`, `attachment`, and `system`.
 - When a Claude transcript entry does not expose top-level `cwd`, panemux falls back to the latest non-auxiliary tool file path, then the latest `Bash` tool `cd ... &&` target, then file-history snapshot paths.
+- Claude Code also records delegated Task subagent activity in separate transcript files under `<sessionId>/subagents/*.jsonl`, next to the parent transcript. A subagent that does worktree-relative work there never updates the parent transcript's own `cwd`, so panemux additionally reads every subagent transcript file and resolves each one with the same rule above, independently of the parent.
+- panemux does not apply any recency or time-window filter when considering subagent transcripts: every distinct worktree signaled by the parent transcript or any subagent transcript for the current session is a candidate, regardless of how long ago that transcript file was last written.
 - This resolver intentionally does not depend on Claude `hooks` or `statusLine` configuration, so no extra Claude-side setup is required for pane-header Git or PR detection.
 - If the agent exits, no longer has an eligible worktree, or the resolved worktree is not a sibling worktree of the pane's current repository, panemux falls back to the pane's own working directory immediately.
 - For SSH panes, panemux resolves interactive agent processes from the remote process list on the current SSH connection.
@@ -567,6 +569,8 @@ When a pane moves to a different parent node, the component may be remounted by 
 - If the resolved repository origin can be converted into a browser URL, the header shows the repository name as a link to that repository page.
 - For SCP-style SSH origins such as `git@alias:owner/repo.git`, panemux uses `~/.ssh/config` `Host` aliases to resolve both the browser link hostname and GitHub PR lookup repo host when a matching alias exists; otherwise it treats the SSH host token as the hostname directly.
 - If the resolved branch has a GitHub pull request, the header shows a PR link labeled `#<number>`.
+- When the active agent (including its subagents) has diverged into more than one distinct sibling worktree of the same repository, panemux shows all of them instead of just one, deduplicated by the worktree's repository root; the pane's own base directory is shown only when nothing has diverged from it. Each distinct worktree gets its own independent GitHub PR lookup, so more than one PR link can be shown at once. See [ui-design.md](ui-design.md) for how the header presents more than one worktree.
+- The "last known worktree" sticky behavior applies per distinct worktree: if the active-workdir lookup transiently fails or returns nothing, panemux keeps showing the previously resolved set of worktrees until a subsequent lookup confirms they are no longer valid (e.g. the branch changed or the worktree was removed).
 
 ## Operational Assumptions
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -131,6 +131,12 @@ When panemux can derive a repository page URL from the pane's Git origin, the re
 
 The PR shortcut is rendered as an inline text link labeled `#<number>`. It does not use a pill, badge, or outlined capsule treatment. On hover, the link shifts to a slightly stronger blue and shows an underline so it reads like the rest of the header chrome instead of a separate button system.
 
+### Multiple worktrees
+
+When the pane's active agent has diverged into exactly one sibling worktree, the header shows that worktree's repo, branch, and PR shortcut inline, exactly as described above.
+
+When two or more distinct worktrees are active at once (for example, several Claude Task subagents each working in a different sibling worktree), the header does not try to fit every branch and PR shortcut inline — the compact header would not have room and would become unreadable. Instead the header shows a single inline text trigger labeled `<N> worktrees` (e.g. `2 worktrees`), styled like the other inline text links rather than as a pill or badge. Clicking the trigger opens a small popover menu anchored below the header, listing every active worktree as its own `repo ⎇ branch #<number>` line using the same inline-link treatment as the single-worktree case. The menu closes on Escape or on clicking outside it.
+
 ### Split vs quick-add
 
 The header now carries two distinct expansion actions:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.18.8",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.18.8",
+      "version": "0.20.1",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/components/PaneHeader.test.tsx
+++ b/frontend/src/components/PaneHeader.test.tsx
@@ -217,7 +217,7 @@ describe('PaneHeader VSCode button', () => {
     )
 
     expect(screen.getByText('main')).toBeInTheDocument()
-    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('group', { name: 'Active worktrees' })).toBeNull()
     expect(screen.queryByRole('button', { name: /worktree/i })).toBeNull()
   })
 
@@ -227,6 +227,11 @@ describe('PaneHeader VSCode button', () => {
         {...defaultProps}
         gitInfo={{
           is_git: true,
+          // The backend always mirrors worktrees[0] into the top-level fields.
+          repo: 'panemux',
+          branch: 'feature/worktree-a',
+          pr_number: 111,
+          pr_url: 'https://github.com/example/panemux/pull/111',
           worktrees: [
             {
               repo: 'panemux',
@@ -246,7 +251,7 @@ describe('PaneHeader VSCode button', () => {
     )
 
     expect(screen.getByRole('button', { name: '2 worktrees' })).toBeInTheDocument()
-    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('group', { name: 'Active worktrees' })).toBeNull()
     expect(screen.queryByRole('link', { name: '#111' })).toBeNull()
   })
 
@@ -256,6 +261,11 @@ describe('PaneHeader VSCode button', () => {
         {...defaultProps}
         gitInfo={{
           is_git: true,
+          // The backend always mirrors worktrees[0] into the top-level fields.
+          repo: 'panemux',
+          branch: 'feature/worktree-a',
+          pr_number: 111,
+          pr_url: 'https://github.com/example/panemux/pull/111',
           worktrees: [
             {
               repo: 'panemux',
@@ -276,7 +286,7 @@ describe('PaneHeader VSCode button', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
 
-    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Active worktrees' })).toBeInTheDocument()
     const prLinkA = screen.getByRole('link', { name: '#111' })
     const prLinkB = screen.getByRole('link', { name: '#222' })
     expect(prLinkA).toHaveAttribute('href', 'https://github.com/example/panemux/pull/111')
@@ -289,6 +299,9 @@ describe('PaneHeader VSCode button', () => {
         {...defaultProps}
         gitInfo={{
           is_git: true,
+          // The backend always mirrors worktrees[0] into the top-level fields.
+          repo: 'panemux',
+          branch: 'feature/worktree-a',
           worktrees: [
             { repo: 'panemux', branch: 'feature/worktree-a' },
             { repo: 'panemux', branch: 'feature/worktree-b' },
@@ -298,10 +311,10 @@ describe('PaneHeader VSCode button', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
-    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Active worktrees' })).toBeInTheDocument()
 
     fireEvent.keyDown(window, { key: 'Escape' })
-    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('group', { name: 'Active worktrees' })).toBeNull()
   })
 
   it('closes the worktree menu when clicking outside it', () => {
@@ -310,6 +323,9 @@ describe('PaneHeader VSCode button', () => {
         {...defaultProps}
         gitInfo={{
           is_git: true,
+          // The backend always mirrors worktrees[0] into the top-level fields.
+          repo: 'panemux',
+          branch: 'feature/worktree-a',
           worktrees: [
             { repo: 'panemux', branch: 'feature/worktree-a' },
             { repo: 'panemux', branch: 'feature/worktree-b' },
@@ -319,9 +335,9 @@ describe('PaneHeader VSCode button', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
-    expect(screen.getByRole('menu')).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: 'Active worktrees' })).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('worktree-menu-backdrop'))
-    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('group', { name: 'Active worktrees' })).toBeNull()
   })
 })

--- a/frontend/src/components/PaneHeader.test.tsx
+++ b/frontend/src/components/PaneHeader.test.tsx
@@ -202,4 +202,126 @@ describe('PaneHeader VSCode button', () => {
       textUnderlineOffset: '2px',
     })
   })
+
+  it('renders a single worktree inline even when the worktrees array has one entry', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          repo: 'panemux',
+          branch: 'main',
+          worktrees: [{ repo: 'panemux', branch: 'main' }],
+        }}
+      />
+    )
+
+    expect(screen.getByText('main')).toBeInTheDocument()
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('button', { name: /worktree/i })).toBeNull()
+  })
+
+  it('collapses two or more worktrees into a closed menu trigger', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          worktrees: [
+            {
+              repo: 'panemux',
+              branch: 'feature/worktree-a',
+              pr_number: 111,
+              pr_url: 'https://github.com/example/panemux/pull/111',
+            },
+            {
+              repo: 'panemux',
+              branch: 'feature/worktree-b',
+              pr_number: 222,
+              pr_url: 'https://github.com/example/panemux/pull/222',
+            },
+          ],
+        }}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: '2 worktrees' })).toBeInTheDocument()
+    expect(screen.queryByRole('menu')).toBeNull()
+    expect(screen.queryByRole('link', { name: '#111' })).toBeNull()
+  })
+
+  it('opens the worktree menu on trigger click and lists every worktree', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          worktrees: [
+            {
+              repo: 'panemux',
+              branch: 'feature/worktree-a',
+              pr_number: 111,
+              pr_url: 'https://github.com/example/panemux/pull/111',
+            },
+            {
+              repo: 'panemux',
+              branch: 'feature/worktree-b',
+              pr_number: 222,
+              pr_url: 'https://github.com/example/panemux/pull/222',
+            },
+          ],
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
+
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    const prLinkA = screen.getByRole('link', { name: '#111' })
+    const prLinkB = screen.getByRole('link', { name: '#222' })
+    expect(prLinkA).toHaveAttribute('href', 'https://github.com/example/panemux/pull/111')
+    expect(prLinkB).toHaveAttribute('href', 'https://github.com/example/panemux/pull/222')
+  })
+
+  it('closes the worktree menu on Escape', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          worktrees: [
+            { repo: 'panemux', branch: 'feature/worktree-a' },
+            { repo: 'panemux', branch: 'feature/worktree-b' },
+          ],
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('closes the worktree menu when clicking outside it', () => {
+    render(
+      <PaneHeader
+        {...defaultProps}
+        gitInfo={{
+          is_git: true,
+          worktrees: [
+            { repo: 'panemux', branch: 'feature/worktree-a' },
+            { repo: 'panemux', branch: 'feature/worktree-b' },
+          ],
+        }}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '2 worktrees' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('worktree-menu-backdrop'))
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
 })

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -188,7 +188,6 @@ const WorktreeMenu: React.FC<WorktreeMenuProps> = ({ worktrees }) => {
     <span style={{ position: 'relative', display: 'inline-flex' }}>
       <button
         type="button"
-        aria-haspopup="true"
         aria-expanded={open}
         onClick={() => setOpen((prev) => !prev)}
         style={{
@@ -212,7 +211,8 @@ const WorktreeMenu: React.FC<WorktreeMenuProps> = ({ worktrees }) => {
             style={{ position: 'fixed', inset: 0, zIndex: 1 }}
           />
           <div
-            role="menu"
+            role="group"
+            aria-label="Active worktrees"
             style={{
               position: 'absolute',
               top: '100%',
@@ -315,7 +315,7 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       />
       <span style={{ color, fontWeight: 600 }}>{label}</span>
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
-      {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch || (gitInfo.worktrees?.length ?? 0) > 0) && (
+      {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch) && (
         <span style={{ color: '#6e8a6e', fontSize: '11px', display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
           {gitInfo.worktrees && gitInfo.worktrees.length > 1 ? (
             <WorktreeMenu worktrees={gitInfo.worktrees} />

--- a/frontend/src/components/PaneHeader.tsx
+++ b/frontend/src/components/PaneHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { DisplayConfig, PaneConfig } from '../types'
-import { GitInfo } from '../schemas'
+import { GitInfo, WorktreeInfo } from '../schemas'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 import {
   AddPaneBottomIcon,
@@ -145,6 +145,107 @@ const InlineHeaderLink: React.FC<InlineHeaderLinkProps> = ({ href, title, label 
   )
 }
 
+interface WorktreeEntryLineProps {
+  repo?: string
+  repoUrl?: string
+  branch?: string
+  prUrl?: string
+  prNumber?: number
+}
+
+const WorktreeEntryLine: React.FC<WorktreeEntryLineProps> = ({ repo, repoUrl, branch, prUrl, prNumber }) => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+    {repo && (repoUrl ? (
+      <InlineHeaderLink href={repoUrl} title="Open repository" label={repo} />
+    ) : (
+      <span>{repo}</span>
+    ))}
+    {repo && branch && <span style={{ color: '#4a6a4a' }}>{' '}⎇{' '}</span>}
+    {branch && <span>{branch}</span>}
+    {prUrl && prNumber && (
+      <InlineHeaderLink href={prUrl} title="Open pull request" label={`#${prNumber}`} />
+    )}
+  </span>
+)
+
+interface WorktreeMenuProps {
+  worktrees: WorktreeInfo[]
+}
+
+const WorktreeMenu: React.FC<WorktreeMenuProps> = ({ worktrees }) => {
+  const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!open) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open])
+
+  return (
+    <span style={{ position: 'relative', display: 'inline-flex' }}>
+      <button
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        style={{
+          appearance: 'none',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          margin: 0,
+          font: 'inherit',
+          color: gitLinkStyle.color,
+          cursor: 'pointer',
+        }}
+      >
+        {worktrees.length} worktrees
+      </button>
+      {open && (
+        <>
+          <div
+            data-testid="worktree-menu-backdrop"
+            onClick={() => setOpen(false)}
+            style={{ position: 'fixed', inset: 0, zIndex: 1 }}
+          />
+          <div
+            role="menu"
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              marginTop: '4px',
+              backgroundColor: '#252526',
+              border: '1px solid #333',
+              borderRadius: '4px',
+              padding: '6px 10px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+              whiteSpace: 'nowrap',
+              zIndex: 2,
+            }}
+          >
+            {worktrees.map((worktree, index) => (
+              <WorktreeEntryLine
+                key={index}
+                repo={worktree.repo}
+                repoUrl={worktree.repo_url}
+                branch={worktree.branch}
+                prUrl={worktree.pr_url}
+                prNumber={worktree.pr_number}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </span>
+  )
+}
+
 export const PaneHeader: React.FC<PaneHeaderProps> = ({
   pane,
   connected,
@@ -214,24 +315,17 @@ export const PaneHeader: React.FC<PaneHeaderProps> = ({
       />
       <span style={{ color, fontWeight: 600 }}>{label}</span>
       {pane.title && <span style={{ color: '#aaa' }}>{pane.title}</span>}
-      {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch) && (
+      {gitInfo?.is_git && (gitInfo.repo || gitInfo.branch || (gitInfo.worktrees?.length ?? 0) > 0) && (
         <span style={{ color: '#6e8a6e', fontSize: '11px', display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
-          {gitInfo.repo && (gitInfo.repo_url ? (
-            <InlineHeaderLink
-              href={gitInfo.repo_url}
-              title="Open repository"
-              label={gitInfo.repo}
-            />
+          {gitInfo.worktrees && gitInfo.worktrees.length > 1 ? (
+            <WorktreeMenu worktrees={gitInfo.worktrees} />
           ) : (
-            <span>{gitInfo.repo}</span>
-          ))}
-          {gitInfo.repo && gitInfo.branch && <span style={{ color: '#4a6a4a' }}>{' '}⎇{' '}</span>}
-          {gitInfo.branch && <span>{gitInfo.branch}</span>}
-          {gitInfo.pr_url && gitInfo.pr_number && (
-            <InlineHeaderLink
-              href={gitInfo.pr_url}
-              title="Open pull request"
-              label={`#${gitInfo.pr_number}`}
+            <WorktreeEntryLine
+              repo={gitInfo.repo}
+              repoUrl={gitInfo.repo_url}
+              branch={gitInfo.branch}
+              prUrl={gitInfo.pr_url}
+              prNumber={gitInfo.pr_number}
             />
           )}
         </span>

--- a/frontend/src/schemas/index.test.ts
+++ b/frontend/src/schemas/index.test.ts
@@ -39,6 +39,46 @@ describe('GitInfoSchema', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  it('accepts git info without a worktrees array', () => {
+    const result = GitInfoSchema.safeParse({
+      is_git: true,
+      branch: 'main',
+      repo: 'panemux',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts git info with multiple worktrees', () => {
+    const result = GitInfoSchema.safeParse({
+      is_git: true,
+      branch: 'feature/worktree-a',
+      repo: 'panemux',
+      pr_number: 111,
+      pr_url: 'https://github.com/example/panemux/pull/111',
+      worktrees: [
+        {
+          branch: 'feature/worktree-a',
+          repo: 'panemux',
+          pr_number: 111,
+          pr_url: 'https://github.com/example/panemux/pull/111',
+        },
+        {
+          branch: 'feature/worktree-b',
+          repo: 'panemux',
+        },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects a worktrees entry with invalid PR metadata types', () => {
+    const result = GitInfoSchema.safeParse({
+      is_git: true,
+      worktrees: [{ branch: 'main', pr_number: '111' }],
+    })
+    expect(result.success).toBe(false)
+  })
 })
 
 describe('DisplayConfigSchema', () => {

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -113,6 +113,16 @@ export const WSControlMessageSchema = z.discriminatedUnion('type', [
 
 export type WSControlMessage = z.infer<typeof WSControlMessageSchema>
 
+export const WorktreeInfoSchema = z.object({
+  branch: z.string().optional(),
+  repo: z.string().optional(),
+  repo_url: z.string().url().optional(),
+  pr_number: z.number().int().positive().optional(),
+  pr_url: z.string().url().optional(),
+})
+
+export type WorktreeInfo = z.infer<typeof WorktreeInfoSchema>
+
 export const GitInfoSchema = z.object({
   is_git: z.boolean(),
   branch: z.string().optional(),
@@ -120,6 +130,7 @@ export const GitInfoSchema = z.object({
   repo_url: z.string().url().optional(),
   pr_number: z.number().int().positive().optional(),
   pr_url: z.string().url().optional(),
+  worktrees: z.array(WorktreeInfoSchema).optional(),
 })
 
 export type GitInfo = z.infer<typeof GitInfoSchema>

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -45,7 +45,7 @@ type Handler struct {
 	listRemoteDirectoriesFn func(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error)
 	readDirFn               func(name string) ([]os.DirEntry, error)
 	preferredCWDMu          sync.Mutex
-	preferredCWDBySession   map[string]preferredCWDState
+	preferredCWDBySession   map[string][]preferredCWDState
 	restartMu               sync.Mutex
 	restartInFlight         map[string]struct{}
 }
@@ -54,6 +54,14 @@ type preferredCWDState struct {
 	CWD       string
 	CommonDir string
 	Root      string
+}
+
+// activeGitContext pairs a resolved git context with the working directory
+// (pane base cwd, or an agent-signaled sibling worktree path) it was
+// inspected from.
+type activeGitContext struct {
+	CWD string
+	Ctx session.GitContext
 }
 
 var gitExistsFn = func() error {
@@ -127,7 +135,7 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 		cfg:                   cfg,
 		manager:               manager,
 		sshConfigPath:         sshconfig.DefaultPath(),
-		preferredCWDBySession: make(map[string]preferredCWDState),
+		preferredCWDBySession: make(map[string][]preferredCWDState),
 		restartInFlight:       make(map[string]struct{}),
 	}
 	h.createSession = session.CreateFromConfig
@@ -265,7 +273,7 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, pane := range panesInLayout(workspace.Layout) {
 		_ = h.manager.Remove(pane.ID)
-		h.clearPreferredCWD(pane.ID)
+		h.clearPreferredCWDs(pane.ID)
 	}
 	writeJSON(w, h.cfg.WorkspacesView())
 }
@@ -401,7 +409,7 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	h.clearPreferredCWD(id)
+	h.clearPreferredCWDs(id)
 	h.cfg.RemovePaneFromLayout(id)
 	if err := h.cfg.SaveLayout(h.cfg.Layout); err != nil {
 		http.Error(w, "failed to save layout", http.StatusInternalServerError)
@@ -449,7 +457,7 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.manager.Remove(id) //nolint:errcheck // ok if already gone
-	h.clearPreferredCWD(id)
+	h.clearPreferredCWDs(id)
 	h.manager.Add(sess)
 	w.WriteHeader(http.StatusOK)
 }
@@ -601,7 +609,7 @@ func (h *Handler) PostOpenVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cwd, _ = h.resolveValidatedPreferredCWD(sess, cwd)
+	cwd = h.resolveSinglePreferredCWD(sess, cwd)
 
 	if !h.validateVSCodeCWD(w, sess, cwd) {
 		return
@@ -763,13 +771,22 @@ func (h *Handler) GetDirectories(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp)
 }
 
-type gitInfoResponse struct {
+type worktreeInfo struct {
 	Branch   string `json:"branch,omitempty"`
-	PRURL    string `json:"pr_url,omitempty"`
 	Repo     string `json:"repo,omitempty"`
 	RepoURL  string `json:"repo_url,omitempty"`
+	PRURL    string `json:"pr_url,omitempty"`
 	PRNumber int    `json:"pr_number,omitempty"`
-	IsGit    bool   `json:"is_git"`
+}
+
+type gitInfoResponse struct {
+	Branch    string         `json:"branch,omitempty"`
+	PRURL     string         `json:"pr_url,omitempty"`
+	Repo      string         `json:"repo,omitempty"`
+	RepoURL   string         `json:"repo_url,omitempty"`
+	Worktrees []worktreeInfo `json:"worktrees,omitempty"`
+	PRNumber  int            `json:"pr_number,omitempty"`
+	IsGit     bool           `json:"is_git"`
 }
 
 // GetGitInfo returns git repository information for the session's current working directory.
@@ -799,120 +816,157 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	targetCWD, ctx := h.resolveValidatedPreferredCWD(sess, cwd)
-	if ctx == nil {
+	activeContexts, err := h.resolveActiveGitContexts(sess, cwd)
+	if err != nil {
 		writeJSON(w, gitInfoResponse{IsGit: false})
 		return
 	}
-	prURL, prNumber := h.lookupPRInfo(sess, targetCWD, *ctx)
+
+	worktrees := h.lookupPRInfoForContexts(sess, activeContexts)
+	primary := worktrees[0]
 
 	writeJSON(w, gitInfoResponse{
-		IsGit:    true,
-		Branch:   ctx.Branch,
-		Repo:     ctx.Repo,
-		RepoURL:  h.repoPageURLFromOriginURL(ctx.OriginURL),
-		PRURL:    prURL,
-		PRNumber: prNumber,
+		IsGit:     true,
+		Branch:    primary.Branch,
+		Repo:      primary.Repo,
+		RepoURL:   primary.RepoURL,
+		PRURL:     primary.PRURL,
+		PRNumber:  primary.PRNumber,
+		Worktrees: worktrees,
 	})
 }
 
-func (h *Handler) resolvePreferredCWD(sess session.Session, cwd string) string {
+// lookupPRInfoForContexts runs an independent PR lookup for each active git
+// context concurrently, since each worktree's `gh pr view` call is
+// independent network I/O with its own timeout.
+func (h *Handler) lookupPRInfoForContexts(sess session.Session, contexts []activeGitContext) []worktreeInfo {
+	results := make([]worktreeInfo, len(contexts))
+	var wg sync.WaitGroup
+	for i, active := range contexts {
+		wg.Add(1)
+		go func(i int, active activeGitContext) {
+			defer wg.Done()
+			prURL, prNumber := h.lookupPRInfo(sess, active.CWD, active.Ctx)
+			results[i] = worktreeInfo{
+				Branch:   active.Ctx.Branch,
+				Repo:     active.Ctx.Repo,
+				RepoURL:  h.repoPageURLFromOriginURL(active.Ctx.OriginURL),
+				PRURL:    prURL,
+				PRNumber: prNumber,
+			}
+		}(i, active)
+	}
+	wg.Wait()
+	return results
+}
+
+// resolveActiveGitContexts returns the git context(s) the pane header should
+// show. When the session's active agent has diverged into one or more
+// sibling worktrees (same repository, different Root) — e.g. a Claude Task
+// subagent that did work in another worktree while the top-level session
+// stayed put — those diverged worktrees are returned instead of the pane's
+// own base context, exactly as a single diverged worktree has always taken
+// priority over the base directory. The base context is returned only when
+// nothing has diverged from it. Falls back to a per-session "sticky" set
+// remembered from the previous successful resolution when the active-workdir
+// lookup transiently fails or returns nothing, so a single flaky poll does
+// not make the pane header drop worktrees it was already showing.
+func (h *Handler) resolveActiveGitContexts(sess session.Session, cwd string) ([]activeGitContext, error) {
 	logScope := h.gitInfoLogScope(sess)
 
 	baseCtx, err := h.inspectGitContextForSession(sess, cwd)
 	if err != nil {
 		log.Printf("%s", formatGitContextLookupError(logScope, "base context lookup", err))
-		return cwd
+		return nil, err
 	}
 
 	activeGetter, ok := sess.(session.ActiveWorkdirGetter)
 	if !ok {
-		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
+		h.clearPreferredCWDs(sess.ID())
+		return []activeGitContext{{CWD: cwd, Ctx: baseCtx}}, nil
 	}
 
-	candidate, err := activeGetter.GetActiveWorkdir()
-	if err != nil || candidate == "" {
-		if err != nil {
-			log.Printf("%s active workdir lookup failed: %v", logScope, err)
-		}
-		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
-	}
-
-	ctx, err := h.inspectGitContextForSession(sess, candidate)
+	candidates, err := activeGetter.GetActiveWorkdirs()
 	if err != nil {
-		log.Printf("%s", formatGitContextLookupError(logScope, "active workdir candidate context lookup", err))
-		return h.recallPreferredCWD(sess.ID(), cwd, baseCtx)
+		log.Printf("%s active workdirs lookup failed: %v", logScope, err)
 	}
-	if ctx.CommonDir == baseCtx.CommonDir && ctx.Root != baseCtx.Root {
-		h.rememberPreferredCWD(sess.ID(), candidate, ctx)
+	if err != nil || len(candidates) == 0 {
+		candidates = h.recallPreferredCWDs(sess.ID(), baseCtx)
+	}
+
+	seenRoots := map[string]bool{baseCtx.Root: true}
+	var diverged []activeGitContext
+	var accepted []preferredCWDState
+	for _, candidate := range candidates {
+		ctx, err := h.inspectGitContextForSession(sess, candidate)
+		if err != nil {
+			log.Printf("%s", formatGitContextLookupError(logScope, "active workdir candidate context lookup", err))
+			continue
+		}
+		if ctx.CommonDir != baseCtx.CommonDir || ctx.Root == baseCtx.Root || seenRoots[ctx.Root] {
+			continue
+		}
+		seenRoots[ctx.Root] = true
+		diverged = append(diverged, activeGitContext{CWD: candidate, Ctx: ctx})
+		accepted = append(accepted, preferredCWDState{CWD: candidate, CommonDir: ctx.CommonDir, Root: ctx.Root})
 		log.Printf(
 			"%s selected active workdir branch transition %q -> %q",
 			logScope,
 			baseCtx.Branch,
 			ctx.Branch,
 		)
-		return candidate
 	}
 
-	h.clearPreferredCWD(sess.ID())
-	log.Printf(
-		"%s ignored active workdir candidate (same_root=%t same_common_dir=%t)",
-		logScope,
-		ctx.Root == baseCtx.Root,
-		ctx.CommonDir == baseCtx.CommonDir,
-	)
-
-	return cwd
+	if len(accepted) == 0 {
+		h.clearPreferredCWDs(sess.ID())
+		return []activeGitContext{{CWD: cwd, Ctx: baseCtx}}, nil
+	}
+	h.rememberPreferredCWDs(sess.ID(), accepted)
+	return diverged, nil
 }
 
-func (h *Handler) resolveValidatedPreferredCWD(sess session.Session, cwd string) (string, *session.GitContext) {
-	targetCWD := h.resolvePreferredCWD(sess, cwd)
-	if targetCWD == cwd {
-		ctx, err := h.inspectGitContextForSession(sess, cwd)
-		if err != nil {
-			return cwd, nil
-		}
-		return cwd, &ctx
+// resolveSinglePreferredCWD returns the one working directory most relevant
+// for an action that can only target a single location (e.g. opening an
+// editor): the first sibling worktree path signaled by the active agent, or
+// the pane's own cwd when none diverges.
+func (h *Handler) resolveSinglePreferredCWD(sess session.Session, cwd string) string {
+	results, err := h.resolveActiveGitContexts(sess, cwd)
+	if err != nil || len(results) == 0 {
+		return cwd
 	}
-	ctx, err := h.inspectGitContextForSession(sess, targetCWD)
-	if err == nil {
-		return targetCWD, &ctx
-	}
-	h.clearPreferredCWD(sess.ID())
-	ctx, err = h.inspectGitContextForSession(sess, cwd)
-	if err != nil {
-		return cwd, nil
-	}
-	return cwd, &ctx
+	return results[0].CWD
 }
 
-func (h *Handler) rememberPreferredCWD(sessionID, cwd string, ctx session.GitContext) {
+func (h *Handler) rememberPreferredCWDs(sessionID string, states []preferredCWDState) {
 	h.preferredCWDMu.Lock()
 	defer h.preferredCWDMu.Unlock()
 
-	h.preferredCWDBySession[sessionID] = preferredCWDState{
-		CWD:       cwd,
-		CommonDir: ctx.CommonDir,
-		Root:      ctx.Root,
-	}
+	h.preferredCWDBySession[sessionID] = states
 }
 
-func (h *Handler) recallPreferredCWD(sessionID, cwd string, baseCtx session.GitContext) string {
+func (h *Handler) recallPreferredCWDs(sessionID string, baseCtx session.GitContext) []string {
 	h.preferredCWDMu.Lock()
 	defer h.preferredCWDMu.Unlock()
 
-	state, ok := h.preferredCWDBySession[sessionID]
+	states, ok := h.preferredCWDBySession[sessionID]
 	if !ok {
-		return cwd
+		return nil
 	}
-	if state.CommonDir != baseCtx.CommonDir || state.Root == baseCtx.Root || state.CWD == "" {
+
+	var cwds []string
+	for _, state := range states {
+		if state.CommonDir != baseCtx.CommonDir || state.Root == baseCtx.Root || state.CWD == "" {
+			continue
+		}
+		cwds = append(cwds, state.CWD)
+	}
+	if len(cwds) == 0 {
 		delete(h.preferredCWDBySession, sessionID)
-		return cwd
 	}
-	return state.CWD
+	return cwds
 }
 
-func (h *Handler) clearPreferredCWD(sessionID string) {
+func (h *Handler) clearPreferredCWDs(sessionID string) {
 	h.preferredCWDMu.Lock()
 	defer h.preferredCWDMu.Unlock()
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -29,11 +29,11 @@ import (
 //nolint:govet // test helper layout is not performance-sensitive
 type mockSession struct {
 	buf     chan []byte
-	bufOnce sync.Once
 	id      string
 	typ     session.Type
 	title   string
 	state   session.State
+	bufOnce sync.Once
 	closed  bool
 }
 
@@ -514,11 +514,11 @@ func TestDeleteWorkspace_ClearsPreferredCWDForRemovedPanes(t *testing.T) {
 	mgr.Add(newMockSession("two-main"))
 	h := NewHandler(cfg, mgr)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
-	h.preferredCWDBySession["two-main"] = preferredCWDState{
+	h.preferredCWDBySession["two-main"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
 		CommonDir: "/repo/.git",
 		Root:      "/tmp/worktree",
-	}
+	}}
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -877,11 +877,11 @@ func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
 	mgr.Add(newMockSession("main"))
 	h := NewHandler(cfg, mgr)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
-	h.preferredCWDBySession["main"] = preferredCWDState{
+	h.preferredCWDBySession["main"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
 		CommonDir: "/repo/.git",
 		Root:      "/tmp/worktree",
-	}
+	}}
 	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
 		return newMockSession(pane.ID), nil
 	}
@@ -950,11 +950,11 @@ func TestRestartSession_CreateFails_PreservesPreferredCWD(t *testing.T) {
 	mgr.Add(newMockSession("main"))
 	h := NewHandler(cfg, mgr)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
-	h.preferredCWDBySession["main"] = preferredCWDState{
+	h.preferredCWDBySession["main"] = []preferredCWDState{{
 		CWD:       "/remote/home/demo",
 		CommonDir: "/remote/home/demo/.git",
 		Root:      "/remote/home/demo",
-	}
+	}}
 	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
 		return nil, errors.New("dial failed")
 	}
@@ -1146,11 +1146,11 @@ func TestDeleteSession_ClearsPreferredCWD(t *testing.T) {
 	mgr.Add(newMockSession("s1"))
 	cfg := defaultTestConfig()
 	h := NewHandler(cfg, mgr)
-	h.preferredCWDBySession["s1"] = preferredCWDState{
+	h.preferredCWDBySession["s1"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
 		CommonDir: "/repo/.git",
 		Root:      "/tmp/worktree",
-	}
+	}}
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -1504,25 +1504,25 @@ func TestPostSSHConfigHost_InvalidBody_400(t *testing.T) {
 //
 //nolint:govet // test helper layout is not performance-sensitive
 type mockCWDSession struct {
+	activeErr error
+	cwdErr    error
+	cwd       string
 	mockSession
-	activeWorkdir string
-	activeErr     error
-	cwd           string
-	cwdErr        error
+	activeWorkdirs []string
 }
 
 func (m *mockCWDSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
-func (m *mockCWDSession) GetActiveWorkdir() (string, error) {
-	return m.activeWorkdir, m.activeErr
+func (m *mockCWDSession) GetActiveWorkdirs() ([]string, error) {
+	return m.activeWorkdirs, m.activeErr
 }
 
 // mockSSHCWDSession is a mockSession that implements both CWDGetter and SSHConnNamer.
 //
 //nolint:govet // test helper layout is not performance-sensitive
 type mockSSHCWDSession struct {
-	mockSession
 	connName string
 	cwd      string
+	mockSession
 }
 
 func (m *mockSSHCWDSession) GetCWD() (string, error) { return m.cwd, nil }
@@ -1533,18 +1533,18 @@ func (m *mockSSHCWDSession) ConnectionName() string  { return m.connName }
 //
 //nolint:govet // test helper layout is not performance-sensitive
 type mockRemoteGitSession struct {
+	activeErr   error
+	cwdErr      error
+	gitContexts map[string]session.GitContext
+	gitErrs     map[string]error
+	cwd         string
 	mockSession
-	activeWorkdir string
-	activeErr     error
-	cwd           string
-	cwdErr        error
-	gitContexts   map[string]session.GitContext
-	gitErrs       map[string]error
+	activeWorkdirs []string
 }
 
 func (m *mockRemoteGitSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
-func (m *mockRemoteGitSession) GetActiveWorkdir() (string, error) {
-	return m.activeWorkdir, m.activeErr
+func (m *mockRemoteGitSession) GetActiveWorkdirs() ([]string, error) {
+	return m.activeWorkdirs, m.activeErr
 }
 func (m *mockRemoteGitSession) InspectGitContext(cwd string) (session.GitContext, error) {
 	if err, ok := m.gitErrs[cwd]; ok {
@@ -1609,9 +1609,9 @@ func TestPostOpenVSCode_ActiveAgentWorkdir_PrefersWorktree(t *testing.T) {
 	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
 
 	resp := postOpenVSCodeOK(t, "local-worktree", &mockCWDSession{
-		mockSession:   mockSession{id: "local-worktree", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-worktree", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	})
 
 	assert.Equal(t, worktreeDir, resp.Cwd)
@@ -1622,9 +1622,9 @@ func TestPostOpenVSCode_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 	_ = addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
 
 	resp := postOpenVSCodeOK(t, "local-fallback", &mockCWDSession{
-		mockSession:   mockSession{id: "local-fallback", typ: session.TypeLocal},
-		activeWorkdir: "",
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-fallback", typ: session.TypeLocal},
+		activeWorkdirs: nil,
+		cwd:            repoDir,
 	})
 
 	assert.Equal(t, repoDir, resp.Cwd)
@@ -1635,9 +1635,9 @@ func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
 	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
 
 	sess := &mockCWDSession{
-		mockSession:   mockSession{id: "local-sticky", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-sticky", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	}
 
 	mgr := session.NewManager()
@@ -1649,7 +1649,7 @@ func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
 	resp := postOpenVSCodeOKWithRouter(t, r, "local-sticky")
 	assert.Equal(t, worktreeDir, resp.Cwd)
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 
 	resp = postOpenVSCodeOKWithRouter(t, r, "local-sticky")
 	assert.Equal(t, worktreeDir, resp.Cwd)
@@ -1660,9 +1660,9 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	worktreeDir := addTempGitWorktree(t, repoDir, "feature/open-in-worktree")
 
 	sess := &mockCWDSession{
-		mockSession:   mockSession{id: "local-open-stale", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-open-stale", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	}
 
 	mgr := session.NewManager()
@@ -1674,7 +1674,7 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	resp := postOpenVSCodeOKWithRouter(t, r, "local-open-stale")
 	assert.Equal(t, worktreeDir, resp.Cwd)
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 	out, err := exec.Command( //nolint:gosec // trusted test args
 		"git",
 		"-C",
@@ -1692,11 +1692,11 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestResolveValidatedPreferredCWD_ReusesInspectedContext(t *testing.T) {
+func TestResolveActiveGitContexts_ReusesInspectedContext(t *testing.T) {
 	sess := &mockRemoteGitSession{
-		mockSession:   mockSession{id: "pane-ctx", typ: session.TypeSSH},
-		activeWorkdir: "/repo/base-worktree",
-		cwd:           "/repo/base",
+		mockSession:    mockSession{id: "pane-ctx", typ: session.TypeSSH},
+		activeWorkdirs: []string{"/repo/base-worktree"},
+		cwd:            "/repo/base",
 		gitContexts: map[string]session.GitContext{
 			"/repo/base": {
 				Branch:    "main",
@@ -1714,10 +1714,11 @@ func TestResolveValidatedPreferredCWD_ReusesInspectedContext(t *testing.T) {
 	}
 
 	h := NewHandler(defaultTestConfig(), session.NewManager())
-	cwd, ctx := h.resolveValidatedPreferredCWD(sess, sess.cwd)
-	require.NotNil(t, ctx)
-	assert.Equal(t, "/repo/base-worktree", cwd)
-	assert.Equal(t, "feature/worktree", ctx.Branch)
+	contexts, err := h.resolveActiveGitContexts(sess, sess.cwd)
+	require.NoError(t, err)
+	require.Len(t, contexts, 1)
+	assert.Equal(t, "/repo/base-worktree", contexts[0].CWD)
+	assert.Equal(t, "feature/worktree", contexts[0].Ctx.Branch)
 }
 
 func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeResponse {
@@ -2168,9 +2169,9 @@ func TestGetGitInfo_ActiveAgentWorkdir_PrefersWorktreeBranch(t *testing.T) {
 
 	mgr := session.NewManager()
 	mgr.Add(&mockCWDSession{
-		mockSession:   mockSession{id: "local-worktree", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-worktree", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr)
@@ -2193,15 +2194,134 @@ func TestGetGitInfo_ActiveAgentWorkdir_PrefersWorktreeBranch(t *testing.T) {
 	assert.Equal(t, 456, resp.PRNumber)
 }
 
+func TestGetGitInfo_MultipleActiveWorktrees_ReturnsAllWorktreesWithPRs(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeA := addTempGitWorktree(t, repoDir, "feature/worktree-a")
+	worktreeB := addTempGitWorktree(t, repoDir, "feature/worktree-b")
+
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession:    mockSession{id: "local-multi", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeA, worktreeB},
+		cwd:            repoDir,
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.ghBinaryPath = writeFakeGHBinary(t, ""+
+		"#!/bin/sh\n"+
+		"case \"$3\" in\n"+
+		"feature/worktree-a) echo '{\"url\":\"https://github.com/example/panemux/pull/111\",\"number\":111}' ;;\n"+
+		"feature/worktree-b) echo '{\"url\":\"https://github.com/example/panemux/pull/222\",\"number\":222}' ;;\n"+
+		"*) exit 1 ;;\n"+
+		"esac\n",
+	)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-multi/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	require.Len(t, resp.Worktrees, 2)
+
+	byBranch := map[string]worktreeInfo{}
+	for _, wt := range resp.Worktrees {
+		byBranch[wt.Branch] = wt
+	}
+	require.Contains(t, byBranch, "feature/worktree-a")
+	require.Contains(t, byBranch, "feature/worktree-b")
+	assert.Equal(t, 111, byBranch["feature/worktree-a"].PRNumber)
+	assert.Equal(t, 222, byBranch["feature/worktree-b"].PRNumber)
+
+	// The top-level fields stay populated with the first worktree for
+	// consumers that only read the single-worktree shape (e.g. WorkspaceTabs).
+	assert.Equal(t, resp.Worktrees[0].Branch, resp.Branch)
+	assert.Equal(t, resp.Worktrees[0].PRNumber, resp.PRNumber)
+}
+
+func TestGetGitInfo_MultipleActiveWorktrees_DuplicateRootDeduped(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeA := addTempGitWorktree(t, repoDir, "feature/worktree-a")
+
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession: mockSession{id: "local-dup", typ: session.TypeLocal},
+		// Two subagents both reported the same worktree path; it must not be
+		// double-counted.
+		activeWorkdirs: []string{worktreeA, worktreeA},
+		cwd:            repoDir,
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.ghBinaryPath = writeFakeGHBinary(
+		t,
+		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/111\",\"number\":111}'\n",
+	)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-dup/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Worktrees, 1)
+	assert.Equal(t, "feature/worktree-a", resp.Worktrees[0].Branch)
+}
+
+func TestGetGitInfo_MultipleActiveWorktrees_OnePRLookupFails_OthersStillReturned(t *testing.T) {
+	repoDir := initTempGitRepo(t)
+	worktreeA := addTempGitWorktree(t, repoDir, "feature/worktree-a")
+	worktreeB := addTempGitWorktree(t, repoDir, "feature/worktree-b")
+
+	mgr := session.NewManager()
+	mgr.Add(&mockCWDSession{
+		mockSession:    mockSession{id: "local-partial", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeA, worktreeB},
+		cwd:            repoDir,
+	})
+
+	h := NewHandler(defaultTestConfig(), mgr)
+	h.ghBinaryPath = writeFakeGHBinary(t, ""+
+		"#!/bin/sh\n"+
+		"case \"$3\" in\n"+
+		"feature/worktree-a) echo '{\"url\":\"https://github.com/example/panemux/pull/111\",\"number\":111}' ;;\n"+
+		"*) exit 1 ;;\n"+
+		"esac\n",
+	)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-partial/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Worktrees, 2)
+
+	byBranch := map[string]worktreeInfo{}
+	for _, wt := range resp.Worktrees {
+		byBranch[wt.Branch] = wt
+	}
+	assert.Equal(t, 111, byBranch["feature/worktree-a"].PRNumber)
+	assert.Empty(t, byBranch["feature/worktree-b"].PRURL)
+	assert.Zero(t, byBranch["feature/worktree-b"].PRNumber)
+}
+
 func TestGetGitInfo_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 	repoDir := initTempGitRepo(t)
 	_ = addTempGitWorktree(t, repoDir, "feature/worktree-pr")
 
 	mgr := session.NewManager()
 	mgr.Add(&mockCWDSession{
-		mockSession:   mockSession{id: "local-fallback", typ: session.TypeLocal},
-		activeWorkdir: "",
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-fallback", typ: session.TypeLocal},
+		activeWorkdirs: nil,
+		cwd:            repoDir,
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr)
@@ -2227,9 +2347,9 @@ func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
 	worktreeDir := addTempGitWorktree(t, repoDir, "feature/worktree-pr")
 
 	sess := &mockCWDSession{
-		mockSession:   mockSession{id: "local-sticky", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-sticky", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	}
 	mgr := session.NewManager()
 	mgr.Add(sess)
@@ -2247,7 +2367,7 @@ func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-sticky/git-info", nil)
@@ -2267,9 +2387,9 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	worktreeDir := addTempGitWorktree(t, repoDir, "feature/worktree-pr")
 
 	sess := &mockCWDSession{
-		mockSession:   mockSession{id: "local-stale", typ: session.TypeLocal},
-		activeWorkdir: worktreeDir,
-		cwd:           repoDir,
+		mockSession:    mockSession{id: "local-stale", typ: session.TypeLocal},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            repoDir,
 	}
 	mgr := session.NewManager()
 	mgr.Add(sess)
@@ -2282,7 +2402,7 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 	out, err := exec.Command( //nolint:gosec // trusted test args
 		"git",
 		"-C",
@@ -2307,15 +2427,15 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestResolvePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) {
+func TestResolveSinglePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) {
 	baseRepo := "/repo/base"
 	worktreeDir := "/repo/base-worktree"
 	otherRepo := "/repo/other"
 
 	sess := &mockRemoteGitSession{
-		mockSession:   mockSession{id: "remote-sticky", typ: session.TypeSSH},
-		activeWorkdir: worktreeDir,
-		cwd:           baseRepo,
+		mockSession:    mockSession{id: "remote-sticky", typ: session.TypeSSH},
+		activeWorkdirs: []string{worktreeDir},
+		cwd:            baseRepo,
 		gitContexts: map[string]session.GitContext{
 			baseRepo: {
 				Branch:    "main",
@@ -2339,19 +2459,19 @@ func TestResolvePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testing.T) 
 	}
 
 	h := NewHandler(defaultTestConfig(), session.NewManager())
-	assert.Equal(t, worktreeDir, h.resolvePreferredCWD(sess, sess.cwd))
+	assert.Equal(t, worktreeDir, h.resolveSinglePreferredCWD(sess, sess.cwd))
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 	sess.cwd = otherRepo
 
-	assert.Equal(t, otherRepo, h.resolvePreferredCWD(sess, sess.cwd))
+	assert.Equal(t, otherRepo, h.resolveSinglePreferredCWD(sess, sess.cwd))
 }
 
-func TestResolvePreferredCWD_LogsPaneIdentity(t *testing.T) {
+func TestResolveSinglePreferredCWD_LogsPaneIdentity(t *testing.T) {
 	sess := &mockRemoteGitSession{
-		mockSession:   mockSession{id: "pane-123", typ: session.TypeSSHTmux},
-		activeWorkdir: "/repo/base-worktree",
-		cwd:           "/repo/base",
+		mockSession:    mockSession{id: "pane-123", typ: session.TypeSSHTmux},
+		activeWorkdirs: []string{"/repo/base-worktree"},
+		cwd:            "/repo/base",
 		gitContexts: map[string]session.GitContext{
 			"/repo/base": {
 				Branch:    "main",
@@ -2379,7 +2499,7 @@ func TestResolvePreferredCWD_LogsPaneIdentity(t *testing.T) {
 	})
 
 	h := NewHandler(defaultTestConfig(), session.NewManager())
-	assert.Equal(t, "/repo/base-worktree", h.resolvePreferredCWD(sess, sess.cwd))
+	assert.Equal(t, "/repo/base-worktree", h.resolveSinglePreferredCWD(sess, sess.cwd))
 	assert.Contains(t, buf.String(), `git info pane="pane-123" type="ssh_tmux" selected active workdir`)
 }
 
@@ -2390,9 +2510,9 @@ func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {
 	)
 
 	sess := &mockRemoteGitSession{
-		mockSession:   mockSession{id: "ssh-sticky", typ: session.TypeSSH},
-		activeWorkdir: worktreeRepo,
-		cwd:           baseRepo,
+		mockSession:    mockSession{id: "ssh-sticky", typ: session.TypeSSH},
+		activeWorkdirs: []string{worktreeRepo},
+		cwd:            baseRepo,
 		gitContexts: map[string]session.GitContext{
 			baseRepo: {
 				Branch:    "main",
@@ -2425,7 +2545,7 @@ func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	sess.activeWorkdir = ""
+	sess.activeWorkdirs = nil
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-sticky/git-info", nil)
@@ -2548,9 +2668,9 @@ func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T
 
 	mgr := session.NewManager()
 	mgr.Add(&mockRemoteGitSession{
-		mockSession:   mockSession{id: "ssh-worktree", typ: session.TypeSSHTmux},
-		cwd:           remoteRepo,
-		activeWorkdir: remoteWorktree,
+		mockSession:    mockSession{id: "ssh-worktree", typ: session.TypeSSHTmux},
+		cwd:            remoteRepo,
+		activeWorkdirs: []string{remoteWorktree},
 		gitContexts: map[string]session.GitContext{
 			remoteRepo: {
 				Branch:    "main",

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -139,29 +139,31 @@ func (s *LocalSession) GetCWD() (string, error) {
 	return getPIDCWD(s.pid)
 }
 
-// GetActiveWorkdir returns the working directory of the newest active Codex or
-// Claude descendant process, or an empty string when none is running.
-func (s *LocalSession) GetActiveWorkdir() (string, error) {
+// GetActiveWorkdirs returns every distinct working directory currently in
+// play for the newest active Codex or Claude descendant process, including
+// worktrees only visited by a delegated Claude Task subagent. Returns an
+// empty slice if no such process exists.
+func (s *LocalSession) GetActiveWorkdirs() ([]string, error) {
 	if s.pid == 0 {
-		return "", errors.New("session has no PID")
+		return nil, errors.New("session has no PID")
 	}
 
 	processes, err := listProcessesFn()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	baseCWD, err := getPIDCWDFn(s.pid)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	pid, ok := newestInteractiveAgentDescendantPID(processes, s.pid)
 	if !ok {
-		return "", nil
+		return nil, nil
 	}
 
-	return resolveInteractiveAgentWorkdir(processes, pid, baseCWD)
+	return resolveInteractiveAgentWorkdirs(processes, pid, baseCWD)
 }
 
 func getPIDCWD(pid int) (string, error) {
@@ -304,11 +306,23 @@ func descendantPIDs(processes []processInfo, rootPID int) []int {
 	return ids
 }
 
-func resolveInteractiveAgentWorkdir(processes []processInfo, agentPID int, baseCWD string) (string, error) {
-	if sessionCWD, err := interactiveAgentSessionCWD(processes, agentPID); err == nil && sessionCWD != "" {
-		return sessionCWD, nil
+// resolveInteractiveAgentWorkdirs returns every distinct workdir signaled by
+// the interactive agent's own session data (e.g. a Claude session's parent
+// transcript plus any Task subagent transcripts), falling back to the single
+// descendant-process cwd scan when no session-derived candidates are found.
+func resolveInteractiveAgentWorkdirs(processes []processInfo, agentPID int, baseCWD string) ([]string, error) {
+	if cwds, err := interactiveAgentSessionCWDs(processes, agentPID); err == nil && len(cwds) > 0 {
+		return cwds, nil
 	}
 
+	cwd, err := descendantCWDFallback(processes, agentPID, baseCWD)
+	if err != nil || cwd == "" {
+		return nil, err
+	}
+	return []string{cwd}, nil
+}
+
+func descendantCWDFallback(processes []processInfo, agentPID int, baseCWD string) (string, error) {
 	candidatePIDs := descendantPIDs(processes, agentPID)
 	sort.Slice(candidatePIDs, func(i, j int) bool {
 		return candidatePIDs[i] > candidatePIDs[j]
@@ -335,18 +349,22 @@ func resolveInteractiveAgentWorkdir(processes []processInfo, agentPID int, baseC
 	return "", nil
 }
 
-func interactiveAgentSessionCWD(processes []processInfo, agentPID int) (string, error) {
+func interactiveAgentSessionCWDs(processes []processInfo, agentPID int) ([]string, error) {
 	proc, ok := processByPID(processes, agentPID)
 	if !ok {
-		return "", nil
+		return nil, nil
 	}
 	switch {
 	case isCodexCommand(proc.Command):
-		return codexSessionCWD(processes, agentPID)
+		cwd, err := codexSessionCWD(processes, agentPID)
+		if err != nil || cwd == "" {
+			return nil, err
+		}
+		return []string{cwd}, nil
 	case isClaudeCommand(proc.Command):
-		return claudeSessionCWD(agentPID)
+		return claudeSessionCWDs(agentPID)
 	default:
-		return "", nil
+		return nil, nil
 	}
 }
 
@@ -375,21 +393,29 @@ type claudeSessionMeta struct {
 	PID       int    `json:"pid"`
 }
 
-func claudeSessionCWD(agentPID int) (string, error) {
+// claudeSessionCWDs returns every distinct workdir found across the Claude
+// session's own transcript and any Task subagent transcripts recorded
+// alongside it. Claude Code records delegated subagent activity in separate
+// per-agent transcript files under a "subagents" directory next to the
+// parent transcript; a subagent that does worktree-relative work there
+// never touches the parent transcript's own recorded cwd, so panemux must
+// read those files too or the pane header silently falls back to the base
+// working directory (see docs/behavior.md "Pane Git and PR metadata").
+func claudeSessionCWDs(agentPID int) ([]string, error) {
 	homeDir, err := userHomeDirFn()
 	if err != nil {
-		return "", fmt.Errorf("resolve home dir for claude session: %w", err)
+		return nil, fmt.Errorf("resolve home dir for claude session: %w", err)
 	}
 
 	sessionMeta, err := findClaudeSessionMeta(homeDir, agentPID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
-		return "", nil
+		return nil, nil
 	}
 	if !validClaudeSessionID.MatchString(sessionMeta.SessionID) {
-		return "", nil
+		return nil, nil
 	}
 
 	projectPath := filepath.Join(
@@ -399,7 +425,47 @@ func claudeSessionCWD(agentPID int) (string, error) {
 		claudeProjectDirName(sessionMeta.CWD),
 		sessionMeta.SessionID+".jsonl",
 	)
-	return readClaudeProjectCWD(projectPath)
+
+	cwds := make([]string, 0, 1)
+	seen := make(map[string]bool)
+	for _, path := range claudeTranscriptPaths(projectPath) {
+		cwd, err := readClaudeProjectCWD(path)
+		if err != nil || cwd == "" || seen[cwd] {
+			continue
+		}
+		seen[cwd] = true
+		cwds = append(cwds, cwd)
+	}
+	return cwds, nil
+}
+
+// claudeTranscriptPaths returns the parent transcript path followed by every
+// sibling Task subagent transcript path, sorted by filename for a
+// deterministic order. Older sessions without a "subagents" directory yield
+// just the parent path.
+func claudeTranscriptPaths(projectPath string) []string {
+	paths := []string{projectPath}
+
+	sessionDir := strings.TrimSuffix(projectPath, ".jsonl")
+	subagentsDir := filepath.Join(sessionDir, "subagents")
+	entries, err := os.ReadDir(subagentsDir)
+	if err != nil {
+		return paths
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		paths = append(paths, filepath.Join(subagentsDir, name))
+	}
+	return paths
 }
 
 func findClaudeSessionMeta(homeDir string, agentPID int) (*claudeSessionMeta, error) {

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -518,9 +518,9 @@ func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
 		return "", errors.New("should not be called")
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Empty(t, cwd)
+	assert.Empty(t, cwds)
 }
 
 func TestGetActiveWorkdir_ReturnsAgentDescendantCWD(t *testing.T) {
@@ -551,9 +551,9 @@ func TestGetActiveWorkdir_ReturnsAgentDescendantCWD(t *testing.T) {
 		return nil, nil
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/panemux-pane-pr-link", cwd)
+	assert.Equal(t, []string{"/tmp/panemux-pane-pr-link"}, cwds)
 }
 
 func TestGetActiveWorkdir_PrefersInteractiveAgentDescendantWorkdir(t *testing.T) {
@@ -591,9 +591,9 @@ func TestGetActiveWorkdir_PrefersInteractiveAgentDescendantWorkdir(t *testing.T)
 		return nil, nil
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/panemux-pane-pr-link", cwd)
+	assert.Equal(t, []string{"/tmp/panemux-pane-pr-link"}, cwds)
 }
 
 func TestGetActiveWorkdir_PrefersCodexSessionCWD(t *testing.T) {
@@ -636,9 +636,9 @@ func TestGetActiveWorkdir_PrefersCodexSessionCWD(t *testing.T) {
 		return []string{sessionLog}, nil
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/worktree-from-session", cwd)
+	assert.Equal(t, []string{"/tmp/worktree-from-session"}, cwds)
 }
 
 func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
@@ -682,9 +682,9 @@ func TestGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 		return []string{sessionLog}, nil
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/worktree-from-command", cwd)
+	assert.Equal(t, []string{"/tmp/worktree-from-command"}, cwds)
 }
 
 func TestReadCodexSessionCWD_UsesCachedValueWhenFingerprintUnchanged(t *testing.T) {
@@ -813,9 +813,9 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 		}
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/panemux-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/panemux-worktree"}, cwds)
 }
 
 func TestClaudeProjectDirName_NormalizesDots(t *testing.T) {
@@ -876,9 +876,9 @@ func TestGetActiveWorkdir_PrefersClaudeTranscriptWorktree_WithDotInCWD(t *testin
 		}
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/panemux-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/panemux-worktree"}, cwds)
 }
 
 func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T) {
@@ -938,9 +938,9 @@ func TestGetActiveWorkdir_ClaudeSessionScanSkipsUnreadableMetadata(t *testing.T)
 		}
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+	assert.Equal(t, []string{filepath.Dir(worktreeFile)}, cwds)
 }
 
 func TestGetActiveWorkdir_ClaudeSessionScanRejectsInvalidSessionID(t *testing.T) {
@@ -979,9 +979,346 @@ func TestGetActiveWorkdir_ClaudeSessionScanRejectsInvalidSessionID(t *testing.T)
 		}
 	}
 
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/repo/main", cwd)
+	assert.Equal(t, []string{"/repo/main"}, cwds)
+}
+
+func setUpClaudeSessionTranscripts(t *testing.T, homeDir string) (sessionMetaPath, transcriptPath string) {
+	t.Helper()
+
+	sessionMetaPath = filepath.Join(homeDir, ".claude", "sessions", "220.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionMetaPath), 0755))
+	require.NoError(t, os.WriteFile(sessionMetaPath, []byte(
+		`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`,
+	), 0600))
+
+	transcriptPath = filepath.Join(homeDir, ".claude", "projects", "-repo-main", "session-123.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(transcriptPath), 0755))
+	return sessionMetaPath, transcriptPath
+}
+
+func claudeAssistantCWDRecord(cwd string) string {
+	return "{\"type\":\"assistant\",\"cwd\":\"" + cwd + "\"," +
+		"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n"
+}
+
+func TestGetActiveWorkdirs_EmptySubagentsDirectory(t *testing.T) {
+	// Distinct from TestGetActiveWorkdirs_NoSubagentsDirectory_BackwardCompatible:
+	// here the "subagents" directory exists but contains no transcript files,
+	// rather than not existing at all.
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/tmp/panemux-worktree")),
+		0600,
+	))
+	subagentsDir := filepath.Join(filepath.Dir(transcriptPath), "session-123", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0755))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/tmp/panemux-worktree"}, cwds)
+}
+
+func TestGetActiveWorkdirs_IncludesSubagentTranscriptWorktree(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	// Parent transcript never leaves the base repo; only a subagent transcript
+	// actually visited a sibling worktree, mirroring the real-world case where
+	// a delegated Task subagent does the worktree-relative work.
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/repo/main")),
+		0600,
+	))
+
+	subagentsDir := filepath.Join(filepath.Dir(transcriptPath), "session-123", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-a1.jsonl"),
+		[]byte(claudeAssistantCWDRecord("/repo/worktree-a")),
+		0600,
+	))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-a"}, cwds)
+}
+
+func TestGetActiveWorkdirs_MultipleSubagentTranscripts_AllDistinctWorktreesReturned(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/repo/main")),
+		0600,
+	))
+
+	subagentsDir := filepath.Join(filepath.Dir(transcriptPath), "session-123", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-a1.jsonl"),
+		[]byte(claudeAssistantCWDRecord("/repo/worktree-a")),
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-a2.jsonl"),
+		[]byte(claudeAssistantCWDRecord("/repo/worktree-b")),
+		0600,
+	))
+	// A subagent that stayed in the same worktree as the parent should not
+	// produce a duplicate entry.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-a3.jsonl"),
+		[]byte(claudeAssistantCWDRecord("/repo/main")),
+		0600,
+	))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-a", "/repo/worktree-b"}, cwds)
+}
+
+func TestGetActiveWorkdirs_StaleSubagentTranscriptStillIncluded(t *testing.T) {
+	// Confirms there is no recency/time-window filter: a subagent transcript
+	// with an old modification time is still returned as a candidate.
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/repo/main")),
+		0600,
+	))
+
+	subagentsDir := filepath.Join(filepath.Dir(transcriptPath), "session-123", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0755))
+	oldAgentPath := filepath.Join(subagentsDir, "agent-old.jsonl")
+	require.NoError(t, os.WriteFile(
+		oldAgentPath,
+		[]byte(claudeAssistantCWDRecord("/repo/worktree-old")),
+		0600,
+	))
+	oldTime := time.Now().Add(-90 * 24 * time.Hour)
+	require.NoError(t, os.Chtimes(oldAgentPath, oldTime, oldTime))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-old"}, cwds)
+}
+
+func TestGetActiveWorkdirs_NoSubagentsDirectory_BackwardCompatible(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/tmp/panemux-worktree")),
+		0600,
+	))
+	// No subagents directory is created at all (older session layout).
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/tmp/panemux-worktree"}, cwds)
+}
+
+func TestGetActiveWorkdirs_CorruptSubagentTranscriptIgnored(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	originalListProcesses := listProcessesFn
+	originalGetPIDCWD := getPIDCWDFn
+	originalUserHomeDir := userHomeDirFn
+	t.Cleanup(func() {
+		listProcessesFn = originalListProcesses
+		getPIDCWDFn = originalGetPIDCWD
+		userHomeDirFn = originalUserHomeDir
+	})
+
+	homeDir := t.TempDir()
+	userHomeDirFn = func() (string, error) { return homeDir, nil }
+
+	_, transcriptPath := setUpClaudeSessionTranscripts(t, homeDir)
+	require.NoError(t, os.WriteFile(
+		transcriptPath,
+		[]byte(claudeAssistantCWDRecord("/repo/main")),
+		0600,
+	))
+
+	subagentsDir := filepath.Join(filepath.Dir(transcriptPath), "session-123", "subagents")
+	require.NoError(t, os.MkdirAll(subagentsDir, 0755))
+	// Empty/corrupt subagent transcripts should be skipped without affecting
+	// resolution of the other, well-formed subagent transcript.
+	require.NoError(t, os.WriteFile(filepath.Join(subagentsDir, "agent-empty.jsonl"), []byte(""), 0600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-corrupt.jsonl"),
+		[]byte("not json at all\n"),
+		0600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subagentsDir, "agent-good.jsonl"),
+		[]byte(claudeAssistantCWDRecord("/repo/worktree-good")),
+		0600,
+	))
+
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 110, PPID: 100, Command: "/bin/zsh"},
+			{PID: 220, PPID: 110, Command: "claude"},
+		}, nil
+	}
+	getPIDCWDFn = func(pid int) (string, error) {
+		switch pid {
+		case 100, 220:
+			return "/repo/main", nil
+		default:
+			return "", errors.New("unexpected pid")
+		}
+	}
+
+	cwds, err := sess.GetActiveWorkdirs()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-good"}, cwds)
 }
 
 func TestValidateShell_InEtcShells_OK(t *testing.T) {
@@ -1100,9 +1437,9 @@ func TestTmuxLocalSessionGetActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {
 	}
 
 	sess := &TmuxLocalSession{tmuxSession: "demo"}
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/worktree", cwd)
+	assert.Equal(t, []string{"/tmp/worktree"}, cwds)
 }
 
 func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
@@ -1155,9 +1492,9 @@ func TestTmuxLocalSessionGetActiveWorkdir_PrefersCodexExecCommandWorkdir(t *test
 	}
 
 	sess := &TmuxLocalSession{tmuxSession: "demo"}
-	cwd, err := sess.GetActiveWorkdir()
+	cwds, err := sess.GetActiveWorkdirs()
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/tmux-worktree-from-command", cwd)
+	assert.Equal(t, []string{"/tmp/tmux-worktree-from-command"}, cwds)
 }
 
 func TestTmuxLocalSessionGetActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(t *testing.T) {
@@ -1212,7 +1549,7 @@ func TestTmuxLocalSessionGetActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCom
 		return []string{sessionLog}, nil
 	}
 
-	cwd, err := tmuxLocalActiveWorkdir("demo")
+	cwds, err := tmuxLocalActiveWorkdirs("demo")
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/tmux-root-codex-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/tmux-root-codex-worktree"}, cwds)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -57,10 +57,12 @@ type CWDGetter interface {
 	GetCWD() (string, error)
 }
 
-// ActiveWorkdirGetter is implemented by sessions that can detect the current
-// working directory of an active Codex/Claude child process.
+// ActiveWorkdirGetter is implemented by sessions that can detect every
+// distinct working directory currently in play for an active Codex/Claude
+// child process, including sibling worktrees only visited by a delegated
+// Claude Task subagent.
 type ActiveWorkdirGetter interface {
-	GetActiveWorkdir() (string, error)
+	GetActiveWorkdirs() ([]string, error)
 }
 
 // GitContext describes the repository state for a session's working directory.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -840,16 +840,17 @@ func (s *SSHSession) GetCWD() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// GetActiveWorkdir returns the working directory of the newest active
-// interactive Codex or Claude process on the SSH connection, or empty string
-// when none is active.
-func (s *SSHSession) GetActiveWorkdir() (string, error) {
+// GetActiveWorkdirs returns every distinct working directory currently in
+// play for the newest active interactive Codex or Claude process on the SSH
+// connection, including worktrees only visited by a delegated Claude Task
+// subagent. Returns an empty slice when none is active.
+func (s *SSHSession) GetActiveWorkdirs() ([]string, error) {
 	baseCWD, err := s.GetCWD()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return activeRemoteWorkdirFromSessionFactory(
+	return activeRemoteWorkdirsFromSessionFactory(
 		func() (sshSessionRunner, error) {
 			return s.client.NewSession()
 		},
@@ -885,22 +886,22 @@ func remoteShellPID(runner sshSessionRunner) (int, error) {
 	return pid, nil
 }
 
-func activeRemoteWorkdirFromSessionFactory(
+func activeRemoteWorkdirsFromSessionFactory(
 	newRunner func() (sshSessionRunner, error),
 	logScope, baseCWD string,
-) (string, error) {
+) ([]string, error) {
 	rootRunner, err := newRunner()
 	if err != nil {
-		return "", fmt.Errorf("new ssh session for remote shell pid: %w", err)
+		return nil, fmt.Errorf("new ssh session for remote shell pid: %w", err)
 	}
 	defer rootRunner.Close()
 
 	rootPID, err := remoteShellPID(rootRunner)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return activeRemoteWorkdirWithOutput(
+	return activeRemoteWorkdirsWithOutput(
 		outputFromSessionFactory(newRunner),
 		logScope,
 		baseCWD,
@@ -908,47 +909,47 @@ func activeRemoteWorkdirFromSessionFactory(
 	)
 }
 
-func activeRemoteWorkdir(runner sshSessionRunner, logScope, baseCWD string, rootPID int) (string, error) {
-	return activeRemoteWorkdirWithOutput(runner.Output, logScope, baseCWD, rootPID)
+func activeRemoteWorkdirs(runner sshSessionRunner, logScope, baseCWD string, rootPID int) ([]string, error) {
+	return activeRemoteWorkdirsWithOutput(runner.Output, logScope, baseCWD, rootPID)
 }
 
-func activeRemoteWorkdirWithOutput(
+func activeRemoteWorkdirsWithOutput(
 	run remoteOutputFunc,
 	logScope, baseCWD string,
 	rootPID int,
-) (string, error) {
-	log.Printf("%s resolving active workdir from base_cwd=%q root_pid=%d", logScope, baseCWD, rootPID)
+) ([]string, error) {
+	log.Printf("%s resolving active workdirs from base_cwd=%q root_pid=%d", logScope, baseCWD, rootPID)
 
 	out, err := run(sshListProcessesCmd)
 	if err != nil {
 		log.Printf("%s list remote processes failed: %v", logScope, err)
-		return "", fmt.Errorf("list remote processes: %w", err)
+		return nil, fmt.Errorf("list remote processes: %w", err)
 	}
 
 	processes, err := parsePSOutput(append([]byte("PID PPID COMMAND\n"), out...))
 	if err != nil {
 		log.Printf("%s parse remote processes failed: %v", logScope, err)
-		return "", err
+		return nil, err
 	}
 
 	agentPID, ok := newestInteractiveAgentDescendantPID(processes, rootPID)
 	if !ok {
 		log.Printf("%s no interactive codex/claude process found beneath root_pid=%d", logScope, rootPID)
-		return "", nil
+		return nil, nil
 	}
 	if proc, found := processByPID(processes, agentPID); found {
 		log.Printf("%s selected interactive agent pid=%d command=%q", logScope, agentPID, proc.Command)
 	}
 
-	sessionCWD, sessionErr := remoteInteractiveAgentSessionCWD(
+	sessionCWDs, sessionErr := remoteInteractiveAgentSessionCWDs(
 		run,
 		logScope,
 		processes,
 		agentPID,
 	)
-	if sessionErr == nil && sessionCWD != "" {
-		log.Printf("%s resolved active workdir from interactive agent session data: %q", logScope, sessionCWD)
-		return sessionCWD, nil
+	if sessionErr == nil && len(sessionCWDs) > 0 {
+		log.Printf("%s resolved active workdirs from interactive agent session data: %q", logScope, sessionCWDs)
+		return sessionCWDs, nil
 	} else if sessionErr != nil {
 		log.Printf("%s interactive agent session workdir lookup failed: %v", logScope, sessionErr)
 	} else {
@@ -958,14 +959,14 @@ func activeRemoteWorkdirWithOutput(
 	cwd, err := resolveRemoteInteractiveAgentWorkdir(logScope, run, processes, agentPID, baseCWD)
 	if err != nil {
 		log.Printf("%s descendant cwd resolution failed: %v", logScope, err)
-		return "", err
+		return nil, err
 	}
 	if cwd == "" {
 		log.Printf("%s descendant cwd scan found no override; keeping base_cwd=%q", logScope, baseCWD)
-	} else {
-		log.Printf("%s descendant cwd scan selected %q", logScope, cwd)
+		return nil, nil
 	}
-	return cwd, nil
+	log.Printf("%s descendant cwd scan selected %q", logScope, cwd)
+	return []string{cwd}, nil
 }
 
 func resolveRemoteInteractiveAgentWorkdir(
@@ -1058,58 +1059,133 @@ func remoteCodexSessionCWD(
 	)
 }
 
-func remoteInteractiveAgentSessionCWD(
+func remoteInteractiveAgentSessionCWDs(
 	run remoteOutputFunc,
 	logScope string,
 	processes []processInfo,
 	agentPID int,
-) (string, error) {
+) ([]string, error) {
 	proc, ok := processByPID(processes, agentPID)
 	if !ok {
-		return "", nil
+		return nil, nil
 	}
 
 	switch {
 	case isCodexCommand(proc.Command):
-		return remoteCodexSessionCWD(run, logScope, processes, agentPID)
+		cwd, err := remoteCodexSessionCWD(run, logScope, processes, agentPID)
+		if err != nil || cwd == "" {
+			return nil, err
+		}
+		return []string{cwd}, nil
 	case isClaudeCommand(proc.Command):
-		return remoteClaudeSessionCWD(run, logScope, processes, agentPID)
+		return remoteClaudeSessionCWDs(run, logScope, processes, agentPID)
 	default:
-		return "", nil
+		return nil, nil
 	}
 }
 
-func remoteClaudeSessionCWD(
+// remoteClaudeSessionCWDs returns every distinct workdir found across the
+// Claude session's own remote transcript and any Task subagent transcripts
+// recorded alongside it under a remote "subagents" directory. See
+// claudeSessionCWDs (local.go) for why subagent transcripts matter: a
+// delegated subagent's worktree-relative work is otherwise invisible because
+// it is never reflected in the parent transcript.
+func remoteClaudeSessionCWDs(
 	run remoteOutputFunc,
 	logScope string,
 	processes []processInfo,
 	agentPID int,
-) (string, error) {
+) ([]string, error) {
 	proc, ok := processByPID(processes, agentPID)
 	if !ok || !isClaudeCommand(proc.Command) {
-		return "", nil
+		return nil, nil
 	}
 
 	sessionMeta, err := remoteClaudeSessionMeta(run, logScope, agentPID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if sessionMeta == nil || sessionMeta.SessionID == "" || sessionMeta.CWD == "" {
-		return "", nil
+		return nil, nil
 	}
 	if !validClaudeSessionID.MatchString(sessionMeta.SessionID) {
-		return "", nil
+		return nil, nil
 	}
 
 	projectPath := remoteClaudeProjectPath(sessionMeta)
-	return remoteCachedAgentLogCWD(
-		run,
-		"ssh:"+logScope+":claude:"+projectPath,
-		logScope,
-		projectPath,
-		remoteClaudeProjectShellPath(sessionMeta),
-		"claude transcript",
-		parseClaudeProjectCWD,
+
+	cwds := make([]string, 0, 1)
+	seen := make(map[string]bool)
+	addCandidate := func(displayPath, shellPath string) {
+		cwd, lookupErr := remoteCachedAgentLogCWD(
+			run,
+			"ssh:"+logScope+":claude:"+displayPath,
+			logScope,
+			displayPath,
+			shellPath,
+			"claude transcript",
+			parseClaudeProjectCWD,
+		)
+		if lookupErr != nil || cwd == "" || seen[cwd] {
+			return
+		}
+		seen[cwd] = true
+		cwds = append(cwds, cwd)
+	}
+
+	addCandidate(projectPath, remoteClaudeProjectShellPath(sessionMeta))
+
+	subagentNames, err := remoteClaudeSubagentTranscriptNames(run, logScope, sessionMeta)
+	if err != nil {
+		log.Printf("%s listing claude subagent transcripts failed: %v", logScope, err)
+		return cwds, nil
+	}
+	for _, name := range subagentNames {
+		addCandidate(
+			filepath.Join(filepath.Dir(projectPath), sessionMeta.SessionID, "subagents", name),
+			remoteClaudeSubagentShellPath(sessionMeta, name),
+		)
+	}
+
+	return cwds, nil
+}
+
+// remoteClaudeSubagentTranscriptNames lists the ".jsonl" filenames in the
+// remote session's "subagents" directory, or returns an empty list (no
+// error) when that directory does not exist, matching older Claude Code
+// session layouts that never created it.
+func remoteClaudeSubagentTranscriptNames(
+	run remoteOutputFunc,
+	logScope string,
+	meta *claudeSessionMeta,
+) ([]string, error) {
+	out, err := run("ls -1 " + remoteClaudeSubagentsDirShellPath(meta) + " 2>/dev/null || true")
+	if err != nil {
+		return nil, err
+	}
+
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasSuffix(line, ".jsonl") {
+			continue
+		}
+		names = append(names, line)
+	}
+	sort.Strings(names)
+	log.Printf("%s found %d claude subagent transcript(s)", logScope, len(names))
+	return names, nil
+}
+
+func remoteClaudeSubagentsDirShellPath(meta *claudeSessionMeta) string {
+	return "~/.claude/projects/" + shellQuotePath(
+		filepath.Join(claudeProjectDirName(meta.CWD), meta.SessionID, "subagents"),
+	)
+}
+
+func remoteClaudeSubagentShellPath(meta *claudeSessionMeta, name string) string {
+	return "~/.claude/projects/" + shellQuotePath(
+		filepath.Join(claudeProjectDirName(meta.CWD), meta.SessionID, "subagents", name),
 	)
 }
 

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -356,9 +356,9 @@ func TestActiveRemoteWorkdir_IgnoresNonInteractiveAgents(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Empty(t, cwd)
+	assert.Empty(t, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteCodexSessionCWD(t *testing.T) {
@@ -374,9 +374,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexSessionCWD(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) {
@@ -393,9 +393,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteCodexExecCommandWorkdir(t *testing.T) 
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree-from-command", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree-from-command"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_SkipsRemoteCodexLogReadWhenFingerprintUnchanged(t *testing.T) {
@@ -418,14 +418,14 @@ func TestActiveRemoteWorkdir_SkipsRemoteCodexLogReadWhenFingerprintUnchanged(t *
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 
 	delete(runner.outputs, catCmd)
-	cwd, err = activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err = activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_ReReadsRemoteClaudeTranscriptWhenFingerprintChanges(t *testing.T) {
@@ -447,18 +447,18 @@ func TestActiveRemoteWorkdir_ReReadsRemoteClaudeTranscriptWhenFingerprintChanges
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-claude-worktree-a", cwd)
+	assert.Equal(t, []string{"/tmp/remote-claude-worktree-a"}, cwds)
 
 	runner.outputs[fingerprintCmd] = []byte("101 1700000001\n")
 	runner.outputs[projectCmd] = []byte(
 		"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree-b\"," +
 			"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
 	)
-	cwd, err = activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err = activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-claude-worktree-b", cwd)
+	assert.Equal(t, []string{"/tmp/remote-claude-worktree-b"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
@@ -471,9 +471,9 @@ func TestActiveRemoteWorkdir_FallsBackToRemoteDescendantCWD(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T) {
@@ -491,9 +491,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree(t *testing.T)
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-claude-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(t *testing.T) {
@@ -511,9 +511,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTranscriptWorktree_WithDotInCWD(
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-claude-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-claude-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeTopLevelCWDOverToolPaths(t *testing.T) {
@@ -533,9 +533,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeTopLevelCWDOverToolPaths(t *test
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/repo/main", cwd)
+	assert.Equal(t, []string{"/repo/main"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
@@ -555,9 +555,9 @@ func TestActiveRemoteWorkdir_PrefersRemoteClaudeBashCDWorktree(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-bash-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-bash-worktree"}, cwds)
 }
 
 func TestActiveRemoteWorkdir_RejectsRemoteClaudeInvalidSessionID(t *testing.T) {
@@ -570,9 +570,128 @@ func TestActiveRemoteWorkdir_RejectsRemoteClaudeInvalidSessionID(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/repo/main", cwd)
+	assert.Equal(t, []string{"/repo/main"}, cwds)
+}
+
+func TestActiveRemoteWorkdir_IncludesSubagentTranscriptWorktree(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
+	subagentsListCmd := "ls -1 ~/.claude/projects/'-repo-main/session-123/subagents' 2>/dev/null || true"
+	subagentCmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-a1.jsonl'"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/main\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			subagentsListCmd: []byte("agent-a1.jsonl\n"),
+			subagentCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/worktree-a\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+		},
+	}
+
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-a"}, cwds)
+}
+
+func TestActiveRemoteWorkdir_MultipleSubagentTranscripts_AllDistinctWorktreesReturned(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
+	subagentsListCmd := "ls -1 ~/.claude/projects/'-repo-main/session-123/subagents' 2>/dev/null || true"
+	subagentACmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-a1.jsonl'"
+	subagentBCmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-a2.jsonl'"
+	subagentCCmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-a3.jsonl'"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/main\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			subagentsListCmd: []byte("agent-a1.jsonl\nagent-a2.jsonl\nagent-a3.jsonl\n"),
+			subagentACmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/worktree-a\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			subagentBCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/worktree-b\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			// A subagent that stayed in the same worktree as the parent should
+			// not produce a duplicate entry.
+			subagentCCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/main\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+		},
+	}
+
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-a", "/repo/worktree-b"}, cwds)
+}
+
+func TestActiveRemoteWorkdir_NoSubagentsDirectory_BackwardCompatible(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
+	subagentsListCmd := "ls -1 ~/.claude/projects/'-repo-main/session-123/subagents' 2>/dev/null || true"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/tmp/remote-claude-worktree\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			// The remote "|| true" makes a missing subagents directory look like
+			// an empty, successful listing rather than a command error.
+			subagentsListCmd: []byte(""),
+		},
+	}
+
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/tmp/remote-claude-worktree"}, cwds)
+}
+
+func TestActiveRemoteWorkdir_CorruptSubagentTranscriptIgnored(t *testing.T) {
+	sessionPath := "~/.claude/sessions/220.json"
+	projectCmd := "cat ~/.claude/projects/'-repo-main/session-123.jsonl'"
+	subagentsListCmd := "ls -1 ~/.claude/projects/'-repo-main/session-123/subagents' 2>/dev/null || true"
+	corruptCmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-corrupt.jsonl'"
+	goodCmd := "cat ~/.claude/projects/'-repo-main/session-123/subagents/agent-good.jsonl'"
+
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			sshListProcessesCmd:  []byte(" 100 1 sh\n 220 100 claude\n"),
+			"cat " + sessionPath: []byte(`{"pid":220,"sessionId":"session-123","cwd":"/repo/main"}`),
+			projectCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/main\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+			subagentsListCmd: []byte("agent-corrupt.jsonl\nagent-good.jsonl\n"),
+			corruptCmd:       []byte("not json at all\n"),
+			goodCmd: []byte(
+				"{\"type\":\"assistant\",\"cwd\":\"/repo/worktree-good\"," +
+					"\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n",
+			),
+		},
+	}
+
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/repo/main", "/repo/worktree-good"}, cwds)
 }
 
 func TestRemoteShellPID_ParsesShellProcess(t *testing.T) {
@@ -600,13 +719,13 @@ func TestActiveRemoteWorkdirFromSessionFactory_UsesSeparateRunners(t *testing.T)
 		return &fakeSSHRunner{outputs: outputs}, nil
 	}
 
-	cwd, err := activeRemoteWorkdirFromSessionFactory(
+	cwds, err := activeRemoteWorkdirsFromSessionFactory(
 		factory,
 		"test active remote",
 		"/repo/main",
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 	// Separate runners are used for: shell PID, process list, open-files probe,
 	// and PID cwd fallback.
 	assert.Equal(t, 4, index)
@@ -622,9 +741,9 @@ func TestActiveRemoteWorkdir_RootPIDScopesRemoteAgents(t *testing.T) {
 		},
 	}
 
-	cwd, err := activeRemoteWorkdir(runner, "test active remote", "/repo/main", 100)
+	cwds, err := activeRemoteWorkdirs(runner, "test active remote", "/repo/main", 100)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 }
 
 func TestTmuxSSHActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {
@@ -638,9 +757,9 @@ func TestTmuxSSHActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {
 		},
 	}
 
-	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
+	cwds, err := tmuxSSHActiveWorkdirs(runner, "test ssh_tmux", "demo")
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 }
 
 func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
@@ -658,9 +777,9 @@ func TestTmuxSSHActiveWorkdir_PrefersCodexExecCommandWorkdir(t *testing.T) {
 		},
 	}
 
-	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
+	cwds, err := tmuxSSHActiveWorkdirs(runner, "test ssh_tmux", "demo")
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-tmux-worktree-from-command", cwd)
+	assert.Equal(t, []string{"/tmp/remote-tmux-worktree-from-command"}, cwds)
 }
 
 func TestTmuxSSHActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
@@ -681,9 +800,9 @@ func TestTmuxSSHActiveWorkdir_PrefersClaudeTranscriptWorktree(t *testing.T) {
 		},
 	}
 
-	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
+	cwds, err := tmuxSSHActiveWorkdirs(runner, "test ssh_tmux", "demo")
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-tmux-claude-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-tmux-claude-worktree"}, cwds)
 }
 
 func TestTmuxSSHActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(t *testing.T) {
@@ -701,9 +820,9 @@ func TestTmuxSSHActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCommandWorkdir(
 		},
 	}
 
-	cwd, err := tmuxSSHActiveWorkdir(runner, "test ssh_tmux", "demo")
+	cwds, err := tmuxSSHActiveWorkdirs(runner, "test ssh_tmux", "demo")
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-root-codex-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-root-codex-worktree"}, cwds)
 }
 
 func TestTmuxSSHActiveWorkdirFromSessionFactory_UsesSeparateRunners(t *testing.T) {
@@ -719,13 +838,13 @@ func TestTmuxSSHActiveWorkdirFromSessionFactory_UsesSeparateRunners(t *testing.T
 		return &fakeSSHRunner{outputs: outputs}, nil
 	}
 
-	cwd, err := tmuxSSHActiveWorkdirFromSessionFactory(
+	cwds, err := tmuxSSHActiveWorkdirsFromSessionFactory(
 		factory,
 		"test ssh_tmux",
 		"demo",
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "/tmp/remote-worktree", cwd)
+	assert.Equal(t, []string{"/tmp/remote-worktree"}, cwds)
 	// Separate runners are used for: tmux pane info, process list, open-files
 	// probe, and PID cwd fallback.
 	assert.Equal(t, 4, index)

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -116,16 +116,18 @@ func (s *TmuxLocalSession) GetCWD() (string, error) {
 	return out, nil
 }
 
-// GetActiveWorkdir returns the working directory of the newest active Codex or
-// Claude descendant process under the active tmux pane, or empty string if none exists.
-func (s *TmuxLocalSession) GetActiveWorkdir() (string, error) {
-	return tmuxLocalActiveWorkdir(s.tmuxSession)
+// GetActiveWorkdirs returns every distinct working directory currently in
+// play for the newest active Codex or Claude descendant process under the
+// active tmux pane, including worktrees only visited by a delegated Claude
+// Task subagent. Returns an empty slice if no such process exists.
+func (s *TmuxLocalSession) GetActiveWorkdirs() ([]string, error) {
+	return tmuxLocalActiveWorkdirs(s.tmuxSession)
 }
 
-func tmuxLocalActiveWorkdir(tmuxSession string) (string, error) {
+func tmuxLocalActiveWorkdirs(tmuxSession string) ([]string, error) {
 	target, err := validateTmuxSessionName(tmuxSession)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	out, err := tmuxLocalOutputFn(
 		"display-message",
@@ -135,33 +137,33 @@ func tmuxLocalActiveWorkdir(tmuxSession string) (string, error) {
 		"#{pane_pid}",
 	)
 	if err != nil {
-		return "", fmt.Errorf("tmux pane pid: %w", err)
+		return nil, fmt.Errorf("tmux pane pid: %w", err)
 	}
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
 	if err != nil {
-		return "", fmt.Errorf("parse tmux pane pid: %w", err)
+		return nil, fmt.Errorf("parse tmux pane pid: %w", err)
 	}
 	if pid == 0 {
-		return "", errors.New("tmux pane pid missing")
+		return nil, errors.New("tmux pane pid missing")
 	}
 
 	processes, err := listProcessesFn()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	agentPID, ok := newestInteractiveAgentDescendantPID(processes, pid)
 	if !ok {
-		return "", nil
+		return nil, nil
 	}
 
 	baseCWD, err := tmuxLocalCWD(target)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return resolveInteractiveAgentWorkdir(processes, agentPID, baseCWD)
+	return resolveInteractiveAgentWorkdirs(processes, agentPID, baseCWD)
 }
 
 func tmuxLocalCWD(tmuxSession string) (string, error) {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -145,10 +145,12 @@ func (s *TmuxSSHSession) GetCWD() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// GetActiveWorkdir returns the working directory of the newest active
-// interactive Codex or Claude process under the active remote tmux pane.
-func (s *TmuxSSHSession) GetActiveWorkdir() (string, error) {
-	return tmuxSSHActiveWorkdirFromSessionFactory(
+// GetActiveWorkdirs returns every distinct working directory currently in
+// play for the newest active interactive Codex or Claude process under the
+// active remote tmux pane, including worktrees only visited by a delegated
+// Claude Task subagent.
+func (s *TmuxSSHSession) GetActiveWorkdirs() ([]string, error) {
+	return tmuxSSHActiveWorkdirsFromSessionFactory(
 		func() (sshSessionRunner, error) {
 			return s.client.NewSession()
 		},
@@ -183,7 +185,7 @@ func parseRemoteTmuxPaneInfo(out []byte) (int, string, error) {
 	return panePID, strings.TrimSpace(fields[1]), nil
 }
 
-func tmuxSSHActiveWorkdir(runner sshSessionRunner, logScope, tmuxSession string) (string, error) {
+func tmuxSSHActiveWorkdirs(runner sshSessionRunner, logScope, tmuxSession string) ([]string, error) {
 	out, err := runner.Output(
 		fmt.Sprintf(
 			"tmux display-message -p -t '%s' '#{pane_pid}\t#{pane_current_path}'",
@@ -192,25 +194,25 @@ func tmuxSSHActiveWorkdir(runner sshSessionRunner, logScope, tmuxSession string)
 	)
 	if err != nil {
 		log.Printf("%s tmux pane info lookup failed: %v", logScope, err)
-		return "", fmt.Errorf("tmux pane info over ssh: %w", err)
+		return nil, fmt.Errorf("tmux pane info over ssh: %w", err)
 	}
 	panePID, baseCWD, err := parseRemoteTmuxPaneInfo(out)
 	if err != nil {
 		log.Printf("%s %v", logScope, err)
-		return "", err
+		return nil, err
 	}
 	log.Printf("%s active tmux pane pid=%d base_cwd=%q", logScope, panePID, baseCWD)
 
-	return activeRemoteWorkdir(runner, logScope, baseCWD, panePID)
+	return activeRemoteWorkdirs(runner, logScope, baseCWD, panePID)
 }
 
-func tmuxSSHActiveWorkdirFromSessionFactory(
+func tmuxSSHActiveWorkdirsFromSessionFactory(
 	newRunner func() (sshSessionRunner, error),
 	logScope, tmuxSession string,
-) (string, error) {
+) ([]string, error) {
 	paneRunner, err := newRunner()
 	if err != nil {
-		return "", fmt.Errorf("new ssh session for active tmux pane info: %w", err)
+		return nil, fmt.Errorf("new ssh session for active tmux pane info: %w", err)
 	}
 	defer paneRunner.Close()
 
@@ -222,16 +224,16 @@ func tmuxSSHActiveWorkdirFromSessionFactory(
 	)
 	if err != nil {
 		log.Printf("%s tmux pane info lookup failed: %v", logScope, err)
-		return "", fmt.Errorf("tmux pane info over ssh: %w", err)
+		return nil, fmt.Errorf("tmux pane info over ssh: %w", err)
 	}
 	panePID, baseCWD, err := parseRemoteTmuxPaneInfo(out)
 	if err != nil {
 		log.Printf("%s %v", logScope, err)
-		return "", err
+		return nil, err
 	}
 	log.Printf("%s active tmux pane pid=%d base_cwd=%q", logScope, panePID, baseCWD)
 
-	return activeRemoteWorkdirWithOutput(
+	return activeRemoteWorkdirsWithOutput(
 		outputFromSessionFactory(newRunner),
 		logScope,
 		baseCWD,


### PR DESCRIPTION
## Summary
- panemux only read a Claude Code session's top-level `<sessionId>.jsonl` transcript to detect the active git worktree, so worktree/PR info in the pane header silently disappeared whenever the actual work happened in a delegated Task subagent instead (subagent activity is recorded in separate `subagents/*.jsonl` files that panemux never read).
- Extend `internal/session/local.go` and `ssh.go` to also read every sibling subagent transcript for a Claude session, returning all distinct workdirs signaled (no recency/time-window filtering — all worktrees found in the session are candidates).
- Extend `internal/api/handler.go` to resolve and show every distinct active sibling worktree instead of just one, with per-worktree GitHub PR lookups run concurrently.
- Extend the pane header (`PaneHeader.tsx`) to show a single worktree inline as before, or collapse into a `<N> worktrees` trigger + popover menu when 2 or more are active.
- Update `docs/behavior.md` and `docs/ui-design.md` to describe the new resolution and display behavior.

## Test plan
- [x] `make test-go` — all Go tests pass, including new coverage for subagent transcript discovery (local + SSH), multi-worktree resolution/dedup, and concurrent PR lookups (partial failure handled).
- [x] `make test-frontend` — all frontend tests pass, including new `GitInfoSchema` worktree-array cases and `PaneHeader` menu open/close/Escape/backdrop-click cases.
- [x] `make lint` — clean.
- [x] `make coverage` — Go 86.1%, frontend 95.25% (both above the 80% gate).
- [x] `make build` — succeeds.
- [x] Manual verification: built the binary, ran it against an isolated config pointed at this worktree, and confirmed in a real browser that the single-worktree case renders unchanged, and the multi-worktree case (via a mocked `git-info` response) shows the `2 worktrees` trigger, opens a menu listing both worktrees with their PR links, and closes on Escape.