### PR TITLE
fix: keep pane header worktree/PR info fresh after claude --resume

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -153,6 +153,13 @@ ones.
 Pane-header Git and PR metadata is fetched immediately when a pane becomes visible, then refreshed
 every 10 seconds only while both the browser tab and that pane remain visible.
 
+The backend caches each session's git-info response for 30 seconds so that this steady-state polling
+(and any other concurrent viewer of the same session, such as another browser tab) does not repeat
+process/transcript scanning, remote git inspection over SSH, or `gh pr view` lookups on every request.
+A pane's displayed Git/PR metadata may therefore lag the true state by up to 30 seconds; the cache is
+cleared whenever a session is deleted or recreated so a new session never inherits another session's
+cached response.
+
 Workspace-summary session-state and Git metadata polling are frontend-only and best-effort. While
 the browser tab is visible, the frontend polls every 10 seconds so it can summarize all known
 panes across all workspaces without mounting hidden terminal instances. The integrated summary view
@@ -546,7 +553,7 @@ When a pane moves to a different parent node, the component may be remounted by 
 ### Pane Git and PR metadata
 
 - The pane header shows Git metadata when the pane's current working context resolves to a Git repository.
-- The displayed Git context is always resolved from the pane's current live work context, not from stale historical output.
+- The displayed Git context is always resolved from the pane's current live work context, not from stale historical output, subject to the 30-second server-side response cache described above.
 - For normal panes, the base context is the pane's current working directory.
 - For local tmux and SSH+tmux panes, the base context is the currently active tmux pane only.
 - When a local, local tmux, SSH, or SSH+tmux pane has an active interactive `codex` or `claude` process working in a different Git worktree for the same repository, panemux prefers that agent worktree over the pane's base directory.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -158,7 +158,11 @@ The backend caches each session's git-info response for 30 seconds so that this 
 process/transcript scanning, remote git inspection over SSH, or `gh pr view` lookups on every request.
 A pane's displayed Git/PR metadata may therefore lag the true state by up to 30 seconds; the cache is
 cleared whenever a session is deleted or recreated so a new session never inherits another session's
-cached response.
+cached response. Explicit refresh triggers — clicking or focusing a pane, restoring the browser tab,
+or opening VS Code — only skip the frontend's own request if it already has a response no older than
+10 seconds, matching the steady-state poll interval, so an explicit refresh is bounded by that 10
+seconds plus the server-side cache above rather than compounding a larger, independent client-side
+window on top of it.
 
 Workspace-summary session-state and Git metadata polling are frontend-only and best-effort. While
 the browser tab is visible, the frontend polls every 10 seconds so it can summarize all known

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "panemux-frontend",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "panemux-frontend",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -116,16 +116,19 @@ describe('useGitInfo', () => {
     })
     expect(window.fetch).toHaveBeenCalledTimes(1)
 
