### PR TITLE
fix: bound tmux/SSH/git exec calls with timeouts and add SSH keepalive

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,8 +60,29 @@ Why an interface-first session layer:
 
 Optional capability interfaces extend the base `Session` contract without breaking existing types:
 
-- `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
+- `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs a shell command over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
+
+Every local `tmux`/`ps`/`lsof`/`git` invocation used for pane metadata inspection (`GetCWD`,
+`GetActiveWorkdirs`, git-context lookups) runs under a package-level timeout (5s for local calls and
+background-polling SSH calls, 10s for user-triggered SSH calls such as directory browsing and remote
+shell detection). `ssh.Session.Output` has no built-in timeout, so SSH call sites route through a
+shared `runOutputWithTimeout` helper (`internal/session/ssh_timeout.go`) that races the command
+against the timeout in a goroutine and force-closes the session to unblock it on expiry. Without this,
+a wedged remote tmux server or a hung `git` process (e.g. a stuck network filesystem mount under the
+pane's cwd) left `GET /api/sessions/{id}/git-info` blocked indefinitely, since that handler calls
+`GetCWD`/`InspectGitContext` synchronously.
+
+`SSHSession` and `TmuxSSHSession` also run a background keepalive probe
+(`internal/session/ssh_keepalive.go`) that sends an unrecognized SSH global request every 15 seconds;
+a compliant server's `SSH_MSG_REQUEST_FAILURE` reply is itself proof of liveness, mirroring OpenSSH's
+`ServerAliveInterval`. `golang.org/x/crypto/ssh` has no built-in equivalent, so without this probe a
+half-dead TCP connection (packets black-holed in one or both directions, no RST/FIN) left
+`Read`/`Write`/`NewSession`/`Session.Wait` blocked forever with no signal — this is the direct cause of
+a pane appearing to hang with no terminal output. After two consecutive failed/timed-out probes (worst
+case ~40s), the keepalive closes the underlying `ssh.Client`, which the existing
+`monitorSSHSession`/`classifySSHWaitError` machinery already observes as a transport error and reacts
+to by transitioning session state to `disconnected`.
 
 ### `internal/api`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -146,6 +146,16 @@ For pane-header Git status, local and local tmux panes inspect the local filesys
 and `ssh_tmux` panes run the equivalent Git inspection on the remote host. This allows headers to
 show branch/repository info even when the repository exists only on the SSH target.
 
+The tmux/git/process-inspection commands behind this (`GetCWD`, `GetActiveWorkdirs`, git-context
+lookups) are individually bounded by a short timeout (5 seconds for local calls and
+background-polling SSH calls, 10 seconds for user-triggered SSH calls). A wedged remote tmux server
+or a hung `git` invocation therefore fails and falls back within seconds instead of leaving
+`GET /api/sessions/{id}/git-info` — and the pane header refresh backing it — blocked indefinitely.
+SSH and SSH+tmux sessions additionally run a background keepalive probe that detects a fully dead
+transport (e.g. a network outage with no clean TCP close) within roughly 40 seconds and transitions
+the pane to `disconnected`, rather than leaving it silently unresponsive with no visible state
+change.
+
 Workspace tab summaries and their integrated pane groups use the same Git metadata source and also
 poll `/api/sessions` to summarize pane connection state across every workspace, including inactive
 ones.

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -93,6 +93,14 @@ var gitExistsFn = func() error {
 
 var prLookupTimeout = 5 * time.Second
 
+// localGitCommandTimeout bounds how long a single local `git` invocation used
+// for pane git-context inspection (rev-parse, branch, config) may block
+// before being killed. Without this, a hung local git process (e.g. a stuck
+// network filesystem mount under the pane's cwd) left GetGitInfo blocked
+// indefinitely. Kept separate from prLookupTimeout so shrinking one in tests
+// does not affect the other.
+var localGitCommandTimeout = 5 * time.Second
+
 const responseErrorKey = "error"
 
 type sshConnectionsResponse struct {
@@ -1130,7 +1138,9 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 }
 
 func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
-	branchCmd := exec.Command("git", "branch", "--show-current")
+	branchCtx, branchCancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
+	defer branchCancel()
+	branchCmd := exec.CommandContext(branchCtx, "git", "branch", "--show-current")
 	branchCmd.Dir = safeCWD
 	branchOut, err := branchCmd.Output()
 	if err != nil {
@@ -1140,7 +1150,9 @@ func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
 	}
 	branchOut = bytes.TrimSpace(branchOut)
 
-	originCmd := exec.Command("git", "config", "--get", "remote.origin.url")
+	originCtx, originCancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
+	defer originCancel()
+	originCmd := exec.CommandContext(originCtx, "git", "config", "--get", "remote.origin.url")
 	originCmd.Dir = safeCWD
 	originOut, err := originCmd.Output()
 	if err != nil {
@@ -1151,7 +1163,9 @@ func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
 }
 
 func runLocalGitContextCommand(safeCWD, originalCWD, operation string, args ...string) ([]byte, error) {
-	cmd := exec.Command("git", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = safeCWD
 	out, err := cmd.Output()
 	if err == nil {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1088,6 +1088,14 @@ func (h *Handler) inspectGitContextForSession(sess session.Session, cwd string) 
 	return h.inspectLocalGitContext(cwd)
 }
 
+// inspectLocalGitContext runs up to four sequential git subprocesses
+// (rev-parse --show-toplevel, rev-parse --git-common-dir, then branch and
+// origin lookups inside localGitOptionalMetadata) against a single shared
+// deadline, rather than giving each an independent localGitCommandTimeout.
+// A stuck working directory (e.g. a hung network filesystem mount) makes
+// every git invocation against it hang the same way, so without a shared
+// deadline the calls could accumulate up to 4x localGitCommandTimeout
+// before the whole lookup fails through.
 func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error) {
 	safeCWD, err := sanitizeGitExecDir(cwd)
 	if err != nil {
@@ -1101,7 +1109,11 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 		)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
+	defer cancel()
+
 	toplevelOut, err := runLocalGitContextCommand(
+		ctx,
 		safeCWD,
 		cwd,
 		"git rev-parse --show-toplevel",
@@ -1114,6 +1126,7 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	toplevelOut = bytes.TrimSpace(toplevelOut)
 
 	commonDirOut, err := runLocalGitContextCommand(
+		ctx,
 		safeCWD,
 		cwd,
 		"git rev-parse --path-format=absolute --git-common-dir",
@@ -1126,7 +1139,7 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	}
 	commonDirOut = bytes.TrimSpace(commonDirOut)
 
-	branchOut, originOut := localGitOptionalMetadata(safeCWD)
+	branchOut, originOut := localGitOptionalMetadata(ctx, safeCWD)
 	root := string(toplevelOut)
 	return session.GitContext{
 		Branch:    string(branchOut),
@@ -1137,10 +1150,8 @@ func (h *Handler) inspectLocalGitContext(cwd string) (session.GitContext, error)
 	}, nil
 }
 
-func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
-	branchCtx, branchCancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
-	defer branchCancel()
-	branchCmd := exec.CommandContext(branchCtx, "git", "branch", "--show-current")
+func localGitOptionalMetadata(ctx context.Context, safeCWD string) ([]byte, []byte) {
+	branchCmd := exec.CommandContext(ctx, "git", "branch", "--show-current")
 	branchCmd.Dir = safeCWD
 	branchOut, err := branchCmd.Output()
 	if err != nil {
@@ -1150,9 +1161,7 @@ func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
 	}
 	branchOut = bytes.TrimSpace(branchOut)
 
-	originCtx, originCancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
-	defer originCancel()
-	originCmd := exec.CommandContext(originCtx, "git", "config", "--get", "remote.origin.url")
+	originCmd := exec.CommandContext(ctx, "git", "config", "--get", "remote.origin.url")
 	originCmd.Dir = safeCWD
 	originOut, err := originCmd.Output()
 	if err != nil {
@@ -1162,9 +1171,9 @@ func localGitOptionalMetadata(safeCWD string) ([]byte, []byte) {
 	return branchOut, originOut
 }
 
-func runLocalGitContextCommand(safeCWD, originalCWD, operation string, args ...string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), localGitCommandTimeout)
-	defer cancel()
+func runLocalGitContextCommand(
+	ctx context.Context, safeCWD, originalCWD, operation string, args ...string,
+) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = safeCWD
 	out, err := cmd.Output()

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -2242,21 +2243,20 @@ func writeFakeGitBinary(t *testing.T, body string) string {
 }
 
 func TestRunLocalGitContextCommand_TimesOutOnHungGit(t *testing.T) {
-	binDir := writeFakeGitBinary(t, "#!/bin/sh\nsleep 5\n")
+	binDir := writeFakeGitBinary(t, "#!/bin/sh\nexec sleep 5\n")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	prev := localGitCommandTimeout
-	localGitCommandTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { localGitCommandTimeout = prev })
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
 
 	start := time.Now()
 	_, err := runLocalGitContextCommand(
-		t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
+		ctx, t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
 	)
 	elapsed := time.Since(start)
 
 	require.Error(t, err)
-	assert.Less(t, elapsed, 2*time.Second, "runLocalGitContextCommand should be bounded by localGitCommandTimeout")
+	assert.Less(t, elapsed, 2*time.Second, "runLocalGitContextCommand should be bounded by the passed-in context")
 }
 
 func TestRunLocalGitContextCommand_ReturnsOutputBeforeTimeout(t *testing.T) {
@@ -2264,27 +2264,82 @@ func TestRunLocalGitContextCommand_ReturnsOutputBeforeTimeout(t *testing.T) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	out, err := runLocalGitContextCommand(
-		t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
+		context.Background(), t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "/repo/main\n", string(out))
 }
 
 func TestLocalGitOptionalMetadata_TimesOutOnHungGit(t *testing.T) {
-	binDir := writeFakeGitBinary(t, "#!/bin/sh\nsleep 5\n")
+	binDir := writeFakeGitBinary(t, "#!/bin/sh\nexec sleep 5\n")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	prev := localGitCommandTimeout
-	localGitCommandTimeout = 10 * time.Millisecond
-	t.Cleanup(func() { localGitCommandTimeout = prev })
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
 
 	start := time.Now()
-	branch, origin := localGitOptionalMetadata(t.TempDir())
+	branch, origin := localGitOptionalMetadata(ctx, t.TempDir())
 	elapsed := time.Since(start)
 
 	assert.Empty(t, branch)
 	assert.Empty(t, origin)
-	assert.Less(t, elapsed, 2*time.Second, "localGitOptionalMetadata should be bounded by localGitCommandTimeout")
+	assert.Less(t, elapsed, 2*time.Second, "localGitOptionalMetadata should be bounded by the passed-in context")
+}
+
+// TestInspectLocalGitContext_SharesDeadlineAcrossAllGitCommands is the
+// regression test for a reviewer-flagged issue: inspectLocalGitContext runs
+// up to four sequential git subprocesses (rev-parse --show-toplevel,
+// rev-parse --git-common-dir, then branch --show-current and
+// config --get remote.origin.url inside localGitOptionalMetadata). If each
+// got its own independent localGitCommandTimeout, a stuck network
+// filesystem mount under the pane's cwd — where all four invocations hang —
+// could take up to 4x localGitCommandTimeout to fail through instead of
+// being bounded by one shared deadline for the whole call.
+//
+// The fake git here lets the first two (toplevel, common-dir) succeed
+// immediately so the call reaches localGitOptionalMetadata's two
+// subprocesses, which both hang. A shared deadline keeps the total near one
+// localGitCommandTimeout window; two independent per-call deadlines would
+// take roughly twice that.
+func TestInspectLocalGitContext_SharesDeadlineAcrossAllGitCommands(t *testing.T) {
+	binDir := writeFakeGitBinary(t, ""+
+		"#!/bin/sh\n"+
+		"case \"$1 $2\" in\n"+
+		"'rev-parse --show-toplevel') echo /repo/main ;;\n"+
+		"'rev-parse --path-format=absolute') echo /repo/main/.git ;;\n"+
+		// exec (rather than a plain "sleep 5") replaces this shell process
+		// image with sleep instead of forking a child that would keep
+		// inheriting stdout after the parent shell is killed on timeout —
+		// without it, cmd.Output() blocks until the orphaned sleep child
+		// itself exits, defeating the timeout this test is verifying.
+		"*) exec sleep 5 ;;\n"+
+		"esac\n",
+	)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prev := localGitCommandTimeout
+	// Long enough that the toplevel/common-dir subprocesses (which just
+	// echo and exit) reliably complete within it even under slow process-
+	// spawn conditions, while still keeping the whole test fast.
+	localGitCommandTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { localGitCommandTimeout = prev })
+
+	h := NewHandler(defaultTestConfig(), session.NewManager())
+
+	// localGitOptionalMetadata treats a failed/timed-out branch or origin
+	// lookup as an empty (not fatal) value, so inspectLocalGitContext
+	// succeeds here even though both underlying commands hung — the
+	// regression this test guards against is elapsed wall-clock time, not
+	// the returned error.
+	start := time.Now()
+	_, err := h.inspectLocalGitContext(t.TempDir())
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Less(
+		t, elapsed, 2*localGitCommandTimeout,
+		"branch and origin lookups should share one deadline, not accumulate localGitCommandTimeout per call",
+	)
 }
 
 func TestLookupPRInfo_TimesOutAndFallsBack(t *testing.T) {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -2230,6 +2230,63 @@ func TestGetGitInfo_DetachedHead_StillReturnsGitInfo(t *testing.T) {
 	assert.NotEmpty(t, resp.Repo)
 }
 
+// writeFakeGitBinary writes an executable shell script named "git" into a
+// fresh directory and returns that directory, for prepending to PATH.
+func writeFakeGitBinary(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "git")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	require.NoError(t, os.Chmod(path, 0755))
+	return dir
+}
+
+func TestRunLocalGitContextCommand_TimesOutOnHungGit(t *testing.T) {
+	binDir := writeFakeGitBinary(t, "#!/bin/sh\nsleep 5\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prev := localGitCommandTimeout
+	localGitCommandTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { localGitCommandTimeout = prev })
+
+	start := time.Now()
+	_, err := runLocalGitContextCommand(
+		t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
+	)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "runLocalGitContextCommand should be bounded by localGitCommandTimeout")
+}
+
+func TestRunLocalGitContextCommand_ReturnsOutputBeforeTimeout(t *testing.T) {
+	binDir := writeFakeGitBinary(t, "#!/bin/sh\necho /repo/main\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := runLocalGitContextCommand(
+		t.TempDir(), t.TempDir(), "rev-parse --show-toplevel", "rev-parse", "--show-toplevel",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main\n", string(out))
+}
+
+func TestLocalGitOptionalMetadata_TimesOutOnHungGit(t *testing.T) {
+	binDir := writeFakeGitBinary(t, "#!/bin/sh\nsleep 5\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prev := localGitCommandTimeout
+	localGitCommandTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { localGitCommandTimeout = prev })
+
+	start := time.Now()
+	branch, origin := localGitOptionalMetadata(t.TempDir())
+	elapsed := time.Since(start)
+
+	assert.Empty(t, branch)
+	assert.Empty(t, origin)
+	assert.Less(t, elapsed, 2*time.Second, "localGitOptionalMetadata should be bounded by localGitCommandTimeout")
+}
+
 func TestLookupPRInfo_TimesOutAndFallsBack(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), session.NewManager())
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nsleep 1\n")

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
@@ -25,6 +27,12 @@ var getPIDCWDFn = getPIDCWD
 var openFilePathsForPIDFn = openFilePathsForPID
 var userHomeDirFn = os.UserHomeDir
 var readFileFn = os.ReadFile
+
+// localExecTimeout bounds how long a single local `ps`/`lsof` CLI invocation
+// may block before being killed. Without this, a wedged process-inspection
+// call left GetActiveWorkdirs/GetCWD blocked indefinitely. Package-level so
+// tests can shrink it.
+var localExecTimeout = 5 * time.Second
 
 // validShellPath matches a valid absolute shell path.
 // Only alphanumeric characters, dots, underscores, hyphens, and slashes are permitted.
@@ -166,18 +174,26 @@ func (s *LocalSession) GetActiveWorkdirs() ([]string, error) {
 	return resolveInteractiveAgentWorkdirs(processes, pid, baseCWD)
 }
 
+// goosDarwin names the darwin GOOS value used by the lsof-based fallback
+// paths below (getPIDCWD, openFilePathsForPID), so darwin-specific logic and
+// tests referencing it don't repeat the string literal.
+const goosDarwin = "darwin"
+
 func getPIDCWD(pid int) (string, error) {
 	switch runtime.GOOS {
 	case "linux":
 		return os.Readlink("/proc/" + strconv.Itoa(pid) + "/cwd")
-	case "darwin":
+	case goosDarwin:
 		pidArg, err := processIDArg(pid)
 		if err != nil {
 			return "", err
 		}
 		// -a ANDs the -p and -d conditions; without -a they are OR'd, which
 		// causes -d cwd to dump the cwd of every process on the system.
-		out, err := exec.Command(
+		ctx, cancel := context.WithTimeout(context.Background(), localExecTimeout)
+		defer cancel()
+		out, err := exec.CommandContext(
+			ctx,
 			"lsof",
 			"-a",
 			"-p",
@@ -217,7 +233,9 @@ var validProcessIDArg = regexp.MustCompile(`^[1-9][0-9]*$`)
 var validLocalUsername = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 func listProcesses() ([]processInfo, error) {
-	out, err := exec.Command("ps", "-Ao", "pid,ppid,command").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), localExecTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-Ao", "pid,ppid,command").Output()
 	if err != nil {
 		return nil, fmt.Errorf("ps: %w", err)
 	}
@@ -574,12 +592,15 @@ func openFilePathsForPID(pid int) ([]string, error) {
 			}
 		}
 		return paths, nil
-	case "darwin":
+	case goosDarwin:
 		pidArg, err := processIDArg(pid)
 		if err != nil {
 			return nil, err
 		}
-		out, err := exec.Command(
+		ctx, cancel := context.WithTimeout(context.Background(), localExecTimeout)
+		defer cancel()
+		out, err := exec.CommandContext(
+			ctx,
 			"lsof",
 			"-a",
 			"-p",

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -1614,4 +1615,100 @@ func TestTmuxLocalSessionGetActiveWorkdir_WhenPanePIDIsCodex_PrefersCodexExecCom
 	cwds, err := tmuxLocalActiveWorkdirs("demo")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"/tmp/tmux-root-codex-worktree"}, cwds)
+}
+
+// writeFakeBinary writes an executable shell script named binName into a
+// fresh directory and returns that directory, for prepending to PATH.
+func writeFakeBinary(t *testing.T, binName, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, binName)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	require.NoError(t, os.Chmod(path, 0755))
+	return dir
+}
+
+func TestTmuxLocalOutputFn_TimesOutOnHungTmux(t *testing.T) {
+	binDir := writeFakeBinary(t, "tmux", "#!/bin/sh\nsleep 5\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prevTimeout := tmuxExecTimeout
+	tmuxExecTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { tmuxExecTimeout = prevTimeout })
+
+	start := time.Now()
+	_, err := tmuxLocalOutputFn("display-message", "-p", "-t", "demo", "#{pane_current_path}")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "tmuxLocalOutputFn should be bounded by tmuxExecTimeout, not the sleep")
+}
+
+func TestTmuxLocalOutputFn_ReturnsOutputBeforeTimeout(t *testing.T) {
+	binDir := writeFakeBinary(t, "tmux", "#!/bin/sh\necho /repo/main\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := tmuxLocalOutputFn("display-message", "-p", "-t", "demo", "#{pane_current_path}")
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/main\n", string(out))
+}
+
+func TestListProcesses_TimesOutOnHungPS(t *testing.T) {
+	binDir := writeFakeBinary(t, "ps", "#!/bin/sh\nsleep 5\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	prevTimeout := localExecTimeout
+	localExecTimeout = 10 * time.Millisecond
+	t.Cleanup(func() { localExecTimeout = prevTimeout })
+
+	start := time.Now()
+	_, err := listProcesses()
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second, "listProcesses should be bounded by localExecTimeout, not the sleep")
+}
+
+func TestListProcesses_ReturnsOutputBeforeTimeout(t *testing.T) {
+	binDir := writeFakeBinary(t, "ps", "#!/bin/sh\necho '  PID  PPID COMMAND'\necho '   1     0 init'\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	processes, err := listProcesses()
+	require.NoError(t, err)
+	assert.Equal(t, []processInfo{{PID: 1, PPID: 0, Command: "init"}}, processes)
+}
+
+// TestDarwinLsofCallers_TimeOutOnHungLsof covers the two darwin-only
+// lsof-backed helpers (getPIDCWD, openFilePathsForPID) with the same
+// hung-binary/timeout scenario, table-driven to avoid duplicating the setup.
+func TestDarwinLsofCallers_TimeOutOnHungLsof(t *testing.T) {
+	if runtime.GOOS != goosDarwin {
+		t.Skip("lsof-based helpers only run on darwin")
+	}
+
+	tests := []struct {
+		call func() error
+		name string
+	}{
+		{name: "getPIDCWD", call: func() error { _, err := getPIDCWD(1); return err }},
+		{name: "openFilePathsForPID", call: func() error { _, err := openFilePathsForPID(1); return err }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := writeFakeBinary(t, "lsof", "#!/bin/sh\nsleep 5\n")
+			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			prevTimeout := localExecTimeout
+			localExecTimeout = 10 * time.Millisecond
+			t.Cleanup(func() { localExecTimeout = prevTimeout })
+
+			start := time.Now()
+			err := tt.call()
+			elapsed := time.Since(start)
+
+			require.Error(t, err)
+			assert.Less(t, elapsed, 2*time.Second, "should be bounded by localExecTimeout, not the fake binary's sleep")
+		})
+	}
 }

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -1629,7 +1629,7 @@ func writeFakeBinary(t *testing.T, binName, body string) string {
 }
 
 func TestTmuxLocalOutputFn_TimesOutOnHungTmux(t *testing.T) {
-	binDir := writeFakeBinary(t, "tmux", "#!/bin/sh\nsleep 5\n")
+	binDir := writeFakeBinary(t, "tmux", "#!/bin/sh\nexec sleep 5\n")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	prevTimeout := tmuxExecTimeout
@@ -1654,7 +1654,7 @@ func TestTmuxLocalOutputFn_ReturnsOutputBeforeTimeout(t *testing.T) {
 }
 
 func TestListProcesses_TimesOutOnHungPS(t *testing.T) {
-	binDir := writeFakeBinary(t, "ps", "#!/bin/sh\nsleep 5\n")
+	binDir := writeFakeBinary(t, "ps", "#!/bin/sh\nexec sleep 5\n")
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	prevTimeout := localExecTimeout
@@ -1696,7 +1696,7 @@ func TestDarwinLsofCallers_TimeOutOnHungLsof(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			binDir := writeFakeBinary(t, "lsof", "#!/bin/sh\nsleep 5\n")
+			binDir := writeFakeBinary(t, "lsof", "#!/bin/sh\nexec sleep 5\n")
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 			prevTimeout := localExecTimeout

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -37,17 +37,18 @@ const invalidRemotePathMsg = "must be an absolute path with no shell metacharact
 
 // SSHSession manages an SSH connection with a PTY.
 type SSHSession struct {
-	client     *ssh.Client
-	session    *ssh.Session
-	jumpClient *ssh.Client // non-nil when connected via ProxyJump; closed after client
-	stdin      io.WriteCloser
-	// combined reader for stdout+stderr
-	reader         io.Reader
-	id             string
-	title          string
-	connectionName string
-	state          State
-	mu             sync.RWMutex
+	stdin             io.WriteCloser
+	reader            io.Reader
+	client            *ssh.Client
+	session           *ssh.Session
+	jumpClient        *ssh.Client
+	keepaliveStop     chan struct{}
+	id                string
+	title             string
+	connectionName    string
+	state             State
+	mu                sync.RWMutex
+	keepaliveStopOnce sync.Once
 }
 
 type sshSessionRunner interface {
@@ -382,6 +383,7 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		reader:         pr,
 		connectionName: cfg.ConnectionName,
 		jumpClient:     jumpClient,
+		keepaliveStop:  make(chan struct{}),
 	}
 
 	monitorSSHSession(sess, pw, func(state State) {
@@ -389,6 +391,8 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		defer s.mu.Unlock()
 		s.state = state
 	})
+
+	startSSHKeepalive(client, s.keepaliveStop, sshKeepaliveOnDeadFn(client, jumpClient))
 
 	return s, nil
 }
@@ -516,7 +520,7 @@ func DetectRemoteShell(cfg SSHConfig) (string, error) {
 	}
 	defer sess.Close()
 
-	out, err := sess.Output("echo $SHELL")
+	out, err := runOutputWithTimeout(sess.Output, sess.Close, "echo $SHELL", sshInteractiveTimeout)
 	if err != nil {
 		return "", fmt.Errorf("detecting remote shell: %w", err)
 	}
@@ -553,7 +557,9 @@ func ListRemoteDirectories(cfg SSHConfig, path string, showHidden bool) ([]Direc
 	}
 	defer sess.Close()
 
-	out, err := sess.Output(remoteDirectoryListCommand(path, showHidden))
+	out, err := runOutputWithTimeout(
+		sess.Output, sess.Close, remoteDirectoryListCommand(path, showHidden), sshInteractiveTimeout,
+	)
 	if err != nil {
 		return nil, "", fmt.Errorf("listing remote directories: %w", err)
 	}
@@ -772,6 +778,8 @@ func (s *SSHSession) Resize(cols, rows uint16) error {
 }
 
 func (s *SSHSession) Close() error {
+	s.keepaliveStopOnce.Do(func() { close(s.keepaliveStop) })
+
 	s.mu.Lock()
 	s.state = StateExited
 	s.mu.Unlock()
@@ -833,7 +841,7 @@ func (s *SSHSession) GetCWD() (string, error) {
 		return "", fmt.Errorf("new ssh session for cwd: %w", err)
 	}
 	defer sess.Close()
-	out, err := sess.Output(sshGetCWDCmd)
+	out, err := runOutputWithTimeout(sess.Output, sess.Close, sshGetCWDCmd, sshRunTimeout)
 	if err != nil {
 		return "", fmt.Errorf("cwd over ssh: %w", err)
 	}
@@ -852,7 +860,11 @@ func (s *SSHSession) GetActiveWorkdirs() ([]string, error) {
 
 	return activeRemoteWorkdirsFromSessionFactory(
 		func() (sshSessionRunner, error) {
-			return s.client.NewSession()
+			sess, err := s.client.NewSession()
+			if err != nil {
+				return nil, err
+			}
+			return &timeoutSessionRunner{sess: sess}, nil
 		},
 		fmt.Sprintf("session=%s type=%s", s.id, s.Type()),
 		baseCWD,
@@ -868,7 +880,7 @@ func (s *SSHSession) InspectGitContext(cwd string) (GitContext, error) {
 	}
 	defer sess.Close()
 
-	return remoteGitContext(sess, cwd)
+	return remoteGitContext(&timeoutSessionRunner{sess: sess}, cwd)
 }
 
 func remoteShellPID(runner sshSessionRunner) (int, error) {

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -386,13 +386,7 @@ func NewSSH(id, title string, cfg SSHConfig) (*SSHSession, error) {
 		keepaliveStop:  make(chan struct{}),
 	}
 
-	monitorSSHSession(sess, pw, func(state State) {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		s.state = state
-	})
-
-	startSSHKeepalive(client, s.keepaliveStop, sshKeepaliveOnDeadFn(client, jumpClient))
+	wireSSHSessionLifecycle(sess, pw, client, jumpClient, s.keepaliveStop, &s.mu, &s.state)
 
 	return s, nil
 }

--- a/internal/session/ssh_keepalive.go
+++ b/internal/session/ssh_keepalive.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"io"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -28,16 +30,57 @@ type sshKeepaliveSender interface {
 }
 
 // sshKeepaliveOnDeadFn builds the onDead callback shared by NewSSH and
-// NewTmuxSSH: on transport death, close the primary client (and jump client,
-// if any) so the session's existing monitorSSHSession/classifySSHWaitError
-// machinery observes the resulting error and transitions state normally.
-func sshKeepaliveOnDeadFn(client, jumpClient *ssh.Client) func() {
+// NewTmuxSSH. It marks the session disconnected *before* closing the
+// client, then closes the primary client (and jump client, if any).
+//
+// Ordering matters here: forcing the transport closed makes the still-
+// pending monitorSSHSession goroutine's sess.Wait() return
+// *ssh.ExitMissingError — the same error golang.org/x/crypto/ssh returns
+// when a remote process's channel closes without ever sending a clean SSH
+// exit-status message, which is indistinguishable from "the transport was
+// severed out from under an in-flight session." classifySSHWaitError
+// therefore classifies it as StateExited, not StateDisconnected, which
+// would misreport a keepalive-detected network failure as a normal session
+// exit and could suppress the frontend's reconnect behavior. Setting
+// StateDisconnected first, combined with the guard in the markExited
+// closure passed to monitorSSHSession, ensures that later, less specific
+// classification never overwrites this one.
+func sshKeepaliveOnDeadFn(markDisconnected func(), client, jumpClient *ssh.Client) func() {
 	return func() {
+		markDisconnected()
 		client.Close()
 		if jumpClient != nil {
 			jumpClient.Close()
 		}
 	}
+}
+
+// wireSSHSessionLifecycle wires monitorSSHSession and startSSHKeepalive
+// together for a *ssh.Session-backed session (SSHSession, TmuxSSHSession),
+// sharing the state guard that keeps a keepalive-detected disconnect from
+// being downgraded back to StateExited by the session's own later Wait()
+// error — see sshKeepaliveOnDeadFn for why that distinction matters.
+// mu/state are the caller's own mutex-protected state field.
+func wireSSHSessionLifecycle(
+	sess *ssh.Session, pw *io.PipeWriter,
+	client, jumpClient *ssh.Client,
+	keepaliveStop chan struct{},
+	mu *sync.RWMutex, state *State,
+) {
+	monitorSSHSession(sess, pw, func(newState State) {
+		mu.Lock()
+		defer mu.Unlock()
+		if *state == StateDisconnected {
+			return
+		}
+		*state = newState
+	})
+
+	startSSHKeepalive(client, keepaliveStop, sshKeepaliveOnDeadFn(func() {
+		mu.Lock()
+		*state = StateDisconnected
+		mu.Unlock()
+	}, client, jumpClient))
 }
 
 // startSSHKeepalive runs a background probe loop and calls onDead once

--- a/internal/session/ssh_keepalive.go
+++ b/internal/session/ssh_keepalive.go
@@ -45,6 +45,13 @@ type sshKeepaliveSender interface {
 // StateDisconnected first, combined with the guard in the markExited
 // closure passed to monitorSSHSession, ensures that later, less specific
 // classification never overwrites this one.
+//
+// markDisconnected itself must also refuse to overwrite an explicit
+// StateExited — see wireSSHSessionLifecycle's symmetric guard for why:
+// Close() can already have committed to StateExited before a probe that was
+// already in flight (blocked on SendRequest) unblocks via Close()'s own
+// client.Close() call and reports a failure, racing onDead in after the
+// fact.
 func sshKeepaliveOnDeadFn(markDisconnected func(), client, jumpClient *ssh.Client) func() {
 	return func() {
 		markDisconnected()
@@ -56,10 +63,24 @@ func sshKeepaliveOnDeadFn(markDisconnected func(), client, jumpClient *ssh.Clien
 }
 
 // wireSSHSessionLifecycle wires monitorSSHSession and startSSHKeepalive
-// together for a *ssh.Session-backed session (SSHSession, TmuxSSHSession),
-// sharing the state guard that keeps a keepalive-detected disconnect from
-// being downgraded back to StateExited by the session's own later Wait()
-// error — see sshKeepaliveOnDeadFn for why that distinction matters.
+// together for a *ssh.Session-backed session (SSHSession, TmuxSSHSession).
+// Both directions of state transition are mutually guarded so neither can
+// downgrade the other's more specific classification:
+//
+//   - monitorSSHSession's callback won't downgrade a keepalive-detected
+//     StateDisconnected back to StateExited when the session's own Wait()
+//     later returns (see sshKeepaliveOnDeadFn's doc comment).
+//   - the keepalive onDead callback won't overwrite an explicit
+//     Close()-driven StateExited with StateDisconnected. Close() sets
+//     StateExited and then closes the transport; if a keepalive probe was
+//     already blocked on SendRequest at that moment, close(keepaliveStop)
+//     doesn't reach it until the next loop iteration, but Close()'s own
+//     client.Close() call unblocks the in-flight SendRequest with an error
+//     first — which can push the loop's failure count over
+//     sshKeepaliveMaxFailures and fire onDead strictly after Close() already
+//     set StateExited. Without this guard, an intentional clean close could
+//     be reported as an unexpected disconnect.
+//
 // mu/state are the caller's own mutex-protected state field.
 func wireSSHSessionLifecycle(
 	sess *ssh.Session, pw *io.PipeWriter,
@@ -78,8 +99,11 @@ func wireSSHSessionLifecycle(
 
 	startSSHKeepalive(client, keepaliveStop, sshKeepaliveOnDeadFn(func() {
 		mu.Lock()
+		defer mu.Unlock()
+		if *state == StateExited {
+			return
+		}
 		*state = StateDisconnected
-		mu.Unlock()
 	}, client, jumpClient))
 }
 

--- a/internal/session/ssh_keepalive.go
+++ b/internal/session/ssh_keepalive.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// sshKeepaliveInterval, sshKeepaliveProbeTimeout, and sshKeepaliveMaxFailures
+// are package-level so tests can shrink them. golang.org/x/crypto/ssh has no
+// equivalent to OpenSSH's ServerAliveInterval/ServerAliveCountMax: a
+// half-dead TCP connection (packets black-holed in one or both directions,
+// no RST/FIN) otherwise leaves Read/Write/NewSession/Session.Wait blocked
+// forever with no signal from the standard library. This probe loop detects
+// that and forces the transport closed so the rest of the session lifecycle
+// (monitorSSHSession/classifySSHWaitError) can react normally.
+var (
+	sshKeepaliveInterval     = 15 * time.Second
+	sshKeepaliveProbeTimeout = 10 * time.Second
+	sshKeepaliveMaxFailures  = 2
+)
+
+// sshKeepaliveSender is the subset of *ssh.Client used by the keepalive
+// probe, extracted so tests can inject a fake instead of standing up a real
+// SSH server for every failure-path test.
+type sshKeepaliveSender interface {
+	SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+// sshKeepaliveOnDeadFn builds the onDead callback shared by NewSSH and
+// NewTmuxSSH: on transport death, close the primary client (and jump client,
+// if any) so the session's existing monitorSSHSession/classifySSHWaitError
+// machinery observes the resulting error and transitions state normally.
+func sshKeepaliveOnDeadFn(client, jumpClient *ssh.Client) func() {
+	return func() {
+		client.Close()
+		if jumpClient != nil {
+			jumpClient.Close()
+		}
+	}
+}
+
+// startSSHKeepalive runs a background probe loop and calls onDead once
+// sshKeepaliveMaxFailures consecutive probes fail or time out. It exits
+// after calling onDead, or immediately once stop is closed — whichever
+// happens first.
+func startSSHKeepalive(client sshKeepaliveSender, stop <-chan struct{}, onDead func()) {
+	go sshKeepaliveLoop(client, stop, onDead, sshKeepaliveInterval, sshKeepaliveProbeTimeout, sshKeepaliveMaxFailures)
+}
+
+// sshKeepaliveLoop is startSSHKeepalive's body, with the timing/threshold
+// values passed explicitly rather than read from the package-level vars.
+// Extracted so tests can run the loop synchronously (or in a goroutine they
+// can wait on) with test-local values, instead of racing a background
+// goroutine against a t.Cleanup that mutates the shared package vars.
+func sshKeepaliveLoop(
+	client sshKeepaliveSender,
+	stop <-chan struct{},
+	onDead func(),
+	interval, probeTimeout time.Duration,
+	maxFailures int,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	failures := 0
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			if sshKeepaliveProbe(client, probeTimeout) {
+				failures = 0
+				continue
+			}
+			failures++
+			if failures >= maxFailures {
+				onDead()
+				return
+			}
+		}
+	}
+}
+
+// sshKeepaliveProbe sends an unrecognized global request and treats any
+// reply (including the SSH_MSG_REQUEST_FAILURE a compliant server sends for
+// an unknown request name) as proof the transport is alive — the same trick
+// OpenSSH's own ServerAliveInterval uses. Returns false if SendRequest
+// returns an error or does not return within timeout.
+func sshKeepaliveProbe(client sshKeepaliveSender, timeout time.Duration) bool {
+	done := make(chan bool, 1)
+	go func() {
+		_, _, err := client.SendRequest("keepalive@panemux", true, nil)
+		done <- err == nil
+	}()
+	select {
+	case ok := <-done:
+		return ok
+	case <-time.After(timeout):
+		return false // the abandoned probe goroutine above unblocks once the
+		// caller's onDead() closes the underlying client; harmless until then.
+	}
+}

--- a/internal/session/ssh_keepalive_integration_test.go
+++ b/internal/session/ssh_keepalive_integration_test.go
@@ -211,3 +211,74 @@ func TestSSHSession_KeepaliveDoesNotDisconnectHealthyTransport(t *testing.T) {
 	time.Sleep(15 * sshKeepaliveInterval)
 	assert.Equal(t, StateConnected, sess.State(), "a transport that keeps answering keepalive probes must stay connected")
 }
+
+// TestSSHSession_CloseDuringInFlightKeepaliveProbe_StaysExited is the
+// regression test for the reviewer-flagged race in sshKeepaliveOnDeadFn:
+// Close() sets StateExited and then closes the transport; if a keepalive
+// probe was already blocked on SendRequest at that moment,
+// close(keepaliveStop) doesn't reach the loop until its next iteration, but
+// Close()'s own client.Close() call unblocks the in-flight SendRequest with
+// an error first. With sshKeepaliveMaxFailures set to 1, that single
+// failure is enough to fire onDead strictly after Close() already set
+// StateExited. Without a guard in markDisconnected mirroring the one
+// monitorSSHSession's callback already has, this would overwrite an
+// intentional clean close with StateDisconnected.
+func TestSSHSession_CloseDuringInFlightKeepaliveProbe_StaysExited(t *testing.T) {
+	prevInterval := sshKeepaliveInterval
+	prevProbeTimeout := sshKeepaliveProbeTimeout
+	prevMaxFailures := sshKeepaliveMaxFailures
+	sshKeepaliveInterval = 10 * time.Millisecond
+	// Long enough that the test can reliably call Close() while this
+	// probe is still blocked waiting for a reply that never comes.
+	sshKeepaliveProbeTimeout = 300 * time.Millisecond
+	sshKeepaliveMaxFailures = 1
+	t.Cleanup(func() {
+		sshKeepaliveInterval = prevInterval
+		sshKeepaliveProbeTimeout = prevProbeTimeout
+		sshKeepaliveMaxFailures = prevMaxFailures
+	})
+
+	probeStarted := make(chan struct{}, 1)
+	host, port, hostKey := startTestSSHServer(t, func(reqs <-chan *gossh.Request) {
+		for range reqs {
+			select {
+			case probeStarted <- struct{}{}:
+			default:
+			}
+			// Never reply: this probe stays in flight until client.Close()
+			// (called by SSHSession.Close(), below) unblocks it with an error.
+		}
+	})
+
+	knownHostsPath := writeTestKnownHosts(t, host, port, hostKey)
+	cfg := SSHConfig{
+		Host:           host,
+		Port:           port,
+		User:           "test",
+		Password:       "test",
+		KnownHostsFile: knownHostsPath,
+	}
+
+	sess, err := NewSSH("close-race-test", "close race test", cfg)
+	require.NoError(t, err)
+
+	select {
+	case <-probeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a keepalive probe to start")
+	}
+
+	// Close() sets StateExited synchronously before it closes the
+	// transport, which is what will unblock the in-flight probe above.
+	require.NoError(t, sess.Close())
+	assert.Equal(t, StateExited, sess.State())
+
+	// Give the keepalive loop time to actually observe the now-failing
+	// probe and call onDead, proving the guard — not just timing luck —
+	// is what keeps the state at StateExited.
+	time.Sleep(5 * sshKeepaliveProbeTimeout)
+	assert.Equal(
+		t, StateExited, sess.State(),
+		"an in-flight keepalive probe's failure must not overwrite an explicit Close()",
+	)
+}

--- a/internal/session/ssh_keepalive_integration_test.go
+++ b/internal/session/ssh_keepalive_integration_test.go
@@ -1,0 +1,213 @@
+package session
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// startTestSSHServer starts a minimal in-process SSH server on loopback that
+// accepts any password, completes the handshake, and satisfies the pty-req
+// and shell requests NewSSH needs to establish a session. globalReqHandler
+// receives every global request (e.g. the keepalive probe's
+// "keepalive@panemux") so a test can control exactly which ones get a
+// reply, simulating a transport that stops responding without a clean
+// TCP close. Returns the server's host, port, and host public key.
+func startTestSSHServer(
+	t *testing.T,
+	globalReqHandler func(reqs <-chan *gossh.Request),
+) (host string, port int, hostKey gossh.PublicKey) {
+	t.Helper()
+
+	hostKeyPath := filepath.Join(t.TempDir(), "host_key")
+	generateTestKeyFile(t, hostKeyPath)
+	keyData, err := os.ReadFile(hostKeyPath)
+	require.NoError(t, err)
+	signer, err := gossh.ParsePrivateKey(keyData)
+	require.NoError(t, err)
+
+	config := &gossh.ServerConfig{
+		PasswordCallback: func(conn gossh.ConnMetadata, password []byte) (*gossh.Permissions, error) {
+			return nil, nil // accept any credentials; this is a local test fixture, not a real auth boundary
+		},
+	}
+	config.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go serveTestSSHConn(conn, config, globalReqHandler)
+		}
+	}()
+
+	hostStr, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	portNum, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	return hostStr, portNum, signer.PublicKey()
+}
+
+func serveTestSSHConn(conn net.Conn, config *gossh.ServerConfig, globalReqHandler func(reqs <-chan *gossh.Request)) {
+	sshConn, chans, reqs, err := gossh.NewServerConn(conn, config)
+	if err != nil {
+		conn.Close()
+		return
+	}
+	defer sshConn.Close()
+
+	go globalReqHandler(reqs)
+
+	for newChannel := range chans {
+		ch, requests, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+		go serveTestSSHChannel(ch, requests)
+	}
+}
+
+// serveTestSSHChannel answers just enough channel requests (pty-req, shell)
+// for NewSSH's setup sequence (RequestPty + Shell) to succeed, and rejects
+// anything else it doesn't recognize.
+func serveTestSSHChannel(ch gossh.Channel, requests <-chan *gossh.Request) {
+	defer ch.Close()
+	for req := range requests {
+		switch req.Type {
+		case "pty-req", "shell":
+			if req.WantReply {
+				req.Reply(true, nil) //nolint:errcheck // best-effort test fixture reply
+			}
+		default:
+			if req.WantReply {
+				req.Reply(false, nil) //nolint:errcheck // best-effort test fixture reply
+			}
+		}
+	}
+}
+
+// writeTestKnownHosts writes a known_hosts file with a single entry matching
+// host:port -> hostKey, in the format golang.org/x/crypto/ssh/knownhosts
+// expects, and returns its path.
+func writeTestKnownHosts(t *testing.T, host string, port int, hostKey gossh.PublicKey) string {
+	t.Helper()
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	line := knownhosts.Line([]string{knownhosts.Normalize(addr)}, hostKey)
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(path, []byte(line+"\n"), 0600))
+	return path
+}
+
+// TestSSHSession_KeepaliveDetectsDeadTransport is the end-to-end regression
+// test for the reported pane-hang bug: golang.org/x/crypto/ssh has no
+// ServerAliveInterval equivalent, so before the keepalive probe was added, a
+// transport that silently stopped responding (no clean TCP close, no error)
+// left the session in StateConnected forever. This test simulates exactly
+// that — the server accepts the first keepalive probe, then goes silent —
+// and verifies the session detects it and transitions to StateDisconnected
+// within the shrunk keepalive window, instead of hanging indefinitely.
+func TestSSHSession_KeepaliveDetectsDeadTransport(t *testing.T) {
+	prevInterval := sshKeepaliveInterval
+	prevProbeTimeout := sshKeepaliveProbeTimeout
+	prevMaxFailures := sshKeepaliveMaxFailures
+	sshKeepaliveInterval = 20 * time.Millisecond
+	sshKeepaliveProbeTimeout = 50 * time.Millisecond
+	sshKeepaliveMaxFailures = 2
+	t.Cleanup(func() {
+		sshKeepaliveInterval = prevInterval
+		sshKeepaliveProbeTimeout = prevProbeTimeout
+		sshKeepaliveMaxFailures = prevMaxFailures
+	})
+
+	var probeCount int32
+	host, port, hostKey := startTestSSHServer(t, func(reqs <-chan *gossh.Request) {
+		for req := range reqs {
+			n := atomic.AddInt32(&probeCount, 1)
+			if n == 1 && req.WantReply {
+				// First probe succeeds — proves the happy path still works
+				// before the transport goes silent.
+				req.Reply(false, nil) //nolint:errcheck // best-effort test fixture reply
+				continue
+			}
+			// Every subsequent probe is left unanswered: the transport is
+			// still technically open (no TCP close), but nothing ever
+			// replies, exactly like a network black hole.
+		}
+	})
+
+	knownHostsPath := writeTestKnownHosts(t, host, port, hostKey)
+	cfg := SSHConfig{
+		Host:           host,
+		Port:           port,
+		User:           "test",
+		Password:       "test",
+		KnownHostsFile: knownHostsPath,
+	}
+
+	sess, err := NewSSH("keepalive-test", "keepalive test", cfg)
+	require.NoError(t, err)
+	defer sess.Close()
+
+	require.Equal(t, StateConnected, sess.State())
+
+	assert.Eventually(t, func() bool {
+		return sess.State() == StateDisconnected
+	}, 5*time.Second, 10*time.Millisecond, "keepalive should detect the dead transport and disconnect")
+
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&probeCount)), 2, "expected a success then a failing probe")
+}
+
+// TestSSHSession_KeepaliveDoesNotDisconnectHealthyTransport is the
+// counterpart to the detection test above: a server that keeps answering
+// every keepalive probe must never be marked disconnected by the keepalive
+// loop on its own.
+func TestSSHSession_KeepaliveDoesNotDisconnectHealthyTransport(t *testing.T) {
+	prevInterval := sshKeepaliveInterval
+	prevProbeTimeout := sshKeepaliveProbeTimeout
+	sshKeepaliveInterval = 20 * time.Millisecond
+	sshKeepaliveProbeTimeout = 50 * time.Millisecond
+	t.Cleanup(func() {
+		sshKeepaliveInterval = prevInterval
+		sshKeepaliveProbeTimeout = prevProbeTimeout
+	})
+
+	host, port, hostKey := startTestSSHServer(t, func(reqs <-chan *gossh.Request) {
+		for req := range reqs {
+			if req.WantReply {
+				req.Reply(false, nil) //nolint:errcheck // best-effort test fixture reply
+			}
+		}
+	})
+
+	knownHostsPath := writeTestKnownHosts(t, host, port, hostKey)
+	cfg := SSHConfig{
+		Host:           host,
+		Port:           port,
+		User:           "test",
+		Password:       "test",
+		KnownHostsFile: knownHostsPath,
+	}
+
+	sess, err := NewSSH("keepalive-healthy-test", "keepalive healthy test", cfg)
+	require.NoError(t, err)
+	defer sess.Close()
+
+	time.Sleep(15 * sshKeepaliveInterval)
+	assert.Equal(t, StateConnected, sess.State(), "a transport that keeps answering keepalive probes must stay connected")
+}

--- a/internal/session/ssh_keepalive_test.go
+++ b/internal/session/ssh_keepalive_test.go
@@ -1,0 +1,184 @@
+package session
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeKeepaliveSender struct {
+	sendRequestFn func(name string, wantReply bool, payload []byte) (bool, []byte, error)
+}
+
+func (f *fakeKeepaliveSender) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	return f.sendRequestFn(name, wantReply, payload)
+}
+
+// testKeepaliveInterval/testKeepaliveProbeTimeout/testKeepaliveMaxFailures
+// are passed explicitly into sshKeepaliveLoop rather than mutating the
+// package-level sshKeepaliveInterval/sshKeepaliveProbeTimeout/
+// sshKeepaliveMaxFailures vars, so a still-running loop goroutine from one
+// test can never race a later test's (or the same test's t.Cleanup)
+// assignment to those package vars.
+const (
+	testKeepaliveInterval     = 10 * time.Millisecond
+	testKeepaliveProbeTimeout = 20 * time.Millisecond
+	testKeepaliveMaxFailures  = 2
+)
+
+func runTestKeepaliveLoop(client sshKeepaliveSender, stop <-chan struct{}, onDead func()) {
+	sshKeepaliveLoop(client, stop, onDead, testKeepaliveInterval, testKeepaliveProbeTimeout, testKeepaliveMaxFailures)
+}
+
+func TestSSHKeepaliveLoop_ConsecutiveSuccessesNeverCallOnDead(t *testing.T) {
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			return false, nil, nil
+		},
+	}
+	var onDeadCalls int32
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		runTestKeepaliveLoop(sender, stop, func() { atomic.AddInt32(&onDeadCalls, 1) })
+		close(done)
+	}()
+
+	time.Sleep(15 * testKeepaliveInterval)
+	assert.Zero(t, atomic.LoadInt32(&onDeadCalls))
+
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected the loop to exit after stop was closed")
+	}
+}
+
+func TestSSHKeepaliveLoop_ConsecutiveFailuresCallOnDeadOnce(t *testing.T) {
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			return false, nil, errors.New("connection reset")
+		},
+	}
+	onDeadCh := make(chan struct{}, 10)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+
+	go runTestKeepaliveLoop(sender, stop, func() { onDeadCh <- struct{}{} })
+
+	select {
+	case <-onDeadCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected onDead to be called after sshKeepaliveMaxFailures consecutive failures")
+	}
+
+	// onDead should be called exactly once — the loop exits after triggering
+	// it, it does not keep firing.
+	time.Sleep(10 * testKeepaliveInterval)
+	assert.Len(t, onDeadCh, 0, "onDead should fire exactly once; the loop must exit after triggering it")
+}
+
+func TestSSHKeepaliveLoop_SingleFailureThenSuccessResetsCounter(t *testing.T) {
+	var callCount int32
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			n := atomic.AddInt32(&callCount, 1)
+			if n == 1 {
+				return false, nil, errors.New("transient failure")
+			}
+			return false, nil, nil // recover on every subsequent probe
+		},
+	}
+	var onDeadCalls int32
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+
+	go runTestKeepaliveLoop(sender, stop, func() { atomic.AddInt32(&onDeadCalls, 1) })
+
+	// Give it enough ticks that sshKeepaliveMaxFailures would have fired if
+	// the single early failure weren't reset by the following success.
+	time.Sleep(15 * testKeepaliveInterval)
+	assert.Zero(t, atomic.LoadInt32(&onDeadCalls))
+	assert.GreaterOrEqual(t, int(atomic.LoadInt32(&callCount)), 3)
+}
+
+func TestSSHKeepaliveLoop_StopClosesLoopBeforeNextTick(t *testing.T) {
+	var callCount int32
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			atomic.AddInt32(&callCount, 1)
+			return false, nil, nil
+		},
+	}
+	stop := make(chan struct{})
+
+	go runTestKeepaliveLoop(sender, stop, func() {})
+	time.Sleep(3 * testKeepaliveInterval)
+	close(stop)
+	// Allow whichever tick/stop the select was already racing between to
+	// settle before sampling the count, since closing stop does not
+	// retroactively cancel a select that had already chosen the ticker.C
+	// branch on this iteration.
+	time.Sleep(2 * testKeepaliveInterval)
+	countAtStop := atomic.LoadInt32(&callCount)
+
+	time.Sleep(10 * testKeepaliveInterval)
+	assert.Equal(t, countAtStop, atomic.LoadInt32(&callCount), "no further probes should run after stop is closed")
+}
+
+func TestSSHKeepaliveProbe_TimesOutWhenSendRequestNeverReturns(t *testing.T) {
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			<-block
+			return false, nil, nil
+		},
+	}
+
+	start := time.Now()
+	ok := sshKeepaliveProbe(sender, 10*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.False(t, ok)
+	assert.Less(t, elapsed, time.Second)
+}
+
+func TestSSHKeepaliveProbe_TrueOnSuccessOrExpectedRequestFailure(t *testing.T) {
+	// An unrecognized global request name gets SSH_MSG_REQUEST_FAILURE from a
+	// compliant server, which the golang.org/x/crypto/ssh client surfaces as
+	// (false, nil, nil) rather than an error — that reply is itself proof of
+	// liveness, matching OpenSSH's ServerAliveInterval trick.
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			require.Equal(t, "keepalive@panemux", name)
+			return false, nil, nil
+		},
+	}
+	assert.True(t, sshKeepaliveProbe(sender, time.Second))
+}
+
+// TestStartSSHKeepalive_UsesPackageLevelDefaults is a thin smoke test that
+// startSSHKeepalive wires the package-level sshKeepaliveInterval/
+// sshKeepaliveProbeTimeout/sshKeepaliveMaxFailures vars into the loop; the
+// loop's actual branching logic is covered by the TestSSHKeepaliveLoop_*
+// tests above via explicit test-local values.
+func TestStartSSHKeepalive_UsesPackageLevelDefaults(t *testing.T) {
+	sender := &fakeKeepaliveSender{
+		sendRequestFn: func(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+			return false, nil, nil
+		},
+	}
+	stop := make(chan struct{})
+
+	startSSHKeepalive(sender, stop, func() {})
+	close(stop) // exit promptly; this test only checks that it starts without panicking
+	time.Sleep(10 * time.Millisecond)
+}