-    act(() => {
-      vi.advanceTimersByTime(30001)
-    })
-
+    // Go hidden immediately so the steady-state poll (which only runs while
+    // the tab is visible) cannot itself refresh the cache in the background;
+    // this isolates the visibility-restore refresh path from polling.
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       value: 'hidden',
     })
     await act(async () => {
       document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(30001)
     })
 
     Object.defineProperty(document, 'visibilityState', {
@@ -150,9 +153,11 @@ describe('useGitInfo', () => {
       json: () => Promise.resolve({ is_git: false }),
     } as Response)
 
-    const { result } = renderHook(() => useGitInfo('pane1'))
+    // Disabled so the steady-state poll doesn't run; this test targets
+    // refreshIfStale's own throttle in isolation.
+    const { result } = renderHook(() => useGitInfo('pane1', false))
     await act(async () => {
-      await Promise.resolve()
+      await result.current.refreshIfStale()
     })
     expect(window.fetch).toHaveBeenCalledTimes(1)
 
@@ -240,6 +245,102 @@ describe('useGitInfo', () => {
     })
 
     expect(result.current.gitInfo.is_git).toBe(false)
+  })
+
+  it('polls automatically every 10 seconds while the tab and pane remain visible, with no interaction required', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    renderHook(() => useGitInfo('pane1'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops polling once the pane becomes disabled', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    const { rerender } = renderHook(({ enabled }) => useGitInfo('pane1', enabled), {
+      initialProps: { enabled: true },
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    rerender({ enabled: false })
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops polling while the browser tab is hidden and resumes once visible again', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-21T00:00:00Z'))
+    window.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ is_git: false }),
+    } as Response)
+
+    renderHook(() => useGitInfo('pane1'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+    })
+    expect(window.fetch).not.toHaveBeenCalledTimes(1)
   })
 
   it('shares cached git info with snapshot consumers without triggering extra fetches', async () => {

--- a/frontend/src/hooks/useGitInfo.test.ts
+++ b/frontend/src/hooks/useGitInfo.test.ts
@@ -128,7 +128,7 @@ describe('useGitInfo', () => {
     })
 
     act(() => {
-      vi.advanceTimersByTime(30001)
+      vi.advanceTimersByTime(10001)
     })
 
     Object.defineProperty(document, 'visibilityState', {
@@ -162,7 +162,7 @@ describe('useGitInfo', () => {
     expect(window.fetch).toHaveBeenCalledTimes(1)
 
     act(() => {
-      vi.advanceTimersByTime(30001)
+      vi.advanceTimersByTime(10001)
     })
 
     await act(async () => {

--- a/frontend/src/hooks/useGitInfo.ts
+++ b/frontend/src/hooks/useGitInfo.ts
@@ -3,6 +3,7 @@ import { GitInfo, GitInfoSchema } from '../schemas'
 
 const GIT_INFO_STALE_MS = 30000
 const GIT_INFO_RECHECK_THROTTLE_MS = 5000
+const GIT_INFO_POLL_INTERVAL_MS = 10000
 
 interface GitInfoCacheEntry {
   gitInfo: GitInfo
@@ -85,6 +86,20 @@ export function useGitInfo(sessionId: string, enabled = true): UseGitInfoResult 
     if (!enabled || !isVisible) return
     void refreshIfStale()
   }, [enabled, isVisible, refreshIfStale])
+
+  // Steady-state poll: keeps the pane header current even when nothing
+  // interacts with this specific pane (e.g. an agent working autonomously
+  // after `claude --resume`). The backend caches its own expensive work
+  // (remote git/PR lookups) on a longer TTL, so it's safe to poll it
+  // unconditionally here rather than relying on the interaction-driven
+  // staleness throttle in refreshIfStale.
+  useEffect(() => {
+    if (!enabled || !isVisible) return
+    const interval = setInterval(() => {
+      void refreshNow()
+    }, GIT_INFO_POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [enabled, isVisible, refreshNow])
 
   useEffect(() => {
     setGitInfo(getOrCreateCacheEntry(sessionId).gitInfo)

--- a/frontend/src/hooks/useGitInfo.ts
+++ b/frontend/src/hooks/useGitInfo.ts
@@ -1,7 +1,15 @@
 import { useState, useEffect, useCallback } from 'react'
 import { GitInfo, GitInfoSchema } from '../schemas'
 
-const GIT_INFO_STALE_MS = 30000
+// Matches GIT_INFO_POLL_INTERVAL_MS: since the steady-state poll already
+// keeps the cache within 10s of fresh while a pane is visible, an
+// interaction-triggered refresh (click/focus/keydown, visibility regain)
+// should not tolerate data any older than that before treating it as stale.
+// Keeping this aligned with the poll interval also bounds the worst-case
+// staleness of an explicit refresh to this value plus the server-side cache
+// TTL, instead of compounding a larger, independent client-side window on
+// top of it.
+const GIT_INFO_STALE_MS = 10000
 const GIT_INFO_RECHECK_THROTTLE_MS = 5000
 const GIT_INFO_POLL_INTERVAL_MS = 10000
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -48,6 +48,9 @@ type Handler struct {
 	preferredCWDBySession   map[string][]preferredCWDState
 	restartMu               sync.Mutex
 	restartInFlight         map[string]struct{}
+	nowFn                   func() time.Time
+	gitInfoCacheMu          sync.Mutex
+	gitInfoCacheBySession   map[string]gitInfoCacheEntry
 }
 
 type preferredCWDState struct {
@@ -55,6 +58,22 @@ type preferredCWDState struct {
 	CommonDir string
 	Root      string
 }
+
+// gitInfoCacheEntry holds a previously computed git-info response for a
+// session, valid until expiresAt. Caching the whole response — not just the
+// remote git/PR lookups — keeps this simple and uniform across local, tmux,
+// ssh, and ssh_tmux sessions alike: local sessions also pay for process and
+// transcript scanning on every request, so they benefit from the same cap.
+type gitInfoCacheEntry struct {
+	expiresAt time.Time
+	response  gitInfoResponse
+}
+
+// gitInfoCacheTTL bounds how long a pane header may show git/PR metadata
+// that is no longer perfectly current, in exchange for not re-running
+// process/transcript scans, remote git inspection, and `gh pr view` lookups
+// on every poll. See docs/behavior.md "Pane Git and PR metadata".
+const gitInfoCacheTTL = 30 * time.Second
 
 // activeGitContext pairs a resolved git context with the working directory
 // (pane base cwd, or an agent-signaled sibling worktree path) it was
@@ -137,6 +156,8 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 		sshConfigPath:         sshconfig.DefaultPath(),
 		preferredCWDBySession: make(map[string][]preferredCWDState),
 		restartInFlight:       make(map[string]struct{}),
+		nowFn:                 time.Now,
+		gitInfoCacheBySession: make(map[string]gitInfoCacheEntry),
 	}
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
@@ -274,6 +295,7 @@ func (h *Handler) DeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	for _, pane := range panesInLayout(workspace.Layout) {
 		_ = h.manager.Remove(pane.ID)
 		h.clearPreferredCWDs(pane.ID)
+		h.clearGitInfoCache(pane.ID)
 	}
 	writeJSON(w, h.cfg.WorkspacesView())
 }
@@ -410,6 +432,7 @@ func (h *Handler) DeleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	h.clearPreferredCWDs(id)
+	h.clearGitInfoCache(id)
 	h.cfg.RemovePaneFromLayout(id)
 	if err := h.cfg.SaveLayout(h.cfg.Layout); err != nil {
 		http.Error(w, "failed to save layout", http.StatusInternalServerError)
@@ -458,6 +481,7 @@ func (h *Handler) RestartSession(w http.ResponseWriter, r *http.Request) {
 
 	h.manager.Remove(id) //nolint:errcheck // ok if already gone
 	h.clearPreferredCWDs(id)
+	h.clearGitInfoCache(id)
 	h.manager.Add(sess)
 	w.WriteHeader(http.StatusOK)
 }
@@ -798,34 +822,46 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if resp, ok := h.cachedGitInfo(id); ok {
+		writeJSON(w, resp)
+		return
+	}
+
+	resp := h.computeGitInfo(sess)
+	h.storeGitInfoCache(id, resp)
+	writeJSON(w, resp)
+}
+
+// computeGitInfo resolves a session's current git/PR metadata. This is the
+// expensive path: process and transcript scanning, remote git inspection
+// over SSH, and `gh pr view` lookups. Callers should go through the
+// gitInfoCacheBySession TTL cache in GetGitInfo rather than calling this
+// directly on every request.
+func (h *Handler) computeGitInfo(sess session.Session) gitInfoResponse {
 	cwdGetter, ok := sess.(session.CWDGetter)
 	if !ok {
-		writeJSON(w, gitInfoResponse{IsGit: false})
-		return
+		return gitInfoResponse{IsGit: false}
 	}
 
 	cwd, err := cwdGetter.GetCWD()
 	if err != nil {
-		writeJSON(w, gitInfoResponse{IsGit: false})
-		return
+		return gitInfoResponse{IsGit: false}
 	}
 
 	err = gitExistsFn()
 	if err != nil {
-		writeJSON(w, gitInfoResponse{IsGit: false})
-		return
+		return gitInfoResponse{IsGit: false}
 	}
 
 	activeContexts, err := h.resolveActiveGitContexts(sess, cwd)
 	if err != nil {
-		writeJSON(w, gitInfoResponse{IsGit: false})
-		return
+		return gitInfoResponse{IsGit: false}
 	}
 
 	worktrees := h.lookupPRInfoForContexts(sess, activeContexts)
 	primary := worktrees[0]
 
-	writeJSON(w, gitInfoResponse{
+	return gitInfoResponse{
 		IsGit:     true,
 		Branch:    primary.Branch,
 		Repo:      primary.Repo,
@@ -833,7 +869,42 @@ func (h *Handler) GetGitInfo(w http.ResponseWriter, r *http.Request) {
 		PRURL:     primary.PRURL,
 		PRNumber:  primary.PRNumber,
 		Worktrees: worktrees,
-	})
+	}
+}
+
+// cachedGitInfo returns a still-valid cached git-info response for a
+// session, if one exists.
+func (h *Handler) cachedGitInfo(sessionID string) (gitInfoResponse, bool) {
+	h.gitInfoCacheMu.Lock()
+	defer h.gitInfoCacheMu.Unlock()
+
+	entry, ok := h.gitInfoCacheBySession[sessionID]
+	if !ok || h.nowFn().After(entry.expiresAt) {
+		return gitInfoResponse{}, false
+	}
+	return entry.response, true
+}
+
+// storeGitInfoCache records a freshly computed git-info response, valid for
+// gitInfoCacheTTL.
+func (h *Handler) storeGitInfoCache(sessionID string, resp gitInfoResponse) {
+	h.gitInfoCacheMu.Lock()
+	defer h.gitInfoCacheMu.Unlock()
+
+	h.gitInfoCacheBySession[sessionID] = gitInfoCacheEntry{
+		response:  resp,
+		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
+	}
+}
+
+// clearGitInfoCache discards any cached git-info response for a session, so
+// a removed or recreated session doesn't serve another session's stale data
+// under the same ID.
+func (h *Handler) clearGitInfoCache(sessionID string) {
+	h.gitInfoCacheMu.Lock()
+	defer h.gitInfoCacheMu.Unlock()
+
+	delete(h.gitInfoCacheBySession, sessionID)
 }
 
 // lookupPRInfoForContexts runs an independent PR lookup for each active git

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1509,9 +1509,13 @@ type mockCWDSession struct {
 	cwd       string
 	mockSession
 	activeWorkdirs []string
+	getCWDCalls    int
 }
 
-func (m *mockCWDSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
+func (m *mockCWDSession) GetCWD() (string, error) {
+	m.getCWDCalls++
+	return m.cwd, m.cwdErr
+}
 func (m *mockCWDSession) GetActiveWorkdirs() ([]string, error) {
 	return m.activeWorkdirs, m.activeErr
 }
@@ -2395,6 +2399,8 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	mgr.Add(sess)
 
 	h := NewHandler(defaultTestConfig(), mgr)
+	now := time.Now()
+	h.nowFn = func() time.Time { return now }
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2413,6 +2419,10 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 		"--force",
 	).CombinedOutput()
 	require.NoError(t, err, "git worktree remove failed: %s", string(out))
+
+	// Advance past the git-info response cache TTL so the second request
+	// recomputes instead of replaying the first response's cached worktree.
+	now = now.Add(gitInfoCacheTTL + time.Second)
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-stale/git-info", nil)
@@ -2581,6 +2591,121 @@ func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
 	var resp gitInfoResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.False(t, resp.IsGit)
+}
+
+func TestGetGitInfo_SecondRequestWithinTTL_ServesCachedResponseWithoutRecomputing(t *testing.T) {
+	dir := initTempGitRepo(t)
+	sess := &mockCWDSession{
+		mockSession: mockSession{id: "local-cached", typ: session.TypeLocal},
+		cwd:         dir,
+	}
+	mgr := session.NewManager()
+	mgr.Add(sess)
+	h := NewHandler(defaultTestConfig(), mgr)
+	now := time.Now()
+	h.nowFn = func() time.Time { return now }
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-cached/git-info", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, sess.getCWDCalls)
+
+	// Well within gitInfoCacheTTL: the second request must be served from
+	// cache, not recomputed.
+	now = now.Add(5 * time.Second)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-cached/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, sess.getCWDCalls, "expected the cached response to be served without recomputing")
+
+	var resp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.True(t, resp.IsGit)
+	assert.Equal(t, "main", resp.Branch)
+}
+
+func TestGetGitInfo_RequestAfterTTLExpires_Recomputes(t *testing.T) {
+	dir := initTempGitRepo(t)
+	sess := &mockCWDSession{
+		mockSession: mockSession{id: "local-expired", typ: session.TypeLocal},
+		cwd:         dir,
+	}
+	mgr := session.NewManager()
+	mgr.Add(sess)
+	h := NewHandler(defaultTestConfig(), mgr)
+	now := time.Now()
+	h.nowFn = func() time.Time { return now }
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-expired/git-info", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, sess.getCWDCalls)
+
+	now = now.Add(gitInfoCacheTTL + time.Second)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-expired/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 2, sess.getCWDCalls, "expected the cache to expire and the response to be recomputed")
+}
+
+func TestGetGitInfo_AfterSessionRecreatedWithSameID_DoesNotServeOldSessionsCache(t *testing.T) {
+	oldDir := initTempGitRepo(t)
+	oldSess := &mockCWDSession{
+		mockSession: mockSession{id: "local-recreated", typ: session.TypeLocal},
+		cwd:         oldDir,
+	}
+	oldSess.ensureBuf()
+	mgr := session.NewManager()
+	mgr.Add(oldSess)
+	h := NewHandler(defaultTestConfig(), mgr)
+	r := setupRouterWithGitInfo(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-recreated/git-info", nil)
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var oldResp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&oldResp))
+	assert.Equal(t, "main", oldResp.Branch)
+
+	require.NoError(t, mgr.Remove("local-recreated"))
+	h.clearGitInfoCache("local-recreated")
+
+	newDir := initTempGitRepo(t)
+	out, err := exec.Command( //nolint:gosec // G204: trusted test args
+		"git",
+		"-C",
+		newDir,
+		"checkout",
+		"-b",
+		"feature/recreated-session",
+	).CombinedOutput()
+	require.NoError(t, err, "git checkout failed: %s", string(out))
+	newSess := &mockCWDSession{
+		mockSession: mockSession{id: "local-recreated", typ: session.TypeLocal},
+		cwd:         newDir,
+	}
+	newSess.ensureBuf()
+	mgr.Add(newSess)
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/sessions/local-recreated/git-info", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var newResp gitInfoResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&newResp))
+	assert.Equal(t, "feature/recreated-session", newResp.Branch)
 }
 
 func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -530,6 +530,29 @@ func TestDeleteWorkspace_ClearsPreferredCWDForRemovedPanes(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestDeleteWorkspace_ClearsGitInfoCacheForRemovedPanes(t *testing.T) {
+	cfg, _ := loadWorkspaceTestConfigFromFile(t)
+	require.True(t, cfg.SetActiveWorkspace("two"))
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("one-main"))
+	mgr.Add(newMockSession("two-main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.gitInfoCacheBySession["two-main"] = gitInfoCacheEntry{
+		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
+		response:  gitInfoResponse{IsGit: true, Branch: "stale-branch"},
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/workspaces/two", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, ok := h.gitInfoCacheBySession["two-main"]
+	assert.False(t, ok, "expected the removed pane's stale cached git-info to be cleared")
+}
+
 func TestPutWorkspace_RenamesWorkspaceAndPersists(t *testing.T) {
 	cfg, path := loadWorkspaceTestConfigFromFile(t)
 	h := NewHandler(cfg, session.NewManager())
@@ -896,6 +919,38 @@ func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRestartSession_ClearsGitInfoCache(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Layout: config.LayoutNode{
+			Direction: "horizontal",
+			Children: []config.LayoutChild{
+				{Size: 100, Pane: &config.PaneConfig{ID: "main", Type: "local"}},
+			},
+		},
+	}
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("main"))
+	h := NewHandler(cfg, mgr)
+	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
+	h.gitInfoCacheBySession["main"] = gitInfoCacheEntry{
+		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
+		response:  gitInfoResponse{IsGit: true, Branch: "stale-branch"},
+	}
+	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
+		return newMockSession(pane.ID), nil
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sessions/main/restart", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	_, ok := h.gitInfoCacheBySession["main"]
+	assert.False(t, ok, "expected the restarted session's stale cached git-info to be cleared")
+}
+
 func TestRestartSession_NotFound_404(t *testing.T) {
 	r := setupRouter(defaultTestConfig(), session.NewManager())
 	rec := httptest.NewRecorder()
@@ -1160,6 +1215,26 @@ func TestDeleteSession_ClearsPreferredCWD(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	_, ok := h.preferredCWDBySession["s1"]
 	assert.False(t, ok)
+}
+
+func TestDeleteSession_ClearsGitInfoCache(t *testing.T) {
+	mgr := session.NewManager()
+	mgr.Add(newMockSession("s1"))
+	cfg := defaultTestConfig()
+	h := NewHandler(cfg, mgr)
+	h.gitInfoCacheBySession["s1"] = gitInfoCacheEntry{
+		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
+		response:  gitInfoResponse{IsGit: true, Branch: "stale-branch"},
+	}
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/sessions/s1", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, ok := h.gitInfoCacheBySession["s1"]
+	assert.False(t, ok, "expected the deleted session's stale cached git-info to be cleared")
 }
 
 func TestGetDisplay_ReturnsJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- Pane headers only refreshed on click/keydown/focus/visibility-regain, so resuming a Claude Code session with `claude --resume` and then watching the agent work autonomously (no interaction with that pane) left the worktree/PR info stuck on stale data indefinitely.
- Add the steady-state 10-second poll already documented in `docs/behavior.md` ("refreshed every 10 seconds only while both the browser tab and that pane remain visible") to `useGitInfo`, so the header eventually catches up with zero interaction.
- Add a 30-second server-side TTL cache for `GET /api/sessions/{id}/git-info` (`internal/api/handler.go`) so the new steady-state polling — and any other concurrent viewer of the same session — doesn't repeat process/transcript scanning, remote git inspection over SSH, or `gh pr view` lookups on every request. Applies uniformly to local/tmux/ssh/ssh_tmux sessions. Cache entries are cleared on session delete/recreate so a new session never inherits stale data.
- Documented the new caching behavior and its bounded-staleness trade-off in `docs/behavior.md`.

## Test plan
- [x] `make test-go`
- [x] `make test-frontend`
- [x] `make lint`
- [x] `make check` (including the pre-push hook's own `make check` run)
- [x] New automated tests directly simulate the reported scenario: `frontend/src/hooks/useGitInfo.test.ts` asserts the pane header keeps refetching every 10s with zero pane interaction (and stops when disabled/hidden); `internal/api/handler_test.go` asserts a second request within 30s is served from the server cache without re-invoking `GetCWD`, that the cache expires and recomputes after 30s, and that a deleted/recreated session under the same ID never serves the old session's cached response.
- [x] Manual end-to-end verification: ran `go run .` and the Vite dev server against a real local session in a scratch git repo, opened it in a browser, and confirmed via network logs that `/api/sessions/{id}/git-info` is now called automatically roughly every 10 seconds with zero clicks/keystrokes on the pane, where previously it would never refire on its own.