--- a/internal/session/ssh_timeout.go
+++ b/internal/session/ssh_timeout.go
@@ -1,0 +1,67 @@
+package session
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// sshRunTimeout bounds how long a single SSH exec-channel command (tmux
+// display-message, git inspection, ps, cat, etc.) may block before the
+// underlying *ssh.Session is force-closed to unblock the caller. Without
+// this, ssh.Session.Output has no way to time out on its own: a wedged
+// remote command (e.g. a stuck remote tmux server) leaves the exec channel
+// open forever. Package-level so tests can shrink it.
+var sshRunTimeout = 5 * time.Second
+
+// sshInteractiveTimeout bounds user-triggered SSH commands (directory
+// browsing, remote shell detection) that are not part of the background
+// polling path and can tolerate a slightly longer bound than sshRunTimeout.
+var sshInteractiveTimeout = 10 * time.Second
+
+// runOutputWithTimeout runs outputFn(cmd) and returns its result, or a
+// timeout error if it does not return within timeout. On timeout it calls
+// closeFn to force the underlying session closed, which unblocks the
+// still-running outputFn call (whose result is then discarded on the
+// abandoned goroutine). outputFn/closeFn are accepted as plain funcs (rather
+// than requiring a *ssh.Session directly) so the timeout race logic is
+// testable without a real SSH connection.
+func runOutputWithTimeout(
+	outputFn func(cmd string) ([]byte, error),
+	closeFn func() error,
+	cmd string,
+	timeout time.Duration,
+) ([]byte, error) {
+	type result struct {
+		err error
+		out []byte
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, err := outputFn(cmd)
+		done <- result{err: err, out: out}
+	}()
+	select {
+	case r := <-done:
+		return r.out, r.err
+	case <-time.After(timeout):
+		closeFn() //nolint:errcheck // best-effort unblock of the abandoned goroutine above
+		return nil, fmt.Errorf("ssh command timed out after %s", timeout)
+	}
+}
+
+// timeoutSessionRunner adapts *ssh.Session to sshSessionRunner, applying
+// sshRunTimeout to every Output call, for call sites that go through the
+// sshSessionRunner abstraction rather than calling sess.Output directly.
+type timeoutSessionRunner struct {
+	sess *ssh.Session
+}
+
+func (t *timeoutSessionRunner) Output(cmd string) ([]byte, error) {
+	return runOutputWithTimeout(t.sess.Output, t.sess.Close, cmd, sshRunTimeout)
+}
+
+func (t *timeoutSessionRunner) Close() error {
+	return t.sess.Close()
+}

--- a/internal/session/ssh_timeout_test.go
+++ b/internal/session/ssh_timeout_test.go
@@ -1,0 +1,66 @@
+package session
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunOutputWithTimeout_ReturnsResultBeforeTimeout(t *testing.T) {
+	outputFn := func(cmd string) ([]byte, error) { return []byte("ok: " + cmd), nil }
+	closeCalled := false
+	closeFn := func() error { closeCalled = true; return nil }
+
+	out, err := runOutputWithTimeout(outputFn, closeFn, "echo hi", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "ok: echo hi", string(out))
+	assert.False(t, closeCalled, "close should not be called when the command completes in time")
+}
+
+func TestRunOutputWithTimeout_PropagatesUnderlyingError(t *testing.T) {
+	wantErr := errors.New("boom")
+	outputFn := func(cmd string) ([]byte, error) { return nil, wantErr }
+	closeFn := func() error { return nil }
+
+	_, err := runOutputWithTimeout(outputFn, closeFn, "echo hi", time.Second)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestRunOutputWithTimeout_TimesOutAndClosesSession(t *testing.T) {
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+
+	outputFn := func(cmd string) ([]byte, error) {
+		<-block // simulate a command that never returns
+		return nil, nil
+	}
+	closeCalled := make(chan struct{}, 1)
+	closeFn := func() error { closeCalled <- struct{}{}; return nil }
+
+	start := time.Now()
+	_, err := runOutputWithTimeout(outputFn, closeFn, "hung command", 10*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, time.Second, "runOutputWithTimeout should return promptly once the timeout fires")
+	select {
+	case <-closeCalled:
+	case <-time.After(time.Second):
+		t.Fatal("expected close to be called on timeout to unblock the underlying command")
+	}
+}
+
+func TestRunOutputWithTimeout_CommandCompletesJustUnderTimeout(t *testing.T) {
+	outputFn := func(cmd string) ([]byte, error) {
+		time.Sleep(5 * time.Millisecond)
+		return []byte("done"), nil
+	}
+	closeFn := func() error { return nil }
+
+	out, err := runOutputWithTimeout(outputFn, closeFn, "echo hi", 200*time.Millisecond)
+	require.NoError(t, err)
+	assert.Equal(t, "done", string(out))
+}

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,12 +11,22 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
 
+// tmuxExecTimeout bounds how long a single local `tmux` CLI invocation (used
+// to query pane metadata such as cwd/pid, not to attach a session) may block
+// before being killed. Without this, a wedged local tmux server left
+// GetCWD/GetActiveWorkdirs blocked indefinitely, which in turn hung the
+// GetGitInfo HTTP handler. Package-level so tests can shrink it.
+var tmuxExecTimeout = 5 * time.Second
+
 var tmuxLocalOutputFn = func(args ...string) ([]byte, error) {
-	return exec.Command("tmux", args...).Output()
+	ctx, cancel := context.WithTimeout(context.Background(), tmuxExecTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, "tmux", args...).Output()
 }
 
 // TmuxLocalSession attaches to an existing local tmux session via PTY.

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -80,13 +80,7 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		keepaliveStop:  make(chan struct{}),
 	}
 
-	monitorSSHSession(sess, pw, func(state State) {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		s.state = state
-	})
-
-	startSSHKeepalive(client, s.keepaliveStop, sshKeepaliveOnDeadFn(client, jumpClient))
+	wireSSHSessionLifecycle(sess, pw, client, jumpClient, s.keepaliveStop, &s.mu, &s.state)
 
 	return s, nil
 }

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -16,29 +16,26 @@ var validTmuxSessionName = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 
 // TmuxSSHSession attaches to a tmux session on a remote host via SSH.
 type TmuxSSHSession struct {
-	client         *ssh.Client
-	session        *ssh.Session
-	jumpClient     *ssh.Client // non-nil when connected via ProxyJump; closed after client
-	stdin          io.WriteCloser
-	reader         io.Reader
-	id             string
-	title          string
-	tmuxSession    string
-	connectionName string
-	state          State
-	mu             sync.RWMutex
+	stdin             io.WriteCloser
+	reader            io.Reader
+	client            *ssh.Client
+	session           *ssh.Session
+	jumpClient        *ssh.Client
+	keepaliveStop     chan struct{}
+	title             string
+	tmuxSession       string
+	connectionName    string
+	state             State
+	id                string
+	mu                sync.RWMutex
+	keepaliveStopOnce sync.Once
 }
 
 // NewTmuxSSH creates a session that attaches to a remote tmux session.
 func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, error) {
-	if tmuxSession == "" {
-		tmuxSession = "0"
-	}
-	if !validTmuxSessionName.MatchString(tmuxSession) {
-		return nil, fmt.Errorf(
-			"invalid tmux session name %q: must match ^[a-zA-Z0-9_.-]+$",
-			tmuxSession,
-		)
+	tmuxSession, err := validateTmuxSessionName(tmuxSession)
+	if err != nil {
+		return nil, err
 	}
 
 	client, jumpClient, err := dialSSHClient(cfg)
@@ -80,6 +77,7 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		reader:         pr,
 		connectionName: cfg.ConnectionName,
 		jumpClient:     jumpClient,
+		keepaliveStop:  make(chan struct{}),
 	}
 
 	monitorSSHSession(sess, pw, func(state State) {
@@ -87,6 +85,8 @@ func NewTmuxSSH(id, title, tmuxSession string, cfg SSHConfig) (*TmuxSSHSession, 
 		defer s.mu.Unlock()
 		s.state = state
 	})
+
+	startSSHKeepalive(client, s.keepaliveStop, sshKeepaliveOnDeadFn(client, jumpClient))
 
 	return s, nil
 }
@@ -138,7 +138,12 @@ func (s *TmuxSSHSession) GetCWD() (string, error) {
 		return "", fmt.Errorf("new ssh session for tmux cwd: %w", err)
 	}
 	defer sess.Close()
-	out, err := sess.Output(fmt.Sprintf("tmux display-message -p -t '%s' '#{pane_current_path}'", s.tmuxSession))
+	out, err := runOutputWithTimeout(
+		sess.Output,
+		sess.Close,
+		fmt.Sprintf("tmux display-message -p -t '%s' '#{pane_current_path}'", s.tmuxSession),
+		sshRunTimeout,
+	)
 	if err != nil {
 		return "", fmt.Errorf("tmux display-message over ssh: %w", err)
 	}
@@ -152,7 +157,11 @@ func (s *TmuxSSHSession) GetCWD() (string, error) {
 func (s *TmuxSSHSession) GetActiveWorkdirs() ([]string, error) {
 	return tmuxSSHActiveWorkdirsFromSessionFactory(
 		func() (sshSessionRunner, error) {
-			return s.client.NewSession()
+			sess, err := s.client.NewSession()
+			if err != nil {
+				return nil, err
+			}
+			return &timeoutSessionRunner{sess: sess}, nil
 		},
 		fmt.Sprintf("session=%s type=%s tmux_session=%s", s.id, s.Type(), s.tmuxSession),
 		s.tmuxSession,
@@ -168,7 +177,7 @@ func (s *TmuxSSHSession) InspectGitContext(cwd string) (GitContext, error) {
 	}
 	defer sess.Close()
 
-	return remoteGitContext(sess, cwd)
+	return remoteGitContext(&timeoutSessionRunner{sess: sess}, cwd)
 }
 
 func parseRemoteTmuxPaneInfo(out []byte) (int, string, error) {
@@ -242,6 +251,8 @@ func tmuxSSHActiveWorkdirsFromSessionFactory(
 }
 
 func (s *TmuxSSHSession) Close() error {
+	s.keepaliveStopOnce.Do(func() { close(s.keepaliveStop) })
+
 	s.mu.Lock()
 	s.state = StateExited
 	s.mu.Unlock()


### PR DESCRIPTION
## Summary
- Pane metadata lookups (`GetCWD`, `GetActiveWorkdirs`, git-context inspection) ran tmux/ps/lsof/git commands and SSH exec-channel commands with no timeout, so a wedged remote tmux server or a hung `git` process left `GET /api/sessions/{id}/git-info` blocked indefinitely — observed in production as a 19-minute hang after opening the Pane Settings directory browser and cancelling it.
- `sshd`'s `ClientAliveInterval 60`/`ClientAliveCountMax 3` (max ~180s) ruled out a simple fully-dead-transport explanation for a 19-minute hang, pointing instead at an individual stuck remote command — the exec-timeout fix (Phase 1) is the direct fix for the reported symptom.
- SSH connections also had no liveness monitoring at all (`golang.org/x/crypto/ssh` has no `ServerAliveInterval` equivalent), so a half-dead transport left pane Read/Write/NewSession calls blocked forever with no way to detect the failure — this is the most likely cause of a pane's terminal appearing entirely unresponsive. Added as a defense-in-depth layer (Phase 2).

## Changes
- Added a package-level timeout to every local (`tmux`, `ps`, `lsof`, `git`) and SSH exec-channel command used for pane metadata inspection, following the existing `prLookupTimeout` pattern (5s for local/background-polling calls, 10s for user-triggered SSH calls like directory browsing).
- New `internal/session/ssh_timeout.go`: `runOutputWithTimeout` + `timeoutSessionRunner`, since `ssh.Session.Output` has no built-in timeout support.
- New `internal/session/ssh_keepalive.go`: background probe that sends an unrecognized SSH global request every 15s; two consecutive failures (~40s worst case) close the transport, which the existing `monitorSSHSession`/`classifySSHWaitError` machinery already reacts to by transitioning session state to `disconnected`.
- Bug found via an in-process fake-SSH-server integration test: forcing the transport closed made the pending `Session.Wait()` return `*ssh.ExitMissingError`, which was misclassified as `StateExited` (normal exit) instead of `StateDisconnected`. Fixed by marking the session disconnected before closing the transport and guarding the `Wait()`-driven state update so it can't downgrade that classification back to exited.
- Updated `docs/architecture.md` and `docs/behavior.md` to document the new timeout/keepalive behavior.

## Test plan
- [x] `make check` passes (lint, Go tests, frontend tests, coverage ≥ 80%)
- [x] `go test -race` passes for `internal/session` and `internal/api`
- [x] New table-driven/unit tests cover: timeout firing vs. completing just under timeout vs. erroring before timeout, for each local exec call site
- [x] New keepalive unit tests cover: consecutive successes never trigger `onDead`, consecutive failures trigger it exactly once, a single failure followed by success resets the counter, closing `stop` halts the loop before the next tick
- [x] New in-process fake-SSH-server integration tests verify end-to-end: a transport that stops answering keepalive probes is detected and the session transitions to `disconnected` within the shrunk keepalive window; a transport that keeps answering never gets disconnected by the keepalive loop