### PR TITLE
docs: design agent board — cross-pane Claude/Codex messaging via agmsg

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ This installs npm packages, downloads Go modules, and configures the repo-local 
 5. Read [docs/behavior.md](docs/behavior.md) for runtime behavior, API behavior, and operational assumptions.
 6. Read [docs/ui-design.md](docs/ui-design.md) when changing frontend interaction or presentation.
 7. Read [docs/maintenance.md](docs/maintenance.md) when touching CI, release automation, or GitHub workflow operations.
+8. Read [docs/agent-board.md](docs/agent-board.md) before implementing cross-pane Claude
+   messaging/status features (the `internal/board` package). It is a design document — check its
+   status note before treating anything in it as shipped behavior.
 
 ## Document Map
 
@@ -35,6 +38,7 @@ This installs npm packages, downloads Go modules, and configures the repo-local 
 - Behavior and API specification: [docs/behavior.md](docs/behavior.md)
 - UI intent and interaction design: [docs/ui-design.md](docs/ui-design.md)
 - CI and release maintenance: [docs/maintenance.md](docs/maintenance.md)
+- Cross-pane Claude messaging design: [docs/agent-board.md](docs/agent-board.md)
 
 ## Editing Rules
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -1,0 +1,285 @@
+# Agent Board: Cross-Pane Claude Messaging and Status Aggregation
+
+> **Status: design, not yet implemented.** This document specifies the target design for the
+> `internal/board` package and its supporting API, config, and security surface. Update this
+> status note (and cross-link it from [architecture.md](architecture.md), [security.md](security.md),
+> and [behavior.md](behavior.md) as appropriate) once a phase below actually ships; until then, no
+> other doc should describe `board` endpoints or config fields as current behavior.
+
+## Purpose
+
+panemux currently infers what an interactive Claude process in a pane is doing by parsing
+`~/.claude/sessions/<pid>.json` and the matching transcript JSONL (see the Claude worktree
+resolution notes in [architecture.md](architecture.md) and [behavior.md](behavior.md)). That
+approach is read-only, heuristic, and pane-local: it cannot tell whether a session is idle or
+mid-turn, and it gives panemux no way to send an agent a message or to let two agents in different
+panes talk to each other.
+
+Agent Board replaces that inference with a small, self-reported, structured channel that:
+
+1. Lets panemux collect accurate per-pane Claude status (idle / working / waiting for approval,
+   last tool used, current summary) instead of guessing from transcripts.
+2. Lets a human (or one designated "supervisor" pane) broadcast a message to one or more panes'
+   Claude sessions without racing raw keystrokes into a live PTY.
+3. Aggregates all of the above into one dashboard and, for a supervisor pane, one queryable feed.
+
+## Design principles
+
+- **No new daemon, no new listening port.** The mechanism is a local SQLite file per host, opened
+  directly by both panemux and the Claude process running in that host's panes, plus reuse of the
+  SSH exec channel panemux already holds open for `GetCWD`/`InspectGitContext`
+  (`internal/session/ssh.go`).
+- **Claude drives its own participation with its own tools.** panemux does not push data into
+  Claude's context out-of-band. It types a one-time bootstrap instruction into the pane (the same
+  mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
+  own inbox and to run a small CLI to report status and send messages. Everything panemux observes
+  is something Claude itself chose to write, using its own `Bash`/`Monitor` tool calls.
+- **Hooks are optional, not primary.** A `Stop` hook that checks the inbox between turns can be
+  added by a user who wants delivery guarantees even when `Monitor` isn't running, mirroring how
+  the [agmsg](https://github.com/fujibee/agmsg) project treats hooks as a fallback "turn mode"
+  behind its primary `Monitor`-based "monitor mode". panemux does not write to a user's
+  `~/.claude/settings.json` on their behalf; if a user wants the hook fallback they add it
+  themselves following the instructions the bootstrap message prints.
+- **panemux is a trusted relay, not an end-to-end encrypted channel.** See
+  [Cross-host relay](#cross-host-relay) and [Security model](#security-model).
+
+## Schema
+
+One table per host, based directly on agmsg's proven schema with two added columns for
+cross-host relay dedup:
+
+```sql
+CREATE TABLE messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  team TEXT NOT NULL DEFAULT 'panemux',
+  from_agent TEXT NOT NULL,
+  to_agent TEXT NOT NULL,
+  kind TEXT NOT NULL DEFAULT 'message',   -- 'message' | 'status'
+  body TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  read_at TEXT,
+  origin_host TEXT,     -- NULL if this row originated on this host; source host id if relayed in
+  origin_id INTEGER     -- the row's id on origin_host, for relay dedup
+);
+CREATE UNIQUE INDEX idx_relay_dedup ON messages(origin_host, origin_id) WHERE origin_host IS NOT NULL;
+CREATE INDEX idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
+CREATE INDEX idx_history ON messages(team, created_at DESC);
+```
+
+`from_agent`/`to_agent` are pane IDs (already globally unique across workspaces per
+[architecture.md](architecture.md)). `kind='status'` rows carry the latest self-reported activity
+summary; `kind='message'` rows carry chat/instruction content.
+
+## Package layout
+
+### `internal/board`
+
+```go
+type Row struct {
+    ID, OriginID int64
+    Team, FromAgent, ToAgent, Kind, Body string
+    CreatedAt time.Time
+    ReadAt    *time.Time
+    OriginHost string
+}
+
+type Store interface {
+    HostID() string
+    Insert(ctx context.Context, r Row) (int64, error)
+    InsertRelayed(ctx context.Context, r Row) error // requires OriginHost/OriginID; INSERT OR IGNORE
+    Since(ctx context.Context, afterID int64) ([]Row, error)
+    LatestStatusByAgent(ctx context.Context, team string) (map[string]Row, error)
+    MarkRead(ctx context.Context, ids []int64) error
+}
+```
+
+- `LocalStore` opens `~/.config/panemux/board.db` directly with a pure-Go SQLite driver (no CGO,
+  consistent with the single-binary distribution story in [overview.md](overview.md)), in WAL
+  mode. One file is shared by every local and local-tmux pane on the host, and by panemux itself.
+- `RemoteStore` never opens a remote file directly (SQLite's WAL guarantees do not extend across a
+  network filesystem boundary). It calls the fixed remote command `panemux board recv` over the
+  existing SSH exec channel and writes the row as JSON to that command's **stdin**. It never
+  interpolates message bodies into a shell command string. See
+  [Security model](#security-model) and [security.md](security.md).
+
+### `internal/session` capability interfaces
+
+Following the existing optional-capability pattern (`CWDGetter`, `ActiveWorkdirGetter`,
+`GitContextGetter`, `SSHConnNamer`):
+
+```go
+// BoardHostID is implemented by every session type. It returns the identifier of the host whose
+// board this session's pane belongs to: "local" for local/tmux sessions, the SSH connection name
+// for ssh/ssh_tmux sessions.
+type BoardHostID interface {
+    BoardHostID() string
+}
+
+// BoardExecutor is implemented by SSH-backed sessions. It runs `panemux board recv` on the remote
+// host over the session's existing exec channel, writing stdin and returning stdout, without ever
+// building a shell command string from body content.
+type BoardExecutor interface {
+    RunBoardCommand(ctx context.Context, args []string, stdin []byte) ([]byte, error)
+}
+```
+
+`LocalSession`/`TmuxLocalSession` implement only `BoardHostID` (`"local"`). `SSHSession`/
+`SSHTmuxSession` implement both.
+
+## Cross-host relay
+
+Two Claude processes on two different SSH-reached hosts cannot share a board file directly (no
+shared filesystem, and the two hosts may not even be able to reach each other — see the write-up in
+this document's revision history / PR discussion for the TURN-server analogy). panemux is the only
+node with a connection to every host, so it relays:
+
+1. A single goroutine polls every known host's `Store.Since(cursor)` every 3 seconds.
+2. `cursor` is one value per source host, persisted in a `relay_cursors(source_host TEXT PRIMARY
+   KEY, last_id INTEGER)` table in the local board so a panemux restart resumes correctly.
+3. For each new row, panemux resolves `to_agent` to its owning host via the already-known
+   pane→session config. If the destination host differs from the source host, panemux calls
+   `InsertRelayed` on the destination `Store` with `OriginHost`/`OriginID` set to the source row, so
+   a re-relay after a crash/restart is a harmless no-op against `idx_relay_dedup`.
+4. Same-host `to_agent` needs no relay: sender and receiver already share one file.
+5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every host's
+   `Store` and are not relayed; relay only matters for agent-to-agent delivery.
+
+This makes panemux's relay role structurally similar to a TURN server (always in the data path for
+the life of the exchange, because a direct path between the two remote hosts is not assumed to
+exist) rather than a STUN server (which only helps two peers find each other and then steps aside).
+Unlike a general-purpose TURN server, panemux is the only possible relay for a given pair of hosts
+(it is the sole node holding SSH credentials to both), so there is no negotiation step — delivery is
+always routed through it by construction.
+
+## CLI subcommands
+
+Same binary, `panemux board <subcommand>`:
+
+| Subcommand | Run where | Purpose |
+|---|---|---|
+| `panemux board join <pane-id> [--role worker\|supervisor]` | inside the pane, by Claude | Prints usage and writes an initial `status` row |
+| `panemux board inbox <pane-id> --watch` | inside the pane, by Claude via `Monitor` | Polls for unread rows addressed to `<pane-id>` every ~1s, prints one line per message, marks each read after printing |
+| `panemux board status <pane-id> "<summary>"` | inside the pane, by Claude | Inserts a `kind='status'` row |
+| `panemux board send <to-pane-id> "<body>"` | inside a `role: supervisor` pane, by Claude | Inserts a `kind='message'` row addressed to another pane |
+| `panemux board recv` | remote host only, invoked by panemux over the exec channel | Reads one JSON row from stdin, inserts it with parameterized SQL. The only board subcommand panemux itself ever executes remotely |
+
+## Bootstrap flow
+
+1. A pane config (or the global default) sets `agent_board.enabled: true`.
+2. panemux's existing interactive-agent process detection (already used for the Claude worktree
+   override in [architecture.md](architecture.md)) notices a `claude` process start in that pane.
+3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
+   used for all terminal input) telling Claude to run `panemux board join <pane-id>` and to start
+   `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
+4. panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once, explicitly
+   (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be given as a
+   short slash command. Installing this skill is itself gated on `agent_board.enabled` and is
+   idempotent.
+
+## Roles: worker and supervisor
+
+- `role: worker` (default): only reads its own inbox and reports its own status.
+- `role: supervisor` (explicit opt-in only, never default): may read every agent's latest status
+  (`panemux board status --all`) and send to any pane (`panemux board send <any-pane-id> ...`).
+  A supervisor pane is typically a local pane the user starts specifically for this purpose.
+
+**Trust implication, stated explicitly:** giving a pane `role: supervisor` means its Claude process
+can inject instructions into every other board-enabled pane, local or remote, including ones
+executing arbitrary shell commands. This is the same class of risk called out for the `SendMessage`
+tool in Claude Code itself: a receiving pane must not treat a board message as pre-authorized, only
+as an ordinary instruction subject to its own normal confirmation flow. This must be stated in the
+bootstrap instruction text itself, not just in this document.
+
+## API additions
+
+All of the following require the global bearer-token auth described in
+[Security model](#security-model) — board auth is not scoped narrower than the rest of the API,
+because an unauthenticated board endpoint would be a smaller problem than the pre-existing
+unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it should cover both.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/board/status` | Latest `kind='status'` row per pane, across every host panemux manages |
+| `GET /api/board/messages?since=<id>` | History feed for the dashboard UI |
+| `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; inserts directly into each target's own host `Store` (never via PTY injection, so it is safe to send to a pane mid-turn) |
+
+## Config additions
+
+```yaml
+server:
+  host: "127.0.0.1"
+  port: 8080
+  auth_token: ""   # empty = auto-generate on first run, saved to ~/.config/panemux/token (0600)
+
+panes:
+  - id: pane-a
+    type: local
+    agent_board:
+      enabled: true
+      role: worker   # or supervisor; supervisor must always be explicit, never a default
+```
+
+A global `agent_board.enabled` default may also be supported so individual panes don't need to
+repeat it.
+
+## Security model
+
+Full implementation rules live in [security.md](security.md); this section states the requirements
+that shaped the design.
+
+- **panemux does not terminate TLS.** `server.host` defaults to `127.0.0.1`. Exposing panemux
+  beyond loopback is the operator's responsibility, using infrastructure built for it (an
+  ALB/nginx/Caddy TLS-terminating reverse proxy, an SSH tunnel, Tailscale/WireGuard, etc.). The
+  panemux↔proxy hop is then treated as trusted network, the same way panemux already treats its
+  own host as trusted.
+- **Auth token without transport encryption is close to meaningless** — a token sniffed on an
+  unencrypted hop can be replayed, and worse, a request can be tampered with in transit (this
+  matters more than usual here because `POST /api/board/broadcast` and the terminal WebSocket both
+  ultimately drive shell-executing agents). Config validation must therefore fail closed: if
+  `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
+  be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
+- **Message bodies never reach a remote shell as an interpolated argument.** `RunBoardCommand`
+  always sends the body over the exec channel's stdin to the fixed argv `panemux board recv`, never
+  via a constructed shell string. This is the same rule already applied to `cwd` in
+  `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`), extended to board content.
+- **Local board files are `0600`.** `~/.config/panemux/board.db` and the remote equivalent are
+  created with owner-only permissions. This does not create a new trust boundary — any other
+  process running as the same OS user is already inside panemux's existing trust boundary per
+  [overview.md](overview.md) — but it does prevent a different local *user* on a shared host from
+  reading cross-pane agent chatter.
+- **panemux sees plaintext at each relay hop.** SSH encrypts each hop (panemux↔host A,
+  panemux↔host B), but panemux itself decrypts and re-serializes the row in between, so the
+  panemux process/host must be trusted for the relay to be meaningful. There is no end-to-end
+  encryption between two remote agents' Claude processes.
+
+## Known limitations
+
+- No claim/lease semantics: if two workers were both addressed by the same message (not a supported
+  case today, since `to_agent` targets one pane), there is no exclusion mechanism. This mirrors
+  agmsg's own documented v1 limitation.
+- Agents/teams are free-text identifiers with no cryptographic authentication of `from_agent`. Any
+  local process that can open the board file can forge a sender. This is an integrity gap distinct
+  from the transport-confidentiality concerns above and is accepted for the same reason panemux
+  already accepts same-user process trust elsewhere.
+- Relay latency is bounded by the 3s poll interval, not real-time; cross-host messaging is not
+  suitable for anything requiring sub-second delivery.
+
+## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
+
+- `internal/board`: insert/read roundtrip, unread filtering and `MarkRead`, relay dedup (same
+  `origin_host`+`origin_id` inserted twice is a no-op), cursor persistence across a simulated
+  restart, `LatestStatusByAgent` with multiple status rows (only the newest per agent wins), empty
+  board.
+- `internal/session`: `RunBoardCommand` never places body content in `exec.Command` args (mirrors
+  the existing `validateShell` test pattern).
+- `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
+  combinations are valid.
+- `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
+  handshake; correct token succeeds.
+
+## Related documents
+
+- Implementation structure: [architecture.md](architecture.md)
+- Security requirements for implementation: [security.md](security.md)
+- Runtime behavior and API specification: [behavior.md](behavior.md)
+- Developer workflow rules: [../DEVELOPMENT.md](../DEVELOPMENT.md)

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -112,11 +112,27 @@ host. Claude-to-Claude only — a Codex pane on the same host cannot join a `nat
 
 ### `agmsg`
 
-Delegates to an agmsg installation already present on the pane's host, using only the interfaces
-agmsg documents as stable for third-party use: the CLI/skill entry points (`/agmsg ...` from inside
-Claude Code, or the equivalent `$agmsg`/skill invocation for other agents) and `scripts/api.sh` for
-JSON-in/JSON-out reads and writes. panemux never reads or writes agmsg's `messages.db` or
-`teams/*/config.json` directly, matching agmsg's own README guidance that those are internal.
+Delegates to an agmsg installation already present on the pane's host. Reads and writes go through
+two different scripts under agmsg's `scripts/` directory, verified against agmsg's source (not
+inferred): panemux never reads or writes agmsg's `messages.db` or `teams/*/config.json` directly,
+matching agmsg's own README guidance that those are internal.
+
+**Reads — `scripts/api.sh`, read-only.** Its `case "$VERB"` block implements only `get`:
+
+| Call | Returns |
+|---|---|
+| `api.sh get teams` | `{"name": "<team>"}` per line, one per team under `teams/` |
+| `api.sh get teams <team> members` | `{"name","types","project"}` per line |
+| `api.sh get teams <team> messages [--agent <name>] [--limit N] [--before-id <id>]` | `{"type":"message_sent","id","team","from","to","body","at"}` per line, JSONL, oldest-first |
+
+`id` is returned as a string (agmsg's own future-proofing against a non-integer ID scheme, per its
+source comments), and `--agent`/`--limit`/`--before-id` are validated as plain digits before being
+used in a query, guarding against SQL injection on agmsg's own side.
+
+**Writes — `scripts/send.sh`, not `api.sh`.** Signature: `send.sh <team> <from> <to> <body>
+[--force]`. Unlike `api.sh`, `send.sh` takes `body` as a **positional shell argument**, not stdin —
+there is no stdin-based write path in agmsg to delegate to. `from` is checked against that team's
+roster unless `--force` is passed, in which case an unregistered sender name is accepted as-is.
 
 Choosing `agmsg` for a pane means:
 
@@ -125,13 +141,14 @@ Choosing `agmsg` for a pane means:
   agent already using agmsg on that host (Codex, Gemini CLI, etc.) can then exchange messages with
   it directly through agmsg, with no panemux involvement in that same-host exchange at all.
 - agmsg has no native "status" concept, only messages. panemux's status reports map onto ordinary
-  agmsg messages addressed to a reserved agent name (e.g. `_panemux_dashboard`) inside the team;
-  `LatestStatusByAgent` for this backend reads the history addressed to that reserved name and
-  keeps only the newest row per sender. The exact `scripts/api.sh` flags this requires must be
-  confirmed against a pinned agmsg version at implementation time — this document does not assert
-  a flag surface it has not verified.
-- panemux's own dashboard reads and the cross-host relay both go through `scripts/api.sh`, not
-  through a shared schema, for the same reason panemux itself avoids the raw file.
+  agmsg messages addressed to a reserved agent name, `_panemux_dashboard`, inside the team;
+  `LatestStatusByAgent` for this backend calls `api.sh get teams <team> messages --agent
+  _panemux_dashboard --limit <N>` and keeps only the newest row per `from`.
+- **The relay and the command center are never agmsg roster members**, so any send they originate
+  into an agmsg team (relaying a `native` pane's message, or the command center instructing an
+  `agmsg` pane) always passes `send.sh ... --force`. `from` is set to the originating pane's ID (or
+  `_panemux` for the command center) exactly as with the `native` backend — `--force` only skips
+  agmsg's own roster check, it does not change how `from` is chosen.
 - **Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
   that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
   or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If
@@ -139,10 +156,11 @@ Choosing `agmsg` for a pane means:
   leaves the pane's shell session itself untouched — board is additive, never load-bearing for the
   pane to function. panemux never runs `npx agmsg`, `npm i -g agmsg`, `git clone`, or any other
   installer on the operator's behalf, on any host.
-- **Version pinning.** Because agmsg's own compatibility promise only covers `scripts/api.sh`'s
-  JSON contract (not internal storage), panemux implementation must pin a specific tested agmsg
-  version/tag range and treat a break in that script's behavior as an external dependency
-  compatibility bug, tracked the same way any other pinned dependency's breaking change would be.
+- **Version pinning.** agmsg's own compatibility promise (per its README) only covers reading
+  through `scripts/api.sh`, not `send.sh`'s argument order or `messages.db`. panemux implementation
+  must pin a specific tested agmsg version/tag and treat any change to either script's observed
+  behavior as an external dependency compatibility bug, tracked the same way any other pinned
+  dependency's breaking change would be.
 
 ## Package layout
 
@@ -177,11 +195,24 @@ Four concrete implementations, chosen per host by that host's panes' `agent_boar
   over the existing SSH exec channel and writes the row as JSON to that command's **stdin**. It
   never interpolates message bodies into a shell command string. See
   [Security model](#security-model) and [security.md](security.md).
-- `LocalAgmsgStore` shells out to the local agmsg installation's `scripts/api.sh` (see
-  [Backends](#backends)); it never touches `messages.db` directly.
-- `RemoteAgmsgStore` runs the remote host's `scripts/api.sh` over the same SSH exec channel as
-  `RemoteNativeStore`, with the same stdin-only, no-argv-interpolation discipline for message
-  bodies.
+- `LocalAgmsgStore` shells out to the local agmsg installation's `scripts/api.sh` for reads and
+  `scripts/send.sh ... --force` for writes (see [Backends](#backends)); it never touches
+  `messages.db` directly. Because this is a local `exec.Command` invocation, Go passes each
+  argument as a genuine array element with no intermediate shell, so `send.sh`'s argument-based
+  `body` parameter carries no injection risk here regardless of its content.
+- `RemoteAgmsgStore` runs the same two scripts on the remote host over the same SSH exec channel as
+  `RemoteNativeStore`. Reads (`api.sh get ...`) only ever take digit-validated or
+  path-traversal-validated arguments, so they need no special quoting beyond the discipline already
+  applied everywhere else. Writes are different: `send.sh` has no stdin-based way to receive `body`
+  (see [Backends](#backends)), so unlike `RemoteNativeStore`'s `panemux board recv`, `body` cannot
+  be kept off the exec command string here. `RemoteAgmsgStore` must instead single-quote-escape
+  every argument (team, from, to, body) with the same `shellQuotePath`-style escaping
+  `internal/session/ssh.go` already applies to `cwd`, and build the exec command string from that —
+  never from unescaped concatenation. This is a documented, precedented exception to the
+  stdin-preferred rule in [Security model](#security-model), not a relaxation of it: the underlying
+  requirement ("no user-controlled content reaches a remote shell unescaped") is upheld by
+  quoting instead of by avoiding the exec command string, because `send.sh`'s own contract leaves
+  no other way to pass `body` to it remotely.
 
 ### `internal/session` capability interfaces
 
@@ -197,9 +228,12 @@ type BoardHostID interface {
 }
 
 // BoardExecutor is implemented by SSH-backed sessions. It runs the remote board command for
-// whichever backend that pane's host uses (`panemux board recv` for native, agmsg's own
-// scripts/api.sh for agmsg) over the session's existing exec channel, writing stdin and returning
-// stdout, without ever building a shell command string from body content.
+// whichever backend that pane's host uses over the session's existing exec channel. For `native`,
+// args is just ["board", "recv"] and body content goes over stdin, never into the command string.
+// For `agmsg`, send.sh has no stdin path for its body argument (see docs/agent-board.md#backends),
+// so args carries every value including body, and the implementation must single-quote-escape each
+// element (the same discipline internal/session/ssh.go already applies to cwd) before building the
+// remote command string — stdin is unused on that path.
 type BoardExecutor interface {
     RunBoardCommand(ctx context.Context, args []string, stdin []byte) ([]byte, error)
 }
@@ -427,11 +461,16 @@ that shaped the design.
   ultimately drive shell-executing agents). Config validation must therefore fail closed: if
   `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
   be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
-- **Message bodies never reach a remote shell as an interpolated argument.** `RunBoardCommand`
-  always sends the body over the exec channel's stdin to a fixed argv (`panemux board recv` for
-  `native`, agmsg's own script invocation for `agmsg`), never via a constructed shell string. This
-  is the same rule already applied to `cwd` in `internal/session/ssh.go` (`validRemotePath` /
-  `shellQuotePath`), extended to board content, and it applies identically to both backends.
+- **Message bodies never reach a remote shell unescaped.** For `native`, `RunBoardCommand` sends
+  the body over the exec channel's stdin to the fixed argv `panemux board recv`, keeping it out of
+  the command string entirely. For `agmsg`, `send.sh` has no stdin-based way to receive its `body`
+  argument — verified against agmsg's own source, not assumed — so this backend cannot avoid
+  putting the body in the remote command string. The requirement is upheld the same way `cwd`
+  already is in `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`): every argument,
+  body included, is single-quote-escaped before the command string is built, never concatenated
+  unescaped. Both backends satisfy "no unescaped user content reaches a remote shell"; they satisfy
+  it by different means because `send.sh`'s own argument-based contract leaves `native` a stdin
+  option that `agmsg` does not have.
 - **agmsg is an operator-installed, unpinned-by-panemux external dependency.** panemux only detects
   and calls it; it never bundles, vendors, or auto-installs it (see [Backends](#backends) and
   [Design principles](#design-principles)). MIT license permits depending on it, but panemux's
@@ -483,8 +522,13 @@ that shaped the design.
   `origin_host`+`origin_id` inserted twice is a no-op), cursor persistence across a simulated
   restart, `LatestStatusByAgent` with multiple status rows (only the newest per agent wins), empty
   board.
-- `internal/session`: `RunBoardCommand` never places body content in `exec.Command` args (mirrors
-  the existing `validateShell` test pattern).
+- `internal/session`: for `native`, `RunBoardCommand` never places body content in the remote
+  command string, only in stdin (mirrors the existing `validateShell` test pattern). For `agmsg`,
+  the reverse must hold and be tested explicitly: a body containing shell metacharacters (`'`, `;`,
+  `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
+  literal argument, not as executed shell syntax — this is the one board path where the assertion
+  is "the command string must escape this correctly," not "this must never enter the command
+  string," and the test suite must cover both properties without conflating them.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
   combinations are valid. `agent_board.backend` accepts only `native`/`agmsg`; anything else is a
   validation error (no silent fallback to a default).

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -34,12 +34,21 @@ Agent Board replaces that inference with a small, self-reported, structured chan
   mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
   own inbox and to run a small CLI to report status and send messages. Everything panemux observes
   is something Claude itself chose to write, using its own `Bash`/`Monitor` tool calls.
-- **Hooks are optional, not primary.** A `Stop` hook that checks the inbox between turns can be
-  added by a user who wants delivery guarantees even when `Monitor` isn't running, mirroring how
-  the [agmsg](https://github.com/fujibee/agmsg) project treats hooks as a fallback "turn mode"
-  behind its primary `Monitor`-based "monitor mode". panemux does not write to a user's
-  `~/.claude/settings.json` on their behalf; if a user wants the hook fallback they add it
-  themselves following the instructions the bootstrap message prints.
+- **Hooks are avoidable, not required — because panemux has something agmsg doesn't.**
+  [agmsg](https://github.com/fujibee/agmsg) is a plain bash+sqlite3 skill with no host-side
+  controller, so it needs a `SessionStart` hook just to auto-launch `Monitor` when a Claude Code
+  session starts, and a `Stop` hook for its "turn mode" fallback (`/agmsg mode monitor|turn|both`) —
+  hooks are how agmsg gets *anything* to happen automatically, for both modes, not only the
+  fallback one. panemux does not have that constraint: it already has write access to every pane's
+  PTY (the same path used for all terminal input), so it can type the `Monitor`-launching bootstrap
+  instruction itself, once, the moment it detects a `claude` process starting in a board-enabled
+  pane — reproducing agmsg's "automatic, no user action" property without ever touching the user's
+  `~/.claude/settings.json`. A user who additionally wants a `Stop`-hook "turn mode" fallback for
+  extra delivery reliability (mirroring agmsg's `turn`/`both` modes) can still add one manually; the
+  bootstrap message prints the hook snippet to add, but panemux never installs it itself.
+- **Delivery mode is configurable per pane, mirroring agmsg's `/agmsg mode`.** `join` accepts
+  `--mode monitor|turn|both` (default `monitor`). `turn` and `both` require the user-added `Stop`
+  hook above; panemux cannot upgrade a pane into those modes on its own.
 - **panemux is a trusted relay, not an end-to-end encrypted channel.** See
   [Cross-host relay](#cross-host-relay) and [Security model](#security-model).
 
@@ -157,24 +166,31 @@ Same binary, `panemux board <subcommand>`:
 
 | Subcommand | Run where | Purpose |
 |---|---|---|
-| `panemux board join <pane-id> [--role worker\|supervisor]` | inside the pane, by Claude | Prints usage and writes an initial `status` row |
-| `panemux board inbox <pane-id> --watch` | inside the pane, by Claude via `Monitor` | Polls for unread rows addressed to `<pane-id>` every ~1s, prints one line per message, marks each read after printing |
+| `panemux board join <pane-id> [--role worker\|supervisor] [--mode monitor\|turn\|both]` | inside the pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
+| `panemux board inbox <pane-id> --watch` | inside the pane, by Claude via `Monitor` (`monitor`/`both` modes) or a `Stop` hook script (`turn`/`both` modes) | Polls for unread rows addressed to `<pane-id>`, prints one line per message, marks each read after printing. Under `Monitor` this polls every ~1s; under a `Stop` hook it runs once, between turns |
 | `panemux board status <pane-id> "<summary>"` | inside the pane, by Claude | Inserts a `kind='status'` row |
 | `panemux board send <to-pane-id> "<body>"` | inside a `role: supervisor` pane, by Claude | Inserts a `kind='message'` row addressed to another pane |
 | `panemux board recv` | remote host only, invoked by panemux over the exec channel | Reads one JSON row from stdin, inserts it with parameterized SQL. The only board subcommand panemux itself ever executes remotely |
 
 ## Bootstrap flow
 
-1. A pane config (or the global default) sets `agent_board.enabled: true`.
+1. A pane config (or the global default) sets `agent_board.enabled: true` (optionally with a
+   non-default `mode`).
 2. panemux's existing interactive-agent process detection (already used for the Claude worktree
    override in [architecture.md](architecture.md)) notices a `claude` process start in that pane.
 3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
-   used for all terminal input) telling Claude to run `panemux board join <pane-id>` and to start
-   `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
+   used for all terminal input) telling Claude to run `panemux board join <pane-id> [--mode ...]`
+   and to start `panemux board inbox <pane-id> --watch` under the `Monitor` tool. This single PTY
+   write is what lets panemux skip the `SessionStart` hook agmsg needs for the same auto-launch
+   effect — see [Design principles](#design-principles).
 4. panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once, explicitly
    (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be given as a
    short slash command. Installing this skill is itself gated on `agent_board.enabled` and is
    idempotent.
+5. If the pane was joined with `--mode turn` or `--mode both`, `join` prints the exact `Stop` hook
+   entry to add to `~/.claude/settings.json`; panemux never writes that file itself, so this step
+   requires the user (or Claude, with the user's confirmation, since editing `settings.json` is a
+   file write like any other) to apply it manually.
 
 ## Roles: worker and supervisor
 
@@ -217,6 +233,7 @@ panes:
     agent_board:
       enabled: true
       role: worker   # or supervisor; supervisor must always be explicit, never a default
+      mode: monitor  # monitor (default) | turn | both; turn/both need a manually-added Stop hook
 ```
 
 A global `agent_board.enabled` default may also be supported so individual panes don't need to

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -308,7 +308,9 @@ more exposure to agmsg's evolution than a "we only read from it" dependency woul
 in Known limitations](#known-limitations) for that tradeoff stated plainly. panemux implementation
 must pin a specific tested agmsg version/tag and treat any change to either script's observed
 behavior as an external dependency compatibility bug, tracked the same way any other pinned
-dependency's breaking change would be.
+dependency's breaking change would be — and must be able to *detect* such a break mechanically
+rather than discover it from a pane silently failing to communicate; see [agmsg compatibility
+contract](#agmsg-compatibility-contract).
 
 ## Status self-report and message flow
 
@@ -854,7 +856,9 @@ that shaped the design.
   `AgmsgClient` can fail even though nothing in panemux's own config changed. This is a real,
   accepted cost of not vendoring/pinning a copy of agmsg inside panemux itself, and is more exposure
   than a read-only dependency on `api.sh` alone would have carried — worth weighing against the
-  cross-agent interoperability agmsg provides that a panemux-owned protocol never could.
+  cross-agent interoperability agmsg provides that a panemux-owned protocol never could. See [agmsg
+  compatibility contract](#agmsg-compatibility-contract) for how this exposure is meant to be
+  caught mechanically rather than discovered by a user.
 - Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
   called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
   following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops
@@ -866,6 +870,54 @@ that shaped the design.
   process startup plus generation time, which is higher than a warm, already-running interactive
   session would give — acceptable for a "converse with an orchestrator" UX, not for anything
   latency-sensitive.
+
+## agmsg compatibility contract
+
+agmsg's own compatibility promise only covers reading through `scripts/api.sh` (see [Version
+pinning](#integration-with-agmsg)); `send.sh`, `join.sh`, and everything else this design depends on
+carry no such promise. Without a mechanical check, an agmsg upgrade that changes one of those
+scripts' behavior would surface as a pane silently failing to communicate, discovered by a user
+long after the fact rather than by CI at the moment it happened.
+
+**What this borrows from [Pact](https://docs.pact.io/), and what it deliberately doesn't.** Pact's
+core idea — the *consumer* writes down the exact interactions it depends on as a contract, and that
+contract is mechanically verified against the real *provider* — is exactly the right shape here:
+panemux is the consumer, agmsg is the provider, and [Integration with
+agmsg](#integration-with-agmsg)'s precise, source-verified prose about `api.sh`/`send.sh`/`join.sh`
+*is* that contract in everything but file format. What doesn't transfer is Pact's actual
+machinery: Pact is built for HTTP/message request-response between two services that both
+participate in verification (typically via a shared Pact Broker, with the *provider's own CI*
+replaying the consumer's recorded interactions against itself). agmsg is a CLI script tool whose
+maintainers are not signed up for any such loop, and there is no request/response protocol here to
+generate Pact's consumer-side mocks from in the first place — shoehorning the actual Pact
+tooling/broker onto shell-exec fixtures would add a heavyweight dependency for no benefit over a
+plain table-driven Go test. So: adopt the *idea*, skip the *tool*.
+
+**Two test tiers, not one:**
+
+- **Tier 1 — fast, hermetic, part of `make check` on every commit.** `internal/board`'s existing
+  test bullets (below) already do this: a fake `AgmsgClient`/`BoardExecutor` asserts the exact
+  command strings panemux builds for each operation, and parses fixed, versioned fixture output
+  (frozen JSONL captured from a real, pinned agmsg run — e.g. `internal/board/testdata/agmsg-v1.1.x/
+  *.jsonl`) the way the real `api.sh` would produce it. This protects panemux's own code from
+  regressing against its own documented assumptions; it cannot, by itself, detect that agmsg
+  changed, since it never touches a real agmsg install.
+- **Tier 2 — a separate, non-blocking-by-default CI job that runs the same contract against a real
+  agmsg install.** Install the pinned agmsg version (via its own documented installer, the same way
+  an operator would) into an ephemeral CI environment, run the exact `join.sh`/`send.sh`/`api.sh`
+  invocations the contract specifies against a throwaway team, and assert the real output/exit-code
+  behavior matches what Tier 1's fixtures encode. This is the piece that actually catches drift, and
+  it should run in at least two situations: **on a schedule** (e.g. weekly) against agmsg's latest
+  tag, as an early warning before panemux's maintainers have chosen to bump the pin at all; and **as
+  a required check** whenever a change actually bumps the pinned version, so a real behavioral diff
+  blocks that bump rather than shipping silently. It is deliberately kept out of the main `make
+  check` gate — it depends on installing and executing a real external tool, which is slower and
+  less hermetic than the rest of this repository's test suite is designed to be.
+
+This does not remove the underlying risk noted in [Known limitations](#known-limitations) — agmsg
+still makes no compatibility promise for the scripts panemux's write path depends on — but it turns
+a silent, user-discovered failure into a specific, actionable CI signal naming exactly which
+documented behavior changed.
 
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -10,139 +10,118 @@
 
 panemux currently infers what an interactive Claude process in a pane is doing by parsing
 `~/.claude/sessions/<pid>.json` and the matching transcript JSONL (see the Claude worktree
-resolution notes in [architecture.md](architecture.md) and [behavior.md](behavior.md)). That
-approach is read-only, heuristic, and pane-local: it cannot tell whether a session is idle or
-mid-turn, and it gives panemux no way to send an agent a message or to let two agents in different
-panes talk to each other.
+resolution notes in [architecture.md](architecture.md) and [behavior.md](behavior.md)). In
+practice this is unreliable: it depends on undocumented, internal Claude/Codex transcript fields
+that change without notice, and pane headers frequently fail to show a branch or PR as a result.
+It is also read-only and pane-local: it cannot tell whether a session is idle or mid-turn, and it
+gives panemux no way to send an agent a message or to let two agents in different panes talk to
+each other.
 
-Agent Board replaces that inference with a small, self-reported, structured channel that:
+Agent Board replaces that inference with a small, self-reported channel:
 
-1. Lets panemux collect accurate per-pane Claude status (idle / working / waiting for approval,
-   last tool used, current summary) instead of guessing from transcripts.
+1. Panes report their own state — working directory, branch, repository, PR link, and whether
+   they're idle, working, or waiting for approval — by running their own commands (`git`, `gh`)
+   and telling panemux the result, instead of panemux guessing from an internal file format. This
+   is the same information a human looking at the pane would see, obtained the same way a human
+   would get it, so it is exactly as stable as the agent's own tool use — not as fragile as
+   reverse-engineering a private transcript schema. See
+   [Design principles](#design-principles) for why this generalizes beyond just this one field.
 2. Lets a human broadcast a message to one or more panes' Claude sessions without racing raw
    keystrokes into a live PTY, and lets a local **command center** (see
    [Command center](#command-center)) do the same conversationally on the human's behalf.
 3. Aggregates all of the above into one dashboard and, for the command center, one continuous,
    reviewable conversation history.
-4. Optionally interoperates with [agmsg](https://github.com/fujibee/agmsg), an existing MIT-licensed
+4. Is built entirely on [agmsg](https://github.com/fujibee/agmsg), an existing MIT-licensed
    bash+sqlite3 agent-messaging tool that already supports Claude Code, Codex, Gemini CLI, GitHub
-   Copilot, Antigravity, OpenCode, and Hermes. Where a pane's host already runs agmsg, a
-   panemux-managed pane can join the same team as a Codex pane and reuse agmsg's own Codex support
-   (its `Stop`-hook turn-mode delivery, since Codex has no `Monitor` tool to auto-launch) instead of
-   panemux reimplementing it. Note this is about an *already-running* Codex process in a
-   panemux-managed pane joining an existing team — it does not involve agmsg's own `spawn.sh`
-   (which launches a brand-new terminal window/process itself, a separate use case panemux never
-   triggers, since panemux already owns pane creation). See
-   [Backends](#backends).
+   Copilot, Antigravity, OpenCode, and Hermes. panemux does not maintain a second, parallel
+   messaging protocol of its own — see [Design principles](#design-principles) for why, and
+   [Integration with agmsg](#integration-with-agmsg) for how.
 
 ## Design principles
 
-- **No new daemon, no new listening port.** The mechanism is a local SQLite file per host. On the
-  host panemux itself runs on, panemux's Go process and the Claude process in that host's panes
-  both open it directly. On a remote (SSH) host, panemux never opens the file directly and never
-  places any binary of its own there — see the next principle — it only runs `sqlite3` over the SSH
-  exec channel panemux already holds open for `GetCWD`/`InspectGitContext`
-  (`internal/session/ssh.go`), the same tool a remote Claude pane's own Bash calls also use.
+- **Ask the agent; don't reverse-engineer its internal state.** This is the central lesson behind
+  this whole redesign, and it applies uniformly to every piece of external state Agent Board
+  touches, not only pane status:
+  - panemux does not parse Claude/Codex transcript internals to guess branch/PR/cwd — it asks the
+    agent to run `git`/`gh` itself and report the result (see
+    [Status self-report](#status-self-report-and-message-flow)).
+  - panemux does not read agmsg's `messages.db` or `teams/*/config.json` directly — those are
+    agmsg's own internal storage, explicitly documented in agmsg's README as "internal and free to
+    change." panemux only calls agmsg's own stable, documented entry points (`scripts/api.sh`,
+    `scripts/send.sh`) — see [Integration with agmsg](#integration-with-agmsg).
+  - Any future integration this document doesn't yet cover should default to the same rule: prefer
+    a tool's own documented command/output contract over parsing whatever file it happens to keep
+    its state in today.
+- **One messaging mechanism, not two.** An earlier draft of this design also specified a
+  panemux-owned SQLite schema and CLI ("`native`") for Claude-only panes, with agmsg reserved for
+  panes that needed to talk to non-Claude agents. Building and maintaining a second protocol next
+  to an already-working one turned out not to be worth it: agmsg already covers everything
+  `native` tried to do, plus interoperability with Codex/Gemini/etc. that `native` could never
+  offer, and every pane on `agmsg` from the start means no relay step is needed even for two panes
+  that happen to both be Claude. Agent Board is therefore built entirely on agmsg; panemux owns no
+  message schema of its own.
+- **No new daemon, no new listening port.** panemux talks to agmsg the same way any of its scripts
+  or a live agent session would: local `exec.Command` calls on the host panemux itself runs on,
+  and the existing SSH exec channel (`GetCWD`/`InspectGitContext` already use it) for every other
+  host. No new process listens for anything, locally or remotely.
 - **panemux itself is never installed on a remote host, under any circumstances.** The `panemux`
   binary is also a server: running it can start the HTTP/WS listener, the auth surface, and the
-  command center. Placing a copy on every SSH-reached host that wants `native`-backend board
-  features would mean each of those hosts could accidentally end up running a second panemux
-  server — a second command center, a second thing to firewall and issue an auth token for, and a
-  second instance of every network-exposure question already worked through for the primary one in
-  [Security model](#security-model). `native`'s remote support is therefore built entirely on
-  `sqlite3`, a tool that cannot itself become a server, exactly mirroring the minimal-footprint
-  assumption the `agmsg` backend already makes about what a remote host has installed.
-- **Claude drives its own participation with its own tools.** panemux does not push data into
-  Claude's context out-of-band. It types a one-time bootstrap instruction into the pane (the same
-  mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
-  own inbox and to run a small CLI to report status and send messages. Everything panemux observes
-  is something Claude itself chose to write, using its own `Bash`/`Monitor` tool calls.
-- **`native`-backend bootstrap does not edit `~/.claude/settings.json`.** panemux writes the
-  `Monitor`-launching instruction directly into the pane's PTY (the same path used for all terminal
-  input) the moment it detects a `claude` process starting in a board-enabled pane. A user who wants
-  a `Stop`-hook "turn mode" fallback for extra delivery reliability can still add one manually; the
-  bootstrap message prints the hook snippet to add, but panemux never installs it itself.
-- **Delivery mode is configurable per pane, mirroring agmsg's `/agmsg mode`.** `join` accepts
-  `--mode monitor|turn|both` (default `monitor`). `turn` and `both` require the user-added `Stop`
-  hook above; panemux cannot upgrade a pane into those modes on its own.
-- **Backend selection is explicit config, never auto-detected, and panemux never installs agmsg
-  itself.** A pane either uses panemux's own built-in ("native") board, or agmsg, per the pane's
-  configured `agent_board.backend`. panemux does not probe a host for agmsg and silently switch
-  behavior based on what it finds — that would make a pane's messaging behavior depend on
-  unrelated host state and would be surprising to debug. If `backend: agmsg` is set for a pane and
-  agmsg is not present on that pane's host, board bootstrap for that pane is skipped with a clear,
-  visible warning; panemux never runs an installer on the operator's behalf, local or remote. See
-  [Backends](#backends).
+  command center. Placing a copy on every SSH-reached host that wants board features would mean
+  each of those hosts could accidentally end up running a second, unmanaged panemux server. Board
+  features on a remote host depend only on an agmsg installation the operator put there themselves
+  (see the next principle) — never on anything panemux ships.
+- **Backend presence is detected, never installed, by panemux.** If agmsg is not found on a pane's
+  host, panemux skips board bootstrap for that pane, logs a clear warning, and leaves the pane's
+  shell session otherwise untouched — board is additive, never load-bearing for the pane to
+  function. panemux never runs `npx agmsg`, `npm i -g agmsg`, `git clone`, or any other installer
+  on the operator's behalf, on any host. See [Integration with agmsg](#integration-with-agmsg).
 - **panemux is a trusted relay, not an end-to-end encrypted channel.** See
   [Cross-host relay](#cross-host-relay) and [Security model](#security-model).
 
-## Schema (native backend only)
+## Architecture
 
-This schema belongs solely to panemux's own built-in ("native") backend. It is loosely inspired by
-agmsg's message-oriented shape (team/from/to/body/read_at), but it is **not** an attempt at
-schema-level compatibility with agmsg's actual `messages.db`: agmsg's own README states that
-`messages.db` and `teams/*/config.json` are "internal and free to change" and that third parties
-should integrate through `scripts/api.sh` instead. panemux follows that guidance — see
-[Backends](#backends) for how the agmsg backend actually integrates. One table per host, with two
-added columns for cross-host relay dedup that agmsg (a single-host tool) has no equivalent of:
+```mermaid
+flowchart TB
+    Browser["ブラウザ<br/>ダッシュボード + Spotlightパレット"]
 
-```sql
-CREATE TABLE messages (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  team TEXT NOT NULL DEFAULT 'panemux',
-  from_agent TEXT NOT NULL,
-  to_agent TEXT NOT NULL,
-  kind TEXT NOT NULL DEFAULT 'message',   -- 'message' | 'status'
-  body TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
-  read_at TEXT,
-  origin_host TEXT,     -- NULL if this row originated on this host; source host id if relayed in
-  origin_id INTEGER     -- the row's id on origin_host, for relay dedup
-);
-CREATE UNIQUE INDEX idx_relay_dedup ON messages(origin_host, origin_id) WHERE origin_host IS NOT NULL;
-CREATE INDEX idx_unread ON messages(team, to_agent, read_at) WHERE read_at IS NULL;
-CREATE INDEX idx_history ON messages(team, created_at DESC);
+    subgraph Local["panemuxが動くホスト（常にここだけ）"]
+        Server["panemux Goプロセス<br/>WS / REST, Bearerトークン認証"]
+        Relay["中継ゴルーチン<br/>数秒間隔でポーリング"]
+        CmdCenter["司令塔<br/>claude -p --resume（クエリごとに起動）"]
+        LocalAgmsg[("ローカルagmsg<br/>（任意インストール）")]
+    end
+
+    subgraph HostA["リモートホストA（SSH）"]
+        AgmsgA[("agmsg")]
+        ClaudeA["Claude pane"]
+    end
+
+    subgraph HostB["リモートホストB（SSH）"]
+        AgmsgB[("agmsg")]
+        CodexB["Codex pane"]
+    end
+
+    Browser <--> Server
+    Server --> Relay
+    Server --> CmdCenter
+    Relay -->|"api.sh / send.sh"| LocalAgmsg
+    CmdCenter -->|"api.sh / send.sh --force"| LocalAgmsg
+    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
+    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
+    ClaudeA -->|"Bashツール呼び出し"| AgmsgA
+    CodexB -->|"Bashツール呼び出し"| AgmsgB
 ```
 
-`from_agent`/`to_agent` are pane IDs (already globally unique across workspaces per
-[architecture.md](architecture.md)). `kind='status'` rows carry the latest self-reported activity
-summary; `kind='message'` rows carry chat/instruction content.
+panemux is never a participant on more than one host's agmsg installation from the inside — it
+only ever reaches a remote host's agmsg through the SSH exec channel it already holds for that
+pane's session, running agmsg's own scripts, exactly as [Local vs remote resource
+placement](#local-vs-remote-resource-placement) details.
 
-## Backends
+## Integration with agmsg
 
-`agent_board.backend` is `native` (default) or `agmsg`, set explicitly per pane or as a global
-default — never inferred by probing the host. Both backends implement the same `Store` interface
-(below), so the relay and dashboard code is backend-agnostic; only the bootstrap flow and the CLI
-surface a board-enabled pane actually runs differ.
-
-`native` is panemux's own mechanism for Claude-only panes. `agmsg` is the communication layer used
-whenever a pane needs to coordinate with agents other than Claude (Codex, Gemini CLI, etc.).
-
-### `native`
-
-panemux's own schema. Claude-to-Claude only — a Codex pane on the same host cannot join a `native`
-team, because `native` is a panemux-specific protocol Codex has no knowledge of.
-
-The CLI surface differs by where the pane lives, because of the no-remote-install rule above:
-
-- **Local/local-tmux panes** (same host as panemux): the pane's Claude process runs the
-  `panemux board join/inbox/status/send` CLI described in [CLI subcommands](#cli-subcommands)
-  directly — the `panemux` binary is trivially already there, since it's the same one serving the
-  pane.
-- **SSH/SSH+tmux panes**: there is no `panemux board *` CLI to run remotely. The bootstrap
-  instruction (see [Bootstrap flow](#bootstrap-flow)) instead defines a handful of shell functions
-  inline, in the text typed into the pane, that wrap direct `sqlite3 <path> "<SQL>"` calls against
-  that host's own `~/.config/panemux/board.db` — nothing is written to disk on the remote host to
-  provide this; the functions exist only for the lifetime of that shell session, the same way any
-  other one-off shell function would. This is self-contained the same way `native` is everywhere
-  else: still no third-party tool, only `sqlite3`, which most hosts already have.
-
-### `agmsg`
-
-Delegates to an agmsg installation already present on the pane's host. Reads and writes go through
-two different scripts under agmsg's `scripts/` directory, verified against agmsg's source (not
-inferred): panemux never reads or writes agmsg's `messages.db` or `teams/*/config.json` directly,
-matching agmsg's own README guidance that those are internal.
+Reads and writes go through two different scripts under agmsg's `scripts/` directory, verified
+against agmsg's source (not inferred). panemux never reads or writes agmsg's `messages.db` or
+`teams/*/config.json` directly, matching agmsg's own README guidance that those are internal.
 
 **Reads — `scripts/api.sh`, read-only.** Its `case "$VERB"` block implements only `get`:
 
@@ -156,51 +135,108 @@ matching agmsg's own README guidance that those are internal.
 source comments), and `--agent`/`--limit`/`--before-id` are validated as plain digits before being
 used in a query, guarding against SQL injection on agmsg's own side. Unlike agmsg's own
 human-facing `inbox.sh`/`check-inbox.sh` (which mark whatever they display as read), `api.sh` never
-writes `read_at` — panemux's dashboard polling through it cannot cause a joined agent to miss a
-message its own inbox/`Monitor` delivery would otherwise have shown it.
+writes `read_at` — panemux's dashboard/relay polling through it cannot cause a joined agent to miss
+a message its own inbox/`Monitor` delivery would otherwise have shown it.
 
 **Writes — `scripts/send.sh`, not `api.sh`.** Signature: `send.sh <team> <from> <to> <body>
 [--force]`. Unlike `api.sh`, `send.sh` takes `body` as a **positional shell argument**, not stdin —
 there is no stdin-based write path in agmsg to delegate to. `from` is checked against that team's
 roster unless `--force` is passed, in which case an unregistered sender name is accepted as-is.
 
-Choosing `agmsg` for a pane means:
+**Panes join with `join.sh <team> <agent_id> <agent_type> <project_path> [--force]`**, typically
+via agmsg's own onboarding (the `/agmsg` skill flow a live Claude session runs itself, or the
+equivalent for another agent type) rather than the raw script directly — see [Bootstrap
+flow](#bootstrap-flow). This registers the pane into `teams/<team>/config.json`, which is the
+"roster" `send.sh` checks `from` against. Any other agent already using agmsg on that host (Codex,
+Gemini CLI, etc.) can then exchange messages with a panemux-managed pane directly through agmsg,
+with no panemux involvement in that same-host exchange at all. Once joined, agmsg's own
+`SessionStart`/`SessionEnd` hooks own that pane's `Monitor` (`watch.sh`)-process lifecycle
+end-to-end (launch, liveness, cleanup) — panemux has no part in it and does not need to.
 
-- That pane's bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to join
-  agmsg's team using agmsg's own onboarding (typically the `/agmsg` skill flow a live Claude
-  session runs itself). The underlying primitive that establishes membership is `join.sh <team>
-  <agent_id> <agent_type> <project_path> [--force]`, which registers the pane into `teams/<team>
-  /config.json` — this is the "roster" `send.sh` checks `from` against. Any other agent already
-  using agmsg on that host (Codex, Gemini CLI, etc.) can then exchange messages with it directly
-  through agmsg, with no panemux involvement in that same-host exchange at all. Once joined, agmsg's
-  own `SessionStart`/`SessionEnd` hooks own that pane's `Monitor`(`watch.sh`)-process lifecycle
-  end-to-end (launch, liveness, cleanup) — panemux has no part in it and does not need to.
-- agmsg has no native "status" concept, only messages. panemux's status reports map onto ordinary
-  agmsg messages addressed to a reserved agent name, `_panemux_dashboard`, inside the team;
-  `LatestStatusByAgent` for this backend calls `api.sh get teams <team> messages --agent
-  _panemux_dashboard --limit <N>` and keeps only the newest row per `from`.
-- **The relay and the command center are never agmsg roster members, and never go through agmsg's
-  own identity-detection layer, so any send they originate into an agmsg team always passes
-  `send.sh ... --force`.** A live Claude session's own `/agmsg send` normally resolves `from`
-  automatically — `whoami.sh` matches environment variables or, failing that, walks the process
-  tree against each agent type's known process-name patterns, then `identities.sh` reconciles that
-  against a joined team/project — but that whole chain assumes a live process to introspect. The
-  relay and command center are panemux's own Go code, not a joined Claude/Codex process, so no
-  identity-detection result would ever exist for them to look up; `--force` is what lets `send.sh`
-  accept an explicit `from` (the originating pane's ID, or `_panemux` for the command center)
-  without that lookup succeeding first.
-- **Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
-  that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
-  or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If
-  not found, panemux skips board bootstrap for that pane, logs a clear warning naming the pane, and
-  leaves the pane's shell session itself untouched — board is additive, never load-bearing for the
-  pane to function. panemux never runs `npx agmsg`, `npm i -g agmsg`, `git clone`, or any other
-  installer on the operator's behalf, on any host.
-- **Version pinning.** agmsg's own compatibility promise (per its README) only covers reading
-  through `scripts/api.sh`, not `send.sh`'s argument order or `messages.db`. panemux implementation
-  must pin a specific tested agmsg version/tag and treat any change to either script's observed
-  behavior as an external dependency compatibility bug, tracked the same way any other pinned
-  dependency's breaking change would be.
+**panemux's own relay and command center are never agmsg roster members, and never go through
+agmsg's own identity-detection layer, so any send they originate always passes `send.sh ...
+--force`.** A live Claude session's own `/agmsg send` normally resolves `from` automatically —
+`whoami.sh` matches environment variables or, failing that, walks the process tree against each
+agent type's known process-name patterns, then `identities.sh` reconciles that against a joined
+team/project — but that whole chain assumes a live process to introspect. The relay and command
+center are panemux's own Go code, not a joined Claude/Codex process, so no identity-detection
+result would ever exist for them to look up; `--force` is what lets `send.sh` accept an explicit
+`from` (the originating pane's ID, or the reserved identity `_panemux` for the command center)
+without that lookup succeeding first.
+
+**Team naming.** All board-enabled panes on a given panemux instance join the same agmsg team by
+default (`agent_board.team`, default `"panemux"`), so message addressing is just pane IDs within
+one team — see [Config additions](#config-additions).
+
+**Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
+that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
+or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If not
+found, panemux skips board bootstrap for that pane, logs a clear warning naming the pane, and
+leaves the pane's shell session itself untouched. panemux never runs `npx agmsg`, `npm i -g agmsg`,
+`git clone`, or any other installer on the operator's behalf, on any host.
+
+**Version pinning.** agmsg's own compatibility promise (per its README) only covers reading through
+`scripts/api.sh`, not `send.sh`'s argument order or `messages.db`. panemux implementation must pin
+a specific tested agmsg version/tag and treat any change to either script's observed behavior as an
+external dependency compatibility bug, tracked the same way any other pinned dependency's breaking
+change would be.
+
+## Status self-report and message flow
+
+Instead of a `kind='status'` field panemux owns (agmsg has no such column), status reports are
+ordinary agmsg messages addressed to the reserved identity `_panemux` — the same identity the
+command center uses as its own `from` when sending. panemux's dashboard reads them with `api.sh get
+teams <team> messages --agent _panemux --limit <N>` and keeps only the newest row per sender.
+
+The bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to gather this
+itself, using its own `Bash` tool, and include it as a small JSON body:
+
+```json
+{
+  "state": "working",
+  "cwd": "/home/user/project",
+  "branch": "feature/x",
+  "repo": "owner/repo",
+  "pr_url": "https://github.com/owner/repo/pull/123",
+  "last_tool": "Edit internal/api/handler.go",
+  "summary": "テスト修正中"
+}
+```
+
+`branch`/`repo`/`pr_url` come from the agent running `git branch --show-current`, `git remote get-
+url origin`, and a PR lookup (e.g. `gh pr view --json url -q .url`) itself — panemux never computes
+these; it only displays what the agent reported. `cwd`/`pr_url` may be absent if the agent isn't in
+a repository or there's no open PR; the dashboard shows what's present.
+
+```mermaid
+sequenceDiagram
+    participant ClaudeA as "Claude pane (Host A)"
+    participant AgmsgA as "agmsg (Host A)"
+    participant Relay as "panemux 中継"
+    participant AgmsgB as "agmsg (Host B)"
+    participant CodexB as "Codex pane (Host B)"
+    participant Dash as "panemux ダッシュボード"
+
+    Note over ClaudeA: 状態報告（自己申告）
+    ClaudeA->>ClaudeA: git branch / gh pr view を実行
+    ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}"
+    Dash->>AgmsgA: api.sh get teams team messages --agent _panemux
+    AgmsgA-->>Dash: 最新status(JSON)
+
+    Note over ClaudeA,CodexB: pane間メッセージの中継
+    ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "レビューして"
+    Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
+    AgmsgA-->>Relay: 新規行
+    Relay->>AgmsgB: send.sh team ClaudeA CodexB "レビューして" --force
+    CodexB->>AgmsgB: Monitor / watch.sh で受信
+```
+
+**Honest tradeoff, stated explicitly.** Self-report is only as good as the agent's compliance: it
+depends on the agent actually running the bootstrap instruction's commands each time it reports,
+whereas the old transcript-parsing approach was passive and automatic (when it worked at all). The
+bet this redesign makes is that "ask, and get an answer that tracks reality because the agent just
+computed it" is more often correct than "silently infer from an internal format panemux does not
+control," even though the former requires the agent's cooperation and the latter didn't.
 
 ## Package layout
 
@@ -208,55 +244,47 @@ Choosing `agmsg` for a pane means:
 
 ```go
 type Row struct {
-    ID, OriginID int64
-    Team, FromAgent, ToAgent, Kind, Body string
-    CreatedAt time.Time
-    ReadAt    *time.Time
-    OriginHost string
+    ID          int64
+    Team        string
+    From, To    string
+    Body        string
+    At          time.Time
 }
 
-type Store interface {
+type Status struct {
+    State, CWD, Branch, Repo, PRURL, LastTool, Summary string
+}
+
+type AgmsgClient interface {
     HostID() string
-    Insert(ctx context.Context, r Row) (int64, error)
-    InsertRelayed(ctx context.Context, r Row) error // requires OriginHost/OriginID; INSERT OR IGNORE
-    Since(ctx context.Context, afterID int64) ([]Row, error)
-    LatestStatusByAgent(ctx context.Context, team string) (map[string]Row, error)
-    MarkRead(ctx context.Context, ids []int64) error
+    Send(ctx context.Context, team, from, to, body string) error         // send.sh ... --force
+    Since(ctx context.Context, team string, afterID int64) ([]Row, error) // api.sh get ... messages
+    LatestStatusByAgent(ctx context.Context, team string) (map[string]Status, error)
 }
 ```
 
-Four concrete implementations, chosen per host by that host's panes' `agent_board.backend`:
+`LatestStatusByAgent` is derived, not a separate agmsg call: it reads the same `messages` stream
+filtered to `--agent _panemux`, and parses each `body` as the JSON shape from [Status
+self-report](#status-self-report-and-message-flow); a body that isn't valid JSON in that shape is
+treated as an ordinary chat message to `_panemux`, not a status update.
 
-- `LocalNativeStore` opens `~/.config/panemux/board.db` directly with a pure-Go SQLite driver (no
-  CGO, consistent with the single-binary distribution story in [overview.md](overview.md)), in WAL
-  mode. One file is shared by every local and local-tmux pane on the host, and by panemux itself.
-- `RemoteNativeStore` never opens a remote file directly (SQLite's WAL guarantees do not extend
-  across a network filesystem boundary), and — per the no-remote-install rule in
-  [Design principles](#design-principles) — never assumes a `panemux` binary is present on that
-  host either. It runs bare `sqlite3 <path> "<SQL>"` over the existing SSH exec channel: the same
-  binary `agmsg` itself depends on, nothing panemux-specific. Because the SQL text is built by
-  panemux, not by a script that escapes its own inputs the way `send.sh` does, this path requires
-  **two independent escaping layers**: SQL string-literal escaping (doubling embedded `'`) for every
-  value placed inside the SQL text, and then POSIX shell escaping (the same `shellQuotePath`-style
-  single-quote wrapping already used for `cwd`) around the resulting SQL text as a whole, since it
-  is itself one argument in the remote command string. Skipping either layer alone is a real
-  injection path — see [Security model](#security-model) and [security.md](security.md).
-- `LocalAgmsgStore` shells out to the local agmsg installation's `scripts/api.sh` for reads and
-  `scripts/send.sh ... --force` for writes (see [Backends](#backends)); it never touches
-  `messages.db` directly. Because this is a local `exec.Command` invocation, Go passes each
-  argument as a genuine array element with no intermediate shell, so `send.sh`'s argument-based
-  `body` parameter carries no injection risk here regardless of its content.
-- `RemoteAgmsgStore` runs the same two scripts on the remote host over the same SSH exec channel as
-  `RemoteNativeStore`. Reads (`api.sh get ...`) only ever take digit-validated or
-  path-traversal-validated arguments, so they need no special quoting beyond the discipline already
-  applied everywhere else. Writes need only the shell-escaping layer, not the SQL-literal layer:
-  `send.sh` does its own SQL escaping internally (verified in [Backends](#backends)), so
-  `RemoteAgmsgStore` only has to single-quote-escape each argument (team, from, to, body) before
-  building the remote command string — the same single layer `RemoteNativeStore` also needs, minus
-  the SQL-literal step that backend's raw SQL construction requires. Both remote stores satisfy the
-  same underlying requirement ("no user-controlled content reaches a remote shell unescaped") the
-  same way — quoting the exec command string correctly — since `send.sh`'s own contract leaves no
-  stdin-based alternative to fall back on; see [Security model](#security-model).
+- `LocalAgmsgClient` shells out to the local agmsg installation's `scripts/api.sh` for reads and
+  `scripts/send.sh ... --force` for writes. Because this is a local `exec.Command` invocation, Go
+  passes each argument as a genuine array element with no intermediate shell, so `send.sh`'s
+  argument-based `body` parameter carries no injection risk here regardless of its content.
+- `RemoteAgmsgClient` runs the same two scripts on the remote host over the SSH exec channel.
+  Reads (`api.sh get ...`) only ever take digit-validated or path-traversal-validated arguments, so
+  they need no special quoting beyond the discipline already applied everywhere else. Writes need
+  single-quote-escaping of every argument (team, from, to, body) — the same `shellQuotePath`-style
+  discipline `internal/session/ssh.go` already applies to `cwd` — before building the remote
+  command string, since `send.sh` has no stdin option to keep `body` out of it entirely. `send.sh`
+  does its own SQL escaping internally, so this is the *only* escaping layer panemux is responsible
+  for here — there is no local schema of panemux's own to also escape SQL text for. See [Security
+  model](#security-model) and [security.md](security.md).
+
+Because panemux owns no schema, it needs no embedded database driver of its own at all — every
+board operation is either a local `exec.Command` or a remote exec-channel command running agmsg's
+own scripts.
 
 ### `internal/session` capability interfaces
 
@@ -265,20 +293,17 @@ Following the existing optional-capability pattern (`CWDGetter`, `ActiveWorkdirG
 
 ```go
 // BoardHostID is implemented by every session type. It returns the identifier of the host whose
-// board this session's pane belongs to: "local" for local/tmux sessions, the SSH connection name
-// for ssh/ssh_tmux sessions.
+// agmsg installation this session's pane participates in: "local" for local/tmux sessions, the
+// SSH connection name for ssh/ssh_tmux sessions.
 type BoardHostID interface {
     BoardHostID() string
 }
 
-// BoardExecutor is implemented by SSH-backed sessions. It runs the remote board command for
-// whichever backend that pane's host uses, over the session's existing exec channel, as a single
-// shell command string built from args — there is no stdin-based write path for either backend
-// (see docs/agent-board.md#backends), so every argument must be single-quote-escaped (the same
-// discipline internal/session/ssh.go already applies to cwd) before that string is built. `native`
-// additionally SQL-literal-escapes each value before shell-escaping it, since it constructs raw SQL
-// text itself; `agmsg`'s send.sh does its own SQL escaping internally, so RunBoardCommand only
-// needs the shell-escaping layer for that backend.
+// BoardExecutor is implemented by SSH-backed sessions. It runs an agmsg script on the remote host
+// over the session's existing exec channel, as a single shell command string built from args.
+// Every argument must be single-quote-escaped (the same discipline internal/session/ssh.go already
+// applies to cwd) before that string is built; send.sh has no stdin-based write path (see
+// docs/agent-board.md#integration-with-agmsg).
 type BoardExecutor interface {
     RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
 }
@@ -287,31 +312,57 @@ type BoardExecutor interface {
 `LocalSession`/`TmuxLocalSession` implement only `BoardHostID` (`"local"`). `SSHSession`/
 `SSHTmuxSession` implement both.
 
+## Local vs remote resource placement
+
+```mermaid
+flowchart LR
+    subgraph PanemuxHost["panemuxホスト（1台だけ）"]
+        direction TB
+        P1["panemuxバイナリ<br/>(HTTP/WSサーバー本体)"]
+        P2["ローカルagmsg（任意導入）"]
+        P3["中継カーソル<br/>(ローカルJSONファイル)"]
+    end
+
+    subgraph RemoteHost["リモートホスト（SSH到達先、複数可）"]
+        direction TB
+        R1["agmsg<br/>(操作者が別途導入)"]
+        R2["Claude / Codex pane"]
+    end
+
+    PanemuxHost -->|"SSH exec channel経由でapi.sh / send.shのみ実行<br/>panemuxバイナリは絶対に置かない"| RemoteHost
+```
+
+Nothing panemux-specific is ever written to a remote host's disk: no binary, no persisted helper
+script. The only thing a remote host needs beyond what it already has for its own agents is agmsg
+itself, installed by the operator for that host's own reasons (typically: so a non-Claude agent
+there can participate at all).
+
 ## Cross-host relay
 
-Two Claude processes on two different SSH-reached hosts cannot share a board file directly (no
-shared filesystem, and the two hosts may not even be able to reach each other — see the write-up in
-this document's revision history / PR discussion for the TURN-server analogy). panemux is the only
-node with a connection to every host, so it relays:
+Two Claude/Codex processes on two different SSH-reached hosts cannot share one agmsg team directly
+(agmsg is a single-host tool with no cross-host awareness, and the two hosts may not even be able
+to reach each other). panemux is the only node with a connection to every host, so it relays:
 
-1. A single goroutine polls every known `Store.Since(cursor)` every 3 seconds. Note this is one
-   cursor per distinct `Store` instance, i.e. per (host, backend) pair — a host running both a
-   `native` pane and an `agmsg` pane has two independent stores and two cursors, not one.
-2. `cursor` is one value per source store, persisted in a `relay_cursors(source_host TEXT,
-   source_backend TEXT, last_id INTEGER, PRIMARY KEY(source_host, source_backend))` table in the
-   local native board so a panemux restart resumes correctly.
-3. For each new row, panemux resolves `to_agent` to its owning pane, and that pane's `Store` via
-   its configured `(host, backend)`, using the already-known pane→session config. If that
-   destination `Store` differs from the source `Store`, panemux calls `InsertRelayed` on it with
-   `OriginHost`/`OriginID` set to the source row, so a re-relay after a crash/restart is a harmless
-   no-op against `idx_relay_dedup`. This is why cross-*backend* messaging works the same way as
-   cross-*host* messaging even when both panes happen to be on the same host: a `native` pane and
-   an `agmsg` pane on one host are still two different stores, and a message between them still
-   goes through this same relay step, not direct sharing.
-4. A message needs no relay only when source and destination are the exact same `Store` instance
-   (same host, same backend): sender and receiver already share one file.
-5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every managed
-   `Store` and are not relayed; relay only matters for agent-to-agent delivery.
+1. A single goroutine polls every known host's `Since(team, cursor)` every few seconds.
+2. `cursor` is one value per (host, team), persisted in a small local JSON file (e.g.
+   `~/.config/panemux/board-relay-cursor.json`) — not a database table, since panemux owns no
+   database — so a panemux restart resumes roughly where it left off.
+3. For each new row, panemux resolves `to` to its owning pane and that pane's host via the
+   already-known pane→session config. If that host differs from the source host, panemux calls
+   `Send` on the destination host's `AgmsgClient` with `--force`.
+4. Same-host `to` needs no relay: sender and receiver are already members of the same local agmsg
+   team.
+5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every host's
+   `AgmsgClient` and are not relayed; relay only matters for agent-to-agent delivery.
+
+**Delivery is at-least-once, not exactly-once — an accepted simplification, not an oversight.**
+Because agmsg's own schema has no field for panemux to mark "this row has already been relayed,"
+the cursor file is the only bookkeeping. If panemux crashes or restarts between relaying a message
+and persisting the updated cursor, that message can be relayed again, and the destination agent
+sees a duplicate. This is judged an acceptable, self-evident nuisance (a repeated message is easy
+for an agent to recognize and ignore) rather than something worth a more complex dedup scheme —
+consistent with agmsg's own documented v1 limitations elsewhere (see [Known
+limitations](#known-limitations)).
 
 This makes panemux's relay role structurally similar to a TURN server (always in the data path for
 the life of the exchange, because a direct path between the two remote hosts is not assumed to
@@ -320,132 +371,77 @@ Unlike a general-purpose TURN server, panemux is the only possible relay for a g
 (it is the sole node holding SSH credentials to both), so there is no negotiation step — delivery is
 always routed through it by construction.
 
-## CLI subcommands
-
-These apply to panes configured with `agent_board.backend: native` **on the host panemux itself
-runs on** — local and local-tmux panes, where the `panemux` binary is already present. A pane on
-`backend: agmsg` never calls `panemux board *`; it drives agmsg's own `/agmsg`/skill entry points
-instead — see [Backends](#backends). A `native` pane reached over SSH also never calls `panemux
-board *` — per the no-remote-install rule in [Design principles](#design-principles), it runs the
-equivalent `sqlite3` statements directly instead; see [`native`](#native) for exactly how. Same
-binary, `panemux board <subcommand>`:
-
-| Subcommand | Run where | Purpose |
-|---|---|---|
-| `panemux board join <pane-id> [--mode monitor\|turn\|both]` | inside a local pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
-| `panemux board inbox <pane-id> --watch` | inside a local pane, by Claude via `Monitor` (`monitor`/`both` modes) or a `Stop` hook script (`turn`/`both` modes) | Polls for unread rows addressed to `<pane-id>`, prints one line per message, marks each read after printing. Under `Monitor` this polls every ~1s; under a `Stop` hook it runs once, between turns |
-| `panemux board status <pane-id> "<summary>"` | inside a local pane, by Claude | Inserts a `kind='status'` row for that pane |
-| `panemux board status --all` | on panemux's local host, by the command center | Reads `LatestStatusByAgent` across every managed `Store` |
-| `panemux board send <to-pane-id> "<body>"` | on panemux's local host, by the command center | Inserts a `kind='message'` row addressed to any pane, local or remote, native or agmsg; the existing relay (not this command) handles cross-`Store` delivery |
-
-Every board-enabled local pane can run `join`/`inbox`/`status` for itself. `status --all` and `send
-<any-pane-id>` are not pane-scoped — see [Command center](#command-center) for who actually runs
-them and how that is authorized. panemux's own Go code never shells out to this CLI for its own
-reads/writes either: local access goes through `LocalNativeStore`'s direct database driver (see
-[Package layout](#package-layout)), and remote access goes through bare `sqlite3`, never through
-this CLI, since this CLI's binary is never present on a remote host.
-
 ## Bootstrap flow
 
-Steps 1–2 are shared; step 3 branches on the pane's configured backend.
-
-1. A pane config (or the global default) sets `agent_board.enabled: true` with a `backend`
-   (`native`, the default, or `agmsg`) and optionally a non-default `mode`.
+1. A pane config (or the global default) sets `agent_board.enabled: true`, optionally overriding
+   `team` or `mode`.
 2. panemux's existing interactive-agent process detection (already used for the Claude worktree
-   override in [architecture.md](architecture.md)) notices a `claude` process start in that pane.
-   For `backend: agmsg`, panemux first runs the detection check described in
-   [Backends](#backends); if agmsg is not found on that host, it logs a warning naming the pane and
-   stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
+   override in [architecture.md](architecture.md)) notices a `claude` (or other configured agent)
+   process start in that pane, then runs the agmsg detection check from [Integration with
+   agmsg](#integration-with-agmsg). If agmsg is not found on that host, it logs a warning naming the
+   pane and stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
 3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
-   used for all terminal input):
-   - **`native`, local/local-tmux pane**: tells Claude to run `panemux board join <pane-id>
-     [--mode ...]` and to start `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
-   - **`native`, SSH/SSH+tmux pane**: per the no-remote-install rule in
-     [Design principles](#design-principles), there is no `panemux board *` to run remotely. The
-     instruction instead defines the small set of `sqlite3`-wrapping shell functions described in
-     [`native`](#native) inline, then tells Claude to use them for `join`/`status`/`inbox` and to
-     watch the inbox function's output under `Monitor`. Nothing from this step is written to the
-     remote host's disk; the functions live only in that shell session.
-   - **`agmsg`**: tells Claude to join agmsg's team using agmsg's own onboarding flow (e.g.
-     `/agmsg` or the equivalent first-run prompt for that team/agent name) and to rely on agmsg's
-     own `Monitor`/hook wiring for delivery, exactly as it would if the user had set this up by
-     hand outside of panemux. This is unaffected by local vs. remote, since it is agmsg's own
-     already-installed skill doing the work either way, not something panemux provisions per pane.
-   This step only ever establishes *that pane's* participation; it never touches any other pane or
-   any other agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps
-   working exactly as it did before panemux was involved).
-4. `native`, local/local-tmux only: panemux installs one skill file, e.g.
-   `~/.claude/commands/panemux-board.md`, once, explicitly (not a silent `settings.json` hooks edit)
-   so the bootstrap instruction can also be given as a short slash command. Installing this skill is
-   itself gated on `agent_board.enabled` and is idempotent. `native` SSH panes skip this step
-   entirely — the same no-remote-install rule that keeps the `panemux` binary off remote hosts
-   applies to this skill file too, so remote panes rely solely on the self-contained PTY instruction
-   from step 3. `agmsg` panes rely on agmsg's own already-installed skill instead, regardless of
-   local or remote.
-5. `native`, local/local-tmux only: if the pane was joined with `--mode turn` or `--mode both`,
-   `join` prints the exact `Stop` hook entry to add to `~/.claude/settings.json`; panemux never
-   writes that file itself, so this step requires the user (or Claude, with the user's confirmation,
-   since editing `settings.json` is a file write like any other) to apply it manually. `native` SSH
-   panes would need this edit applied to `~/.claude/settings.json` *on the remote host*, which is
-   the user's own file to manage there, same as it would be for a `local` pane's `settings.json`;
-   panemux's role is limited to printing the snippet either way. `agmsg` panes use agmsg's own
-   `/agmsg mode` instead, entirely outside panemux's control.
+   used for all terminal input) telling the agent to join agmsg's team using agmsg's own onboarding
+   flow (e.g. `/agmsg` or the equivalent first-run prompt), to rely on agmsg's own `Monitor`/hook
+   wiring for delivery exactly as it would if the user had set this up by hand, and to include the
+   [status self-report](#status-self-report-and-message-flow) fields on every status update. This
+   is unaffected by local vs. remote — it is agmsg's own already-installed skill doing the work
+   either way, not something panemux provisions per pane. This step only ever establishes *that
+   pane's* participation; it never touches any other pane or any other agent already using agmsg on
+   that host (a pre-existing Codex agent, for example, keeps working exactly as it did before
+   panemux was involved).
+4. If `mode` is `turn` or `both` (mirroring agmsg's own `/agmsg mode monitor|turn|both`, default
+   `monitor`), the bootstrap instruction also tells the agent to run `/agmsg mode <value>` — this
+   is agmsg's own setting, not something panemux tracks or enforces separately.
 
 ## Command center
-
-Earlier drafts of this document modeled the orchestrator as a pane with `role: supervisor` running
-an ordinary interactive `claude` process. That is no longer the design: the intended experience is
-a local, Spotlight-style command palette the user converses with, not a terminal pane sitting in
-the layout. This section replaces the old "Roles" section.
 
 ### What it is
 
 - A single, persistent **headless** Claude session, not a pane and not a PTY. panemux invokes it as
-  a short-lived subprocess per query — `claude -p --resume <command-center-session-id> "<prompt>"`
-  — rather than a long-running process, so this does not introduce the "new daemon" this document's
-  [Design principles](#design-principles) rule out. `--resume` against one fixed session id is what
-  gives the command center conversational continuity across separate queries.
-- It reads and writes the board through the exact same `panemux board status --all` / `panemux
-  board send <any-pane-id> "<body>"` native CLI already defined in
-  [CLI subcommands](#cli-subcommands), invoked as ordinary `Bash` tool calls within its own turn —
-  no new board primitive is needed for it.
-- `board send` always writes to the *local* native `Store` (the command center is not itself a
-  pane bound to a particular host/backend). The existing [cross-host relay](#cross-host-relay)
-  — which already routes by the destination pane's `(host, backend)` regardless of where a message
-  originated — delivers it onward to native or agmsg panes, local or remote, with no
-  command-center-specific routing logic required.
-- The reserved agent identity `_panemux` is used both as the `from_agent` when the command center
-  sends, and as the `to_agent` workers report status to for dashboard aggregation (unifying the
-  identity already introduced for the `agmsg` backend's status mapping in [Backends](#backends)
-  rather than adding a second reserved name).
+  a short-lived subprocess per query — `claude -p --resume <command-center-session-id>
+  --output-format=stream-json "<prompt>"` — rather than a long-running process, so this does not
+  introduce the "new daemon" [Design principles](#design-principles) rules out. `--resume` against
+  one fixed session id is what gives the command center conversational continuity across separate
+  queries.
+- It runs on panemux's own local host only (never remote), so it uses the local agmsg installation
+  directly: `send.sh <team> _panemux <to-pane-id> "<body>" --force` to instruct any pane, and
+  `api.sh get teams <team> messages --agent _panemux --limit <N>` to read status across every pane
+  — the same calls [Package layout](#package-layout)'s `AgmsgClient` already wraps, invoked as
+  ordinary `Bash` tool calls within its own turn. Enabling the command center therefore requires
+  agmsg to be present on panemux's own host, gated by the same detection (never installation) rule
+  as any other agmsg-backed pane.
+- Because the destination pane's host is resolved the same way for any `send.sh --force` call
+  regardless of who issued it, the command center needs no special-cased routing: the [cross-host
+  relay](#cross-host-relay) delivers its messages onward exactly as it would for any other pane's
+  message to a pane on a different host.
 
 ### Authorization
 
 The command center's privilege (it can message *any* board-enabled pane) is not granted by any
-board-level pane role — there is no pane role left in this design. It is granted the same way every
-other capability in panemux is: `POST`/WS access to the command center's own endpoint requires the
-global bearer-token auth described in [Security model](#security-model). This is a cleaner trust
-boundary than a pane self-declaring `role: supervisor` ever was, because it is enforced by
-panemux's existing authenticated API layer rather than by convention a receiving pane has to trust.
+per-pane role — there is no pane role in this design. It is granted the same way every other
+capability in panemux is: WS/REST access to the command center's own endpoints requires the global
+bearer-token auth described in [Security model](#security-model).
 
-**Trust implication, stated explicitly, still applies:** a message the command center sends is an
-ordinary instruction to the receiving pane, not something pre-authorized — the same caveat already
-called out for the `SendMessage` tool in Claude Code itself. The receiving pane's own normal
-confirmation flow still applies.
+**Trust implication, stated explicitly:** a message the command center sends is an ordinary
+instruction to the receiving pane, not something pre-authorized — the same caveat already called
+out for the `SendMessage` tool in Claude Code itself. The receiving pane's own normal confirmation
+flow still applies.
 
 ### API and streaming
 
-- `POST /ws/board-command` (WebSocket, matching the existing `/ws/{sessionID}` streaming pattern
-  rather than a blocking REST call): the frontend sends `{"prompt": "..."}`, panemux runs `claude -p
-  --resume <id> --output-format=stream-json "<prompt>"` and streams tokens back as they're
-  generated, so the palette can show live output instead of waiting for the full response.
-- `GET /api/board/command/history`: returns the command center's own turn-by-turn history, parsed
-  from its Claude Code session transcript using the transcript-reading capability panemux already
-  has for Claude worktree resolution (see [architecture.md](architecture.md)) — reused as-is, not
-  duplicated into the board's `messages` table. Because `board send`/`board status --all` calls
-  the command center makes appear as ordinary tool calls in that same transcript, the returned
-  history already interleaves "what the user asked," "what the command center did on the board,"
-  and "what it told the user" in one chronological feed, with no extra bookkeeping required.
+- `WS /ws/board-command`: the frontend sends `{"prompt": "..."}`, panemux runs `claude -p --resume
+  <id> --output-format=stream-json "<prompt>"` and streams the subprocess's output back as it
+  arrives, so the palette can show live output instead of waiting for the full response.
+- `GET /api/board/command/history`: returns the command center's own turn-by-turn history. This is
+  **not** re-derived from Claude Code's transcript file after the fact — per [Design
+  principles](#design-principles)'s "ask, don't reverse-engineer" rule, panemux persists what it
+  already captured directly from the `--output-format=stream-json` stream while relaying it to the
+  WS client (a documented, stable CLI output contract), appending it to a local file panemux fully
+  owns the format of. Because `send.sh`/`api.sh` calls the command center makes appear as ordinary
+  tool-use entries in that same captured stream, the returned history already interleaves "what the
+  user asked," "what the command center did on the board," and "what it told the user" in one
+  chronological feed, with no extra bookkeeping required.
 
 ### UI
 
@@ -473,11 +469,11 @@ unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it s
 
 | Endpoint | Purpose |
 |---|---|
-| `GET /api/board/status` | Latest `kind='status'` row per pane, across every host panemux manages |
+| `GET /api/board/status` | Latest self-reported status per pane, across every host panemux manages |
 | `GET /api/board/messages?since=<id>` | History feed for the dashboard UI |
-| `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; inserts directly into each target's own host `Store` (never via PTY injection, so it is safe to send to a pane mid-turn) |
+| `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn) |
 | `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
-| `GET /api/board/command/history` | Command center's own transcript-derived conversation history — see [Command center](#command-center) |
+| `GET /api/board/command/history` | Command center's own captured conversation history — see [Command center](#command-center) |
 
 ## Config additions
 
@@ -488,27 +484,28 @@ server:
   auth_token: ""   # empty = auto-generate on first run, saved to ~/.config/panemux/token (0600)
 
 command_center:
-  enabled: true   # default false; spawns the headless claude -p --resume process on demand
+  enabled: true   # default false; requires agmsg present on panemux's own host
+
+agent_board:
+  team: "panemux"  # default; all board-enabled panes share this agmsg team unless overridden
 
 panes:
   - id: pane-a
     type: local
     agent_board:
       enabled: true
-      backend: native  # native (default) | agmsg; explicit only, never auto-detected
-      mode: monitor    # monitor (default) | turn | both; turn/both need a manually-added Stop hook
+      mode: monitor    # monitor (default) | turn | both, mirrors agmsg's own /agmsg mode
 
-  - id: pane-b          # e.g. a Codex pane sharing pane-a's host
+  - id: pane-b          # e.g. a Codex pane
     type: ssh
     connection: build-host
     agent_board:
       enabled: true
-      backend: agmsg   # required for any non-Claude agent; panemux has no native protocol for Codex
 ```
 
-A global `agent_board.enabled`/`backend` default may also be supported so individual panes don't
-need to repeat it, but `backend: agmsg` still requires agmsg to already be present on that pane's
-host — panemux will not install it, per [Backends](#backends).
+A global `agent_board.enabled` default may also be supported so individual panes don't need to
+repeat it, but board features on any given host still require agmsg to already be present there —
+panemux will not install it, per [Integration with agmsg](#integration-with-agmsg).
 
 ## Security model
 
@@ -526,64 +523,60 @@ that shaped the design.
   ultimately drive shell-executing agents). Config validation must therefore fail closed: if
   `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
   be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
-- **Message bodies never reach a remote shell unescaped.** Neither remote backend has a stdin-based
-  write path: `native` builds its own `sqlite3 <path> "<SQL>"` invocation (no panemux binary is ever
-  on the remote host to hand a JSON payload to over stdin — see the next point), and `send.sh` — the
-  `agmsg` write path, verified against its own source, not assumed — takes `body` as a positional
-  argument with no stdin option either. The requirement is upheld the way `cwd` already is in
-  `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`): every argument is single-quote
-  escaped before the remote command string is built, never concatenated unescaped. `native`
-  additionally SQL-literal-escapes each value first, since it is the one constructing the SQL text
-  itself; `agmsg`'s `send.sh` does that escaping internally, so only the shell-escaping layer is
-  panemux's responsibility on that path. See [Package layout](#package-layout) for exactly which
-  store needs which layer.
-- **panemux itself is never deployed to a remote host, for its own sake as much as for the reasons
-  above.** Beyond the injection-surface argument, the `panemux` binary is also the server: a copy
-  running on an SSH-reached host could start its own HTTP/WS listener, auth surface, and command
-  center — a second, unmanaged instance of everything [Security model](#security-model) already
-  works to contain for the primary one, multiplied by every remote host in the config. `native`'s
-  remote support is deliberately built only on `sqlite3` so this can never happen as a side effect
-  of using board features.
+- **Message bodies never reach a remote shell unescaped.** `send.sh` has no stdin-based way to
+  receive its `body` argument — verified against agmsg's own source, not assumed — so
+  `RemoteAgmsgClient` cannot avoid putting the body in the remote command string. The requirement
+  is upheld the way `cwd` already is in `internal/session/ssh.go` (`validRemotePath` /
+  `shellQuotePath`): every argument is single-quote-escaped before the command string is built,
+  never concatenated unescaped. `send.sh` does its own SQL escaping internally, so this
+  shell-escaping layer is the only one panemux is responsible for — there is no panemux-owned SQL
+  text to also escape, unlike an earlier draft of this design that had panemux building its own SQL.
+- **panemux itself is never deployed to a remote host.** Beyond the injection-surface argument
+  above, the `panemux` binary is also the server: a copy running on an SSH-reached host could start
+  its own HTTP/WS listener, auth surface, and command center — a second, unmanaged instance of
+  everything this section already works to contain for the primary one, multiplied by every remote
+  host in the config. Board features depend only on an agmsg installation the operator placed
+  there, never on anything panemux ships.
 - **agmsg is an operator-installed, unpinned-by-panemux external dependency.** panemux only detects
-  and calls it; it never bundles, vendors, or auto-installs it (see [Backends](#backends) and
-  [Design principles](#design-principles)). MIT license permits depending on it, but panemux's
-  implementation still owes itself a pinned tested version/tag and treats a break in
-  `scripts/api.sh`'s behavior as an external dependency compatibility bug.
-- **Local board files are `0600`.** `~/.config/panemux/board.db` and the remote equivalent are
-  created with owner-only permissions. This does not create a new trust boundary — any other
-  process running as the same OS user is already inside panemux's existing trust boundary per
-  [overview.md](overview.md) — but it does prevent a different local *user* on a shared host from
-  reading cross-pane agent chatter.
+  and calls it; it never bundles, vendors, or auto-installs it (see [Integration with
+  agmsg](#integration-with-agmsg) and [Design principles](#design-principles)). MIT license permits
+  depending on it, but panemux's implementation still owes itself a pinned tested version/tag and
+  treats a break in `scripts/api.sh`'s or `scripts/send.sh`'s behavior as an external dependency
+  compatibility bug.
 - **panemux sees plaintext at each relay hop.** SSH encrypts each hop (panemux↔host A,
   panemux↔host B), but panemux itself decrypts and re-serializes the row in between, so the
   panemux process/host must be trusted for the relay to be meaningful. There is no end-to-end
-  encryption between two remote agents' Claude processes.
+  encryption between two remote agents' Claude/Codex processes.
 - **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
-  bearer token as everything else, and that gate is the entire authorization model for
-  `board send <any-pane-id>`** — see [Command center](#command-center). There is deliberately no
-  separate, weaker permission tier for it; anyone who can authenticate to panemux at all can already
-  reach the full-shell terminal WebSocket, so a second, narrower gate here would not reduce real
-  risk, only add a second thing to keep in sync.
+  bearer token as everything else, and that gate is the entire authorization model for messaging
+  any pane from the command center** — see [Command center](#command-center). There is deliberately
+  no separate, weaker permission tier for it; anyone who can authenticate to panemux at all can
+  already reach the full-shell terminal WebSocket, so a second, narrower gate here would not reduce
+  real risk, only add a second thing to keep in sync.
 
 ## Known limitations
 
 - No claim/lease semantics: if two workers were both addressed by the same message (not a supported
-  case today, since `to_agent` targets one pane), there is no exclusion mechanism. This mirrors
-  agmsg's own documented v1 limitation. Note this is distinct from agmsg's `actas-claim.sh` lock,
-  verified against its source: that lock only prevents two sessions from claiming the *same role
-  name* at once (exit code 1 if already held) — it says nothing about, and does not provide, message
-  claim/lease semantics for delivery.
-- Agents/teams are free-text identifiers with no cryptographic authentication of `from_agent`. Any
-  local process that can open the board file can forge a sender. This is an integrity gap distinct
-  from the transport-confidentiality concerns above and is accepted for the same reason panemux
-  already accepts same-user process trust elsewhere.
-- Relay latency is bounded by the 3s poll interval, not real-time; cross-host messaging is not
-  suitable for anything requiring sub-second delivery.
-- `backend: agmsg` panes depend on an operator-installed third-party tool panemux does not manage
-  the lifecycle of. If that installation is upgraded to a version whose `scripts/api.sh` behavior
-  has changed incompatibly, panemux's `LocalAgmsgStore`/`RemoteAgmsgStore` can fail even though
-  nothing in panemux's own config changed. This is the accepted cost of not vendoring/pinning a
-  copy of agmsg inside panemux itself.
+  case today, since `to` targets one pane), there is no exclusion mechanism. This mirrors agmsg's
+  own documented v1 limitation. Distinct from that: agmsg's `actas-claim.sh` lock only prevents two
+  sessions from claiming the *same role name* at once (exit code 1 if already held) — it says
+  nothing about, and does not provide, message claim/lease semantics for delivery.
+- Agents/teams are free-text identifiers with no cryptographic authentication of `from`. Any local
+  process that can reach a host's agmsg installation can forge a sender. This is an integrity gap
+  distinct from the transport-confidentiality concerns above and is accepted for the same reason
+  panemux already accepts same-user process trust elsewhere.
+- Relay delivery is at-least-once, bounded by the poll interval, not real-time or exactly-once; see
+  [Cross-host relay](#cross-host-relay) for why a duplicate message after a panemux restart is an
+  accepted outcome rather than something engineered away.
+- Board features depend on an operator-installed third-party tool (agmsg) panemux does not manage
+  the lifecycle of. If that installation is upgraded to a version whose scripts behave
+  incompatibly, panemux's `AgmsgClient` can fail even though nothing in panemux's own config
+  changed. This is the accepted cost of not vendoring/pinning a copy of agmsg inside panemux
+  itself.
+- Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
+  called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
+  following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops
+  updating its status until its next report, with no separate liveness signal from panemux itself.
 - Exactly one command center session exists per panemux instance (see
   [Command center](#command-center)); it is not per-workspace and does not support multiple
   concurrent orchestrators today.
@@ -594,37 +587,28 @@ that shaped the design.
 
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 
-- `internal/board`: insert/read roundtrip, unread filtering and `MarkRead`, relay dedup (same
-  `origin_host`+`origin_id` inserted twice is a no-op), cursor persistence across a simulated
-  restart, `LatestStatusByAgent` with multiple status rows (only the newest per agent wins), empty
-  board.
-- `internal/session`: for `RemoteAgmsgStore`, a body containing shell metacharacters (`'`, `;`,
+- `internal/board`: status JSON parsing (valid full payload, missing optional fields, a body that
+  isn't the expected shape falls back to being treated as a plain message), `LatestStatusByAgent`
+  with multiple status rows (only the newest per sender wins), relay cursor persistence across a
+  simulated restart (including the accepted at-least-once duplicate case — assert it is delivered
+  again, not that it's silently dropped or that the relay errors), empty team.
+- `internal/session`: for `RemoteAgmsgClient`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
-  literal argument, not as executed shell syntax. For `RemoteNativeStore`, the same class of body
-  must round-trip through *two* escaping layers correctly: the built `sqlite3` SQL text contains
-  the value as a valid SQL string literal (embedded `'` doubled), and that whole SQL text then
-  round-trips through shell-escaping as a single argument — a test that only checks one layer would
-  miss a real injection path in the other. Neither backend has a "must never enter the command
-  string" property to test anymore (see [Design principles](#design-principles) for why); the
-  assertion for both is "the command string must escape this correctly."
+  literal argument, not as executed shell syntax.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
-  combinations are valid. `agent_board.backend` accepts only `native`/`agmsg`; anything else is a
-  validation error (no silent fallback to a default).
+  combinations are valid. `agent_board.team` defaults to `"panemux"` when unset.
 - `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
   handshake; correct token succeeds.
-- Backend selection and detection: a pane configured with `backend: agmsg` on a host where agmsg is
-  absent skips bootstrap and logs a warning without touching the pane's session (asserted against a
-  fake/no-op `BoardExecutor`/host check, not a real agmsg install); a pane configured with
-  `backend: agmsg` where agmsg is present bootstraps through the agmsg path instead of `panemux
-  board *`; mixed-backend same-host relay (a `native` pane and an `agmsg` pane on one host,
-  addressed to each other) goes through the relay step rather than being treated as already-shared.
+- agmsg detection: a pane on a host where agmsg is absent skips bootstrap and logs a warning
+  without touching the pane's session (asserted against a fake/no-op `BoardExecutor`/host check,
+  not a real agmsg install); a pane on a host where agmsg is present bootstraps normally.
 - Command center: `/ws/board-command` rejects an unauthenticated connection the same way the
-  terminal WebSocket does; `board send`/`board status --all` issued from the command center's
-  subprocess reach a target pane regardless of that pane's `(host, backend)`, using a fake `Store`
-  per combination to assert routing without a real agmsg/SSH dependency; `GET
-  /api/board/command/history` parses a fixture transcript containing interleaved user turns,
-  assistant text, and `board send`/`status --all` tool calls into one ordered feed, and returns an
-  empty/well-defined result before the command center has ever been used (no transcript file yet).
+  terminal WebSocket does; a `send.sh --force` call issued from the command center's subprocess
+  reaches a target pane regardless of that pane's host, using a fake `AgmsgClient` per host to
+  assert routing without a real agmsg/SSH dependency; `GET /api/board/command/history` returns a
+  correctly ordered feed built from a fixture `stream-json` capture containing interleaved user
+  turns, assistant text, and tool calls, and returns an empty/well-defined result before the
+  command center has ever been used.
 
 ## Related documents
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -82,39 +82,55 @@ Agent Board replaces that inference with a small, self-reported channel:
 
 ```mermaid
 flowchart TB
-    Browser["ブラウザ<br/>ダッシュボード + Spotlightパレット"]
+    subgraph UILayer["UI層（ブラウザ）"]
+        Dashboard["ダッシュボード"]
+        Palette["Spotlightパレット"]
+    end
 
-    subgraph Local["panemuxが動くホスト（常にここだけ）"]
-        Server["panemux Goプロセス<br/>WS / REST, Bearerトークン認証"]
+    subgraph CommLayer["通信層"]
+        RestWs["REST /api/board/*<br/>WS /ws/board-command<br/>Bearerトークン認証"]
+        LocalExec["ローカル exec.Command"]
+        ExecCh["SSH exec channel<br/>（GetCWD/InspectGitContextと共用）"]
+    end
+
+    subgraph ClientLayer["クライアント層（panemux Goプロセス）"]
         Relay["中継ゴルーチン<br/>数秒間隔でポーリング"]
         CmdCenter["司令塔<br/>claude -p --resume（クエリごとに起動）"]
+        AgmsgClient["AgmsgClient<br/>Local/RemoteAgmsgClient"]
+    end
+
+    subgraph AgentLayer["エージェント層（agmsgチーム）"]
         LocalAgmsg[("ローカルagmsg<br/>（任意インストール）")]
-    end
-
-    subgraph HostA["リモートホストA（SSH）"]
-        AgmsgA[("agmsg")]
+        AgmsgA[("agmsg（Host A）")]
         ClaudeA["Claude pane"]
-    end
-
-    subgraph HostB["リモートホストB（SSH）"]
-        AgmsgB[("agmsg")]
+        AgmsgB[("agmsg（Host B）")]
         CodexB["Codex pane"]
     end
 
-    Browser <--> Server
-    Server --> Relay
-    Server --> CmdCenter
-    Relay -->|"api.sh / send.sh"| LocalAgmsg
-    CmdCenter -->|"api.sh / send.sh --force"| LocalAgmsg
-    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
-    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
+    Dashboard --> RestWs
+    Palette --> RestWs
+    RestWs --> Relay
+    RestWs --> CmdCenter
+    Relay --> AgmsgClient
+    CmdCenter --> AgmsgClient
+    AgmsgClient --> LocalExec
+    AgmsgClient --> ExecCh
+    LocalExec -->|"api.sh / send.sh"| LocalAgmsg
+    ExecCh -->|"api.sh / send.sh"| AgmsgA
+    ExecCh -->|"api.sh / send.sh"| AgmsgB
     ClaudeA -->|"Bashツール呼び出し"| AgmsgA
     CodexB -->|"Bashツール呼び出し"| AgmsgB
 ```
 
-panemux is never a participant on more than one host's agmsg installation from the inside — it
-only ever reaches a remote host's agmsg through the SSH exec channel it already holds for that
-pane's session, running agmsg's own scripts, exactly as [Local vs remote resource
+Four layers, top to bottom: the **UI layer** (dashboard + Spotlight palette) never talks to agmsg
+directly — everything goes through the **communication layer** (the authenticated REST/WS surface
+for the browser, plus local `exec.Command`/SSH exec channel for reaching agmsg itself). The
+**client layer** is panemux's own Go code (relay, command center, the `AgmsgClient` abstraction
+from [Package layout](#package-layout)) — it is the only thing that ever calls agmsg's scripts, and
+it is never a participant *inside* more than one host's agmsg installation at a time. The **agent
+layer** is agmsg itself (one team per host) plus the Claude/Codex panes that are its actual
+members; panemux only ever reaches a remote one through the SSH exec channel it already holds for
+that pane's session, exactly as [Local vs remote resource
 placement](#local-vs-remote-resource-placement) details.
 
 ## Integration with agmsg

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -37,10 +37,21 @@ Agent Board replaces that inference with a small, self-reported, structured chan
 
 ## Design principles
 
-- **No new daemon, no new listening port.** The mechanism is a local SQLite file per host, opened
-  directly by both panemux and the Claude process running in that host's panes, plus reuse of the
-  SSH exec channel panemux already holds open for `GetCWD`/`InspectGitContext`
-  (`internal/session/ssh.go`).
+- **No new daemon, no new listening port.** The mechanism is a local SQLite file per host. On the
+  host panemux itself runs on, panemux's Go process and the Claude process in that host's panes
+  both open it directly. On a remote (SSH) host, panemux never opens the file directly and never
+  places any binary of its own there — see the next principle — it only runs `sqlite3` over the SSH
+  exec channel panemux already holds open for `GetCWD`/`InspectGitContext`
+  (`internal/session/ssh.go`), the same tool a remote Claude pane's own Bash calls also use.
+- **panemux itself is never installed on a remote host, under any circumstances.** The `panemux`
+  binary is also a server: running it can start the HTTP/WS listener, the auth surface, and the
+  command center. Placing a copy on every SSH-reached host that wants `native`-backend board
+  features would mean each of those hosts could accidentally end up running a second panemux
+  server — a second command center, a second thing to firewall and issue an auth token for, and a
+  second instance of every network-exposure question already worked through for the primary one in
+  [Security model](#security-model). `native`'s remote support is therefore built entirely on
+  `sqlite3`, a tool that cannot itself become a server, exactly mirroring the minimal-footprint
+  assumption the `agmsg` backend already makes about what a remote host has installed.
 - **Claude drives its own participation with its own tools.** panemux does not push data into
   Claude's context out-of-band. It types a one-time bootstrap instruction into the pane (the same
   mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
@@ -109,10 +120,22 @@ whenever a pane needs to coordinate with agents other than Claude (Codex, Gemini
 
 ### `native`
 
-panemux's own schema and CLI, exactly as described above and in
-[CLI subcommands](#cli-subcommands). Self-contained: no third-party tool required on the pane's
-host. Claude-to-Claude only — a Codex pane on the same host cannot join a `native` team, because
-`native` is a panemux-specific protocol Codex has no knowledge of.
+panemux's own schema. Claude-to-Claude only — a Codex pane on the same host cannot join a `native`
+team, because `native` is a panemux-specific protocol Codex has no knowledge of.
+
+The CLI surface differs by where the pane lives, because of the no-remote-install rule above:
+
+- **Local/local-tmux panes** (same host as panemux): the pane's Claude process runs the
+  `panemux board join/inbox/status/send` CLI described in [CLI subcommands](#cli-subcommands)
+  directly — the `panemux` binary is trivially already there, since it's the same one serving the
+  pane.
+- **SSH/SSH+tmux panes**: there is no `panemux board *` CLI to run remotely. The bootstrap
+  instruction (see [Bootstrap flow](#bootstrap-flow)) instead defines a handful of shell functions
+  inline, in the text typed into the pane, that wrap direct `sqlite3 <path> "<SQL>"` calls against
+  that host's own `~/.config/panemux/board.db` — nothing is written to disk on the remote host to
+  provide this; the functions exist only for the lifetime of that shell session, the same way any
+  other one-off shell function would. This is self-contained the same way `native` is everywhere
+  else: still no third-party tool, only `sqlite3`, which most hosts already have.
 
 ### `agmsg`
 
@@ -208,10 +231,16 @@ Four concrete implementations, chosen per host by that host's panes' `agent_boar
   CGO, consistent with the single-binary distribution story in [overview.md](overview.md)), in WAL
   mode. One file is shared by every local and local-tmux pane on the host, and by panemux itself.
 - `RemoteNativeStore` never opens a remote file directly (SQLite's WAL guarantees do not extend
-  across a network filesystem boundary). It calls the fixed remote command `panemux board recv`
-  over the existing SSH exec channel and writes the row as JSON to that command's **stdin**. It
-  never interpolates message bodies into a shell command string. See
-  [Security model](#security-model) and [security.md](security.md).
+  across a network filesystem boundary), and — per the no-remote-install rule in
+  [Design principles](#design-principles) — never assumes a `panemux` binary is present on that
+  host either. It runs bare `sqlite3 <path> "<SQL>"` over the existing SSH exec channel: the same
+  binary `agmsg` itself depends on, nothing panemux-specific. Because the SQL text is built by
+  panemux, not by a script that escapes its own inputs the way `send.sh` does, this path requires
+  **two independent escaping layers**: SQL string-literal escaping (doubling embedded `'`) for every
+  value placed inside the SQL text, and then POSIX shell escaping (the same `shellQuotePath`-style
+  single-quote wrapping already used for `cwd`) around the resulting SQL text as a whole, since it
+  is itself one argument in the remote command string. Skipping either layer alone is a real
+  injection path — see [Security model](#security-model) and [security.md](security.md).
 - `LocalAgmsgStore` shells out to the local agmsg installation's `scripts/api.sh` for reads and
   `scripts/send.sh ... --force` for writes (see [Backends](#backends)); it never touches
   `messages.db` directly. Because this is a local `exec.Command` invocation, Go passes each
@@ -220,16 +249,14 @@ Four concrete implementations, chosen per host by that host's panes' `agent_boar
 - `RemoteAgmsgStore` runs the same two scripts on the remote host over the same SSH exec channel as
   `RemoteNativeStore`. Reads (`api.sh get ...`) only ever take digit-validated or
   path-traversal-validated arguments, so they need no special quoting beyond the discipline already
-  applied everywhere else. Writes are different: `send.sh` has no stdin-based way to receive `body`
-  (see [Backends](#backends)), so unlike `RemoteNativeStore`'s `panemux board recv`, `body` cannot
-  be kept off the exec command string here. `RemoteAgmsgStore` must instead single-quote-escape
-  every argument (team, from, to, body) with the same `shellQuotePath`-style escaping
-  `internal/session/ssh.go` already applies to `cwd`, and build the exec command string from that —
-  never from unescaped concatenation. This is a documented, precedented exception to the
-  stdin-preferred rule in [Security model](#security-model), not a relaxation of it: the underlying
-  requirement ("no user-controlled content reaches a remote shell unescaped") is upheld by
-  quoting instead of by avoiding the exec command string, because `send.sh`'s own contract leaves
-  no other way to pass `body` to it remotely.
+  applied everywhere else. Writes need only the shell-escaping layer, not the SQL-literal layer:
+  `send.sh` does its own SQL escaping internally (verified in [Backends](#backends)), so
+  `RemoteAgmsgStore` only has to single-quote-escape each argument (team, from, to, body) before
+  building the remote command string — the same single layer `RemoteNativeStore` also needs, minus
+  the SQL-literal step that backend's raw SQL construction requires. Both remote stores satisfy the
+  same underlying requirement ("no user-controlled content reaches a remote shell unescaped") the
+  same way — quoting the exec command string correctly — since `send.sh`'s own contract leaves no
+  stdin-based alternative to fall back on; see [Security model](#security-model).
 
 ### `internal/session` capability interfaces
 
@@ -245,14 +272,15 @@ type BoardHostID interface {
 }
 
 // BoardExecutor is implemented by SSH-backed sessions. It runs the remote board command for
-// whichever backend that pane's host uses over the session's existing exec channel. For `native`,
-// args is just ["board", "recv"] and body content goes over stdin, never into the command string.
-// For `agmsg`, send.sh has no stdin path for its body argument (see docs/agent-board.md#backends),
-// so args carries every value including body, and the implementation must single-quote-escape each
-// element (the same discipline internal/session/ssh.go already applies to cwd) before building the
-// remote command string — stdin is unused on that path.
+// whichever backend that pane's host uses, over the session's existing exec channel, as a single
+// shell command string built from args — there is no stdin-based write path for either backend
+// (see docs/agent-board.md#backends), so every argument must be single-quote-escaped (the same
+// discipline internal/session/ssh.go already applies to cwd) before that string is built. `native`
+// additionally SQL-literal-escapes each value before shell-escaping it, since it constructs raw SQL
+// text itself; `agmsg`'s send.sh does its own SQL escaping internally, so RunBoardCommand only
+// needs the shell-escaping layer for that backend.
 type BoardExecutor interface {
-    RunBoardCommand(ctx context.Context, args []string, stdin []byte) ([]byte, error)
+    RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
 }
 ```
 
@@ -294,22 +322,28 @@ always routed through it by construction.
 
 ## CLI subcommands
 
-These apply only to panes configured with `agent_board.backend: native`. A pane on `backend: agmsg`
-never calls `panemux board *`; it drives agmsg's own `/agmsg`/skill entry points instead — see
-[Backends](#backends). Same binary, `panemux board <subcommand>`:
+These apply to panes configured with `agent_board.backend: native` **on the host panemux itself
+runs on** — local and local-tmux panes, where the `panemux` binary is already present. A pane on
+`backend: agmsg` never calls `panemux board *`; it drives agmsg's own `/agmsg`/skill entry points
+instead — see [Backends](#backends). A `native` pane reached over SSH also never calls `panemux
+board *` — per the no-remote-install rule in [Design principles](#design-principles), it runs the
+equivalent `sqlite3` statements directly instead; see [`native`](#native) for exactly how. Same
+binary, `panemux board <subcommand>`:
 
 | Subcommand | Run where | Purpose |
 |---|---|---|
-| `panemux board join <pane-id> [--mode monitor\|turn\|both]` | inside the pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
-| `panemux board inbox <pane-id> --watch` | inside the pane, by Claude via `Monitor` (`monitor`/`both` modes) or a `Stop` hook script (`turn`/`both` modes) | Polls for unread rows addressed to `<pane-id>`, prints one line per message, marks each read after printing. Under `Monitor` this polls every ~1s; under a `Stop` hook it runs once, between turns |
-| `panemux board status <pane-id> "<summary>"` | inside the pane, by Claude | Inserts a `kind='status'` row for that pane |
+| `panemux board join <pane-id> [--mode monitor\|turn\|both]` | inside a local pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
+| `panemux board inbox <pane-id> --watch` | inside a local pane, by Claude via `Monitor` (`monitor`/`both` modes) or a `Stop` hook script (`turn`/`both` modes) | Polls for unread rows addressed to `<pane-id>`, prints one line per message, marks each read after printing. Under `Monitor` this polls every ~1s; under a `Stop` hook it runs once, between turns |
+| `panemux board status <pane-id> "<summary>"` | inside a local pane, by Claude | Inserts a `kind='status'` row for that pane |
 | `panemux board status --all` | on panemux's local host, by the command center | Reads `LatestStatusByAgent` across every managed `Store` |
 | `panemux board send <to-pane-id> "<body>"` | on panemux's local host, by the command center | Inserts a `kind='message'` row addressed to any pane, local or remote, native or agmsg; the existing relay (not this command) handles cross-`Store` delivery |
-| `panemux board recv` | remote host only, invoked by panemux over the exec channel | Reads one JSON row from stdin, inserts it with parameterized SQL. The only board subcommand panemux itself ever executes remotely |
 
-Every board-enabled pane can run `join`/`inbox`/`status` for itself. `status --all` and `send
+Every board-enabled local pane can run `join`/`inbox`/`status` for itself. `status --all` and `send
 <any-pane-id>` are not pane-scoped — see [Command center](#command-center) for who actually runs
-them and how that is authorized.
+them and how that is authorized. panemux's own Go code never shells out to this CLI for its own
+reads/writes either: local access goes through `LocalNativeStore`'s direct database driver (see
+[Package layout](#package-layout)), and remote access goes through bare `sqlite3`, never through
+this CLI, since this CLI's binary is never present on a remote host.
 
 ## Bootstrap flow
 
@@ -324,24 +358,38 @@ Steps 1–2 are shared; step 3 branches on the pane's configured backend.
    stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
 3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
    used for all terminal input):
-   - **`native`**: tells Claude to run `panemux board join <pane-id> [--mode ...]` and to start
-     `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
+   - **`native`, local/local-tmux pane**: tells Claude to run `panemux board join <pane-id>
+     [--mode ...]` and to start `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
+   - **`native`, SSH/SSH+tmux pane**: per the no-remote-install rule in
+     [Design principles](#design-principles), there is no `panemux board *` to run remotely. The
+     instruction instead defines the small set of `sqlite3`-wrapping shell functions described in
+     [`native`](#native) inline, then tells Claude to use them for `join`/`status`/`inbox` and to
+     watch the inbox function's output under `Monitor`. Nothing from this step is written to the
+     remote host's disk; the functions live only in that shell session.
    - **`agmsg`**: tells Claude to join agmsg's team using agmsg's own onboarding flow (e.g.
      `/agmsg` or the equivalent first-run prompt for that team/agent name) and to rely on agmsg's
      own `Monitor`/hook wiring for delivery, exactly as it would if the user had set this up by
-     hand outside of panemux.
+     hand outside of panemux. This is unaffected by local vs. remote, since it is agmsg's own
+     already-installed skill doing the work either way, not something panemux provisions per pane.
    This step only ever establishes *that pane's* participation; it never touches any other pane or
    any other agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps
    working exactly as it did before panemux was involved).
-4. `native` only: panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once,
-   explicitly (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be
-   given as a short slash command. Installing this skill is itself gated on `agent_board.enabled`
-   and is idempotent. `agmsg` panes rely on agmsg's own already-installed skill instead.
-5. `native` only: if the pane was joined with `--mode turn` or `--mode both`, `join` prints the
-   exact `Stop` hook entry to add to `~/.claude/settings.json`; panemux never writes that file
-   itself, so this step requires the user (or Claude, with the user's confirmation, since editing
-   `settings.json` is a file write like any other) to apply it manually. `agmsg` panes use agmsg's
-   own `/agmsg mode` instead, entirely outside panemux's control.
+4. `native`, local/local-tmux only: panemux installs one skill file, e.g.
+   `~/.claude/commands/panemux-board.md`, once, explicitly (not a silent `settings.json` hooks edit)
+   so the bootstrap instruction can also be given as a short slash command. Installing this skill is
+   itself gated on `agent_board.enabled` and is idempotent. `native` SSH panes skip this step
+   entirely — the same no-remote-install rule that keeps the `panemux` binary off remote hosts
+   applies to this skill file too, so remote panes rely solely on the self-contained PTY instruction
+   from step 3. `agmsg` panes rely on agmsg's own already-installed skill instead, regardless of
+   local or remote.
+5. `native`, local/local-tmux only: if the pane was joined with `--mode turn` or `--mode both`,
+   `join` prints the exact `Stop` hook entry to add to `~/.claude/settings.json`; panemux never
+   writes that file itself, so this step requires the user (or Claude, with the user's confirmation,
+   since editing `settings.json` is a file write like any other) to apply it manually. `native` SSH
+   panes would need this edit applied to `~/.claude/settings.json` *on the remote host*, which is
+   the user's own file to manage there, same as it would be for a `local` pane's `settings.json`;
+   panemux's role is limited to printing the snippet either way. `agmsg` panes use agmsg's own
+   `/agmsg mode` instead, entirely outside panemux's control.
 
 ## Command center
 
@@ -478,16 +526,24 @@ that shaped the design.
   ultimately drive shell-executing agents). Config validation must therefore fail closed: if
   `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
   be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
-- **Message bodies never reach a remote shell unescaped.** For `native`, `RunBoardCommand` sends
-  the body over the exec channel's stdin to the fixed argv `panemux board recv`, keeping it out of
-  the command string entirely. For `agmsg`, `send.sh` has no stdin-based way to receive its `body`
-  argument — verified against agmsg's own source, not assumed — so this backend cannot avoid
-  putting the body in the remote command string. The requirement is upheld the same way `cwd`
-  already is in `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`): every argument,
-  body included, is single-quote-escaped before the command string is built, never concatenated
-  unescaped. Both backends satisfy "no unescaped user content reaches a remote shell"; they satisfy
-  it by different means because `send.sh`'s own argument-based contract leaves `native` a stdin
-  option that `agmsg` does not have.
+- **Message bodies never reach a remote shell unescaped.** Neither remote backend has a stdin-based
+  write path: `native` builds its own `sqlite3 <path> "<SQL>"` invocation (no panemux binary is ever
+  on the remote host to hand a JSON payload to over stdin — see the next point), and `send.sh` — the
+  `agmsg` write path, verified against its own source, not assumed — takes `body` as a positional
+  argument with no stdin option either. The requirement is upheld the way `cwd` already is in
+  `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`): every argument is single-quote
+  escaped before the remote command string is built, never concatenated unescaped. `native`
+  additionally SQL-literal-escapes each value first, since it is the one constructing the SQL text
+  itself; `agmsg`'s `send.sh` does that escaping internally, so only the shell-escaping layer is
+  panemux's responsibility on that path. See [Package layout](#package-layout) for exactly which
+  store needs which layer.
+- **panemux itself is never deployed to a remote host, for its own sake as much as for the reasons
+  above.** Beyond the injection-surface argument, the `panemux` binary is also the server: a copy
+  running on an SSH-reached host could start its own HTTP/WS listener, auth surface, and command
+  center — a second, unmanaged instance of everything [Security model](#security-model) already
+  works to contain for the primary one, multiplied by every remote host in the config. `native`'s
+  remote support is deliberately built only on `sqlite3` so this can never happen as a side effect
+  of using board features.
 - **agmsg is an operator-installed, unpinned-by-panemux external dependency.** panemux only detects
   and calls it; it never bundles, vendors, or auto-installs it (see [Backends](#backends) and
   [Design principles](#design-principles)). MIT license permits depending on it, but panemux's
@@ -542,13 +598,15 @@ that shaped the design.
   `origin_host`+`origin_id` inserted twice is a no-op), cursor persistence across a simulated
   restart, `LatestStatusByAgent` with multiple status rows (only the newest per agent wins), empty
   board.
-- `internal/session`: for `native`, `RunBoardCommand` never places body content in the remote
-  command string, only in stdin (mirrors the existing `validateShell` test pattern). For `agmsg`,
-  the reverse must hold and be tested explicitly: a body containing shell metacharacters (`'`, `;`,
+- `internal/session`: for `RemoteAgmsgStore`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
-  literal argument, not as executed shell syntax — this is the one board path where the assertion
-  is "the command string must escape this correctly," not "this must never enter the command
-  string," and the test suite must cover both properties without conflating them.
+  literal argument, not as executed shell syntax. For `RemoteNativeStore`, the same class of body
+  must round-trip through *two* escaping layers correctly: the built `sqlite3` SQL text contains
+  the value as a valid SQL string literal (embedded `'` doubled), and that whole SQL text then
+  round-trips through shell-escaping as a single argument — a test that only checks one layer would
+  miss a real injection path in the other. Neither backend has a "must never enter the command
+  string" property to test anymore (see [Design principles](#design-principles) for why); the
+  assertion for both is "the command string must escape this correctly."
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
   combinations are valid. `agent_board.backend` accepts only `native`/`agmsg`; anything else is a
   validation error (no silent fallback to a default).

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -42,18 +42,22 @@ Agent Board replaces that inference with a small, self-reported, structured chan
   mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
   own inbox and to run a small CLI to report status and send messages. Everything panemux observes
   is something Claude itself chose to write, using its own `Bash`/`Monitor` tool calls.
-- **Hooks are avoidable, not required — because panemux has something agmsg doesn't.**
-  [agmsg](https://github.com/fujibee/agmsg) is a plain bash+sqlite3 skill with no host-side
-  controller, so it needs a `SessionStart` hook just to auto-launch `Monitor` when a Claude Code
-  session starts, and a `Stop` hook for its "turn mode" fallback (`/agmsg mode monitor|turn|both`) —
-  hooks are how agmsg gets *anything* to happen automatically, for both modes, not only the
-  fallback one. panemux does not have that constraint: it already has write access to every pane's
-  PTY (the same path used for all terminal input), so it can type the `Monitor`-launching bootstrap
-  instruction itself, once, the moment it detects a `claude` process starting in a board-enabled
-  pane — reproducing agmsg's "automatic, no user action" property without ever touching the user's
-  `~/.claude/settings.json`. A user who additionally wants a `Stop`-hook "turn mode" fallback for
-  extra delivery reliability (mirroring agmsg's `turn`/`both` modes) can still add one manually; the
-  bootstrap message prints the hook snippet to add, but panemux never installs it itself.
+- **Hooks are optional for panemux-managed panes because panemux and
+  [agmsg](https://github.com/fujibee/agmsg) sit at different layers of the system, not because one
+  supersedes the other.** agmsg is deliberately environment-agnostic: a skill that works the same
+  way whether or not anything is hosting the terminal it runs in, which is exactly why it relies on
+  hooks (`SessionStart` to auto-launch `Monitor`, `Stop` for its "turn mode" fallback via `/agmsg
+  mode monitor|turn|both`) — hooks are how *any* Claude Code session gets something to happen
+  automatically, agmsg included, when nothing external is watching. panemux, by contrast, already
+  sits between the user and the pane as the terminal host, with write access to every pane's PTY
+  (the same path used for all terminal input). That host-level position is what lets it type the
+  `Monitor`-launching bootstrap instruction itself, once, the moment it detects a `claude` process
+  starting in a board-enabled pane, without touching the user's `~/.claude/settings.json` —
+  reproducing the same "automatic, no user action" property agmsg achieves through hooks, just by a
+  different mechanism available to a host application that a standalone skill does not have access
+  to. A user who additionally wants a `Stop`-hook "turn mode" fallback for extra delivery
+  reliability (mirroring agmsg's `turn`/`both` modes) can still add one manually; the bootstrap
+  message prints the hook snippet to add, but panemux never installs it itself.
 - **Delivery mode is configurable per pane, mirroring agmsg's `/agmsg mode`.** `join` accepts
   `--mode monitor|turn|both` (default `monitor`). `turn` and `both` require the user-added `Stop`
   hook above; panemux cannot upgrade a pane into those modes on its own.
@@ -106,6 +110,16 @@ summary; `kind='message'` rows carry chat/instruction content.
 default — never inferred by probing the host. Both backends implement the same `Store` interface
 (below), so the relay and dashboard code is backend-agnostic; only the bootstrap flow and the CLI
 surface a board-enabled pane actually runs differ.
+
+These two backends are not ranked against each other, and this document does not treat either as
+the "real" or preferred one. They cover different ground: agmsg is a general, host-agnostic,
+multi-agent messaging tool that already works across many CLI agents and many environments, with a
+maturity and breadth panemux does not attempt to duplicate. `native` exists for the narrower case
+of Claude-only panes on a host where the operator has not installed a separate tool, and it works
+only *because* panemux is already the terminal host for those panes, giving it options (PTY
+injection, an existing SSH exec channel to relay over) that a portable, environment-agnostic tool
+like agmsg deliberately does not assume it has. Choosing one over the other for a given pane is a
+question of what that pane needs, not which backend is "better."
 
 ### `native`
 
@@ -283,8 +297,9 @@ Steps 1–2 are shared; step 3 branches on the pane's configured backend.
      `/agmsg` or the equivalent first-run prompt for that team/agent name) and to rely on agmsg's
      own `Monitor`/hook wiring for delivery, exactly as it would if the user had set this up by
      hand outside of panemux.
-   Either way, this single PTY write is what lets panemux skip the `SessionStart` hook agmsg itself
-   needs for the same auto-launch effect — see [Design principles](#design-principles). This step
+   Either way, this single PTY write is panemux's host-level counterpart to the `SessionStart` hook
+   agmsg relies on for the same auto-launch effect in environments with no host application present
+   — see [Design principles](#design-principles). This step
    only ever establishes *that pane's* participation; it never touches any other pane or any other
    agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps working
    exactly as it did before panemux was involved).

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -42,22 +42,11 @@ Agent Board replaces that inference with a small, self-reported, structured chan
   mechanism already used for terminal input) telling Claude to use the `Monitor` tool to watch its
   own inbox and to run a small CLI to report status and send messages. Everything panemux observes
   is something Claude itself chose to write, using its own `Bash`/`Monitor` tool calls.
-- **Hooks are optional for panemux-managed panes because panemux and
-  [agmsg](https://github.com/fujibee/agmsg) sit at different layers of the system, not because one
-  supersedes the other.** agmsg is deliberately environment-agnostic: a skill that works the same
-  way whether or not anything is hosting the terminal it runs in, which is exactly why it relies on
-  hooks (`SessionStart` to auto-launch `Monitor`, `Stop` for its "turn mode" fallback via `/agmsg
-  mode monitor|turn|both`) — hooks are how *any* Claude Code session gets something to happen
-  automatically, agmsg included, when nothing external is watching. panemux, by contrast, already
-  sits between the user and the pane as the terminal host, with write access to every pane's PTY
-  (the same path used for all terminal input). That host-level position is what lets it type the
-  `Monitor`-launching bootstrap instruction itself, once, the moment it detects a `claude` process
-  starting in a board-enabled pane, without touching the user's `~/.claude/settings.json` —
-  reproducing the same "automatic, no user action" property agmsg achieves through hooks, just by a
-  different mechanism available to a host application that a standalone skill does not have access
-  to. A user who additionally wants a `Stop`-hook "turn mode" fallback for extra delivery
-  reliability (mirroring agmsg's `turn`/`both` modes) can still add one manually; the bootstrap
-  message prints the hook snippet to add, but panemux never installs it itself.
+- **`native`-backend bootstrap does not edit `~/.claude/settings.json`.** panemux writes the
+  `Monitor`-launching instruction directly into the pane's PTY (the same path used for all terminal
+  input) the moment it detects a `claude` process starting in a board-enabled pane. A user who wants
+  a `Stop`-hook "turn mode" fallback for extra delivery reliability can still add one manually; the
+  bootstrap message prints the hook snippet to add, but panemux never installs it itself.
 - **Delivery mode is configurable per pane, mirroring agmsg's `/agmsg mode`.** `join` accepts
   `--mode monitor|turn|both` (default `monitor`). `turn` and `both` require the user-added `Stop`
   hook above; panemux cannot upgrade a pane into those modes on its own.
@@ -111,15 +100,8 @@ default — never inferred by probing the host. Both backends implement the same
 (below), so the relay and dashboard code is backend-agnostic; only the bootstrap flow and the CLI
 surface a board-enabled pane actually runs differ.
 
-These two backends are not ranked against each other, and this document does not treat either as
-the "real" or preferred one. They cover different ground: agmsg is a general, host-agnostic,
-multi-agent messaging tool that already works across many CLI agents and many environments, with a
-maturity and breadth panemux does not attempt to duplicate. `native` exists for the narrower case
-of Claude-only panes on a host where the operator has not installed a separate tool, and it works
-only *because* panemux is already the terminal host for those panes, giving it options (PTY
-injection, an existing SSH exec channel to relay over) that a portable, environment-agnostic tool
-like agmsg deliberately does not assume it has. Choosing one over the other for a given pane is a
-question of what that pane needs, not which backend is "better."
+`native` is panemux's own mechanism for Claude-only panes. `agmsg` is the communication layer used
+whenever a pane needs to coordinate with agents other than Claude (Codex, Gemini CLI, etc.).
 
 ### `native`
 
@@ -297,12 +279,9 @@ Steps 1–2 are shared; step 3 branches on the pane's configured backend.
      `/agmsg` or the equivalent first-run prompt for that team/agent name) and to rely on agmsg's
      own `Monitor`/hook wiring for delivery, exactly as it would if the user had set this up by
      hand outside of panemux.
-   Either way, this single PTY write is panemux's host-level counterpart to the `SessionStart` hook
-   agmsg relies on for the same auto-launch effect in environments with no host application present
-   — see [Design principles](#design-principles). This step
-   only ever establishes *that pane's* participation; it never touches any other pane or any other
-   agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps working
-   exactly as it did before panemux was involved).
+   This step only ever establishes *that pane's* participation; it never touches any other pane or
+   any other agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps
+   working exactly as it did before panemux was involved).
 4. `native` only: panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once,
    explicitly (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be
    given as a short slash command. Installing this skill is itself gated on `agent_board.enabled`

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -73,7 +73,9 @@ Agent Board replaces that inference with a small, self-reported channel:
   `native` tried to do, plus interoperability with Codex/Gemini/etc. that `native` could never
   offer, and every pane on `agmsg` from the start means no relay step is needed even for two panes
   that happen to both be Claude. Agent Board is therefore built entirely on agmsg; panemux owns no
-  message schema of its own.
+  message schema of its own. The same reasoning was later applied to Claude Code's own native
+  cross-session messaging feature — see [Alternatives
+  considered](#claude-codes-native-cross-session-messaging-2026-08-08).
 - **No new daemon, no new listening port — scoped to what panemux itself starts.** panemux talks to
   agmsg the same way any of its scripts or a live agent session would: local `exec.Command` calls on
   the host panemux itself runs on, and the existing SSH exec channel (`GetCWD`/`InspectGitContext`
@@ -97,6 +99,56 @@ Agent Board replaces that inference with a small, self-reported channel:
   on the operator's behalf, on any host. See [Integration with agmsg](#integration-with-agmsg).
 - **panemux is a trusted relay, not an end-to-end encrypted channel.** See
   [Cross-host relay](#cross-host-relay) and [Security model](#security-model).
+
+## Alternatives considered
+
+### Claude Code's native cross-session messaging (2026-08-08)
+
+Claude Code [added native cross-session
+messaging](https://code.claude.com/docs/en/cross-session-messaging) (v2.1.224+): a `ListAgents`
+tool for discovering other Claude Code sessions and a `SendMessage` tool for delivering plain text
+to one of them by name, callable by Claude itself, not by an external process. Same-machine delivery
+goes over a per-session Unix domain socket the receiving session binds and never touches Anthropic
+servers; delivery to a session on another machine or [Claude Code on the
+web](claude-code-on-the-web) goes through Anthropic servers via a Remote Control connection, and is
+reply-only in that direction — a session here cannot originate a message to a session it hasn't
+first heard from.
+
+This looked promising enough to evaluate seriously against Agent Board's own goals, and was
+rejected as a replacement (or a parallel mechanism) for the same reasons the earlier `native`
+SQLite draft was rejected in favor of agmsg, plus one more specific to how this feature is exposed:
+
+- **Claude-only.** It has no notion of Codex, Gemini CLI, or any other agent type — exactly the
+  interoperability agmsg provides and the `native` draft could not (see [Design
+  principles](#design-principles)'s "one messaging mechanism, not two"). Adopting it for board
+  traffic would mean two different mechanisms depending on which agent is in a pane, which is the
+  same shape of problem this document already reasoned its way out of once.
+- **Doesn't fit panemux's arbitrary-SSH-host model.** Same-machine delivery requires both sessions
+  to see the same on-disk registration files — it says nothing about an SSH-reached remote host.
+  Cross-machine delivery exists, but only through a Remote Control connection and only as a reply,
+  never as an originating send — a fundamentally different, heavier operational model than "the
+  operator already has agmsg installed on that host," and one that still couldn't originate the
+  status self-report or command-center broadcast this design depends on across hosts.
+- **No documented interface for panemux itself to use.** The only sanctioned way to send or receive
+  is Claude calling `SendMessage`/`ListAgents` itself; there is no REST/CLI entry point a Go process
+  can call directly. The one adjacent primitive that looks like an external hook —
+  `CLAUDE_CODE_MESSAGING_SOCKET`, the inbox socket path exported to a session's own child processes
+  — has no documented wire format here, and panemux is the *parent* of a pane's shell (and thus an
+  ancestor, not a child, of the Claude process running inside it), so it would not even qualify for
+  the "own-child" delivery path this feature defines. Writing to that socket directly would be
+  exactly the kind of undocumented-internal-format reverse-engineering [Design
+  principles](#design-principles)'s "ask the agent; don't reverse-engineer its internal state" rule
+  already rejects for agmsg's `messages.db` — the principle applies here just as much as it did
+  there, including to a first-party Anthropic feature.
+
+None of this rules out a Claude session itself choosing to use `SendMessage` for its own,
+non-board-related purposes — that's between the user and their agent, and orthogonal to what Agent
+Board specifies. It also doesn't rule out a narrower future integration (for example, prompting a
+Claude pane to use `SendMessage` instead of `send.sh` when both sender and receiver are confirmed
+local Claude sessions) if a real need for it shows up later. But nothing in this design should be
+built toward that today: it would reintroduce exactly the two-mechanism problem "one messaging
+mechanism, not two" exists to prevent, for a narrower agent-type and host-topology coverage than
+agmsg already provides.
 
 ## Architecture
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -22,6 +22,12 @@ Agent Board replaces that inference with a small, self-reported, structured chan
 2. Lets a human (or one designated "supervisor" pane) broadcast a message to one or more panes'
    Claude sessions without racing raw keystrokes into a live PTY.
 3. Aggregates all of the above into one dashboard and, for a supervisor pane, one queryable feed.
+4. Optionally interoperates with [agmsg](https://github.com/fujibee/agmsg), an existing MIT-licensed
+   bash+sqlite3 agent-messaging tool that already supports Claude Code, Codex, Gemini CLI, GitHub
+   Copilot, Antigravity, OpenCode, and Hermes. Where a pane's host already runs agmsg, a
+   panemux-managed pane can join the same team as a Codex pane and reuse agmsg's own Codex support
+   (boot-prompt handoff, turn-mode delivery) instead of panemux reimplementing it. See
+   [Backends](#backends).
 
 ## Design principles
 
@@ -49,13 +55,26 @@ Agent Board replaces that inference with a small, self-reported, structured chan
 - **Delivery mode is configurable per pane, mirroring agmsg's `/agmsg mode`.** `join` accepts
   `--mode monitor|turn|both` (default `monitor`). `turn` and `both` require the user-added `Stop`
   hook above; panemux cannot upgrade a pane into those modes on its own.
+- **Backend selection is explicit config, never auto-detected, and panemux never installs agmsg
+  itself.** A pane either uses panemux's own built-in ("native") board, or agmsg, per the pane's
+  configured `agent_board.backend`. panemux does not probe a host for agmsg and silently switch
+  behavior based on what it finds — that would make a pane's messaging behavior depend on
+  unrelated host state and would be surprising to debug. If `backend: agmsg` is set for a pane and
+  agmsg is not present on that pane's host, board bootstrap for that pane is skipped with a clear,
+  visible warning; panemux never runs an installer on the operator's behalf, local or remote. See
+  [Backends](#backends).
 - **panemux is a trusted relay, not an end-to-end encrypted channel.** See
   [Cross-host relay](#cross-host-relay) and [Security model](#security-model).
 
-## Schema
+## Schema (native backend only)
 
-One table per host, based directly on agmsg's proven schema with two added columns for
-cross-host relay dedup:
+This schema belongs solely to panemux's own built-in ("native") backend. It is loosely inspired by
+agmsg's message-oriented shape (team/from/to/body/read_at), but it is **not** an attempt at
+schema-level compatibility with agmsg's actual `messages.db`: agmsg's own README states that
+`messages.db` and `teams/*/config.json` are "internal and free to change" and that third parties
+should integrate through `scripts/api.sh` instead. panemux follows that guidance — see
+[Backends](#backends) for how the agmsg backend actually integrates. One table per host, with two
+added columns for cross-host relay dedup that agmsg (a single-host tool) has no equivalent of:
 
 ```sql
 CREATE TABLE messages (
@@ -78,6 +97,54 @@ CREATE INDEX idx_history ON messages(team, created_at DESC);
 `from_agent`/`to_agent` are pane IDs (already globally unique across workspaces per
 [architecture.md](architecture.md)). `kind='status'` rows carry the latest self-reported activity
 summary; `kind='message'` rows carry chat/instruction content.
+
+## Backends
+
+`agent_board.backend` is `native` (default) or `agmsg`, set explicitly per pane or as a global
+default — never inferred by probing the host. Both backends implement the same `Store` interface
+(below), so the relay and dashboard code is backend-agnostic; only the bootstrap flow and the CLI
+surface a board-enabled pane actually runs differ.
+
+### `native`
+
+panemux's own schema and CLI, exactly as described above and in
+[CLI subcommands](#cli-subcommands). Self-contained: no third-party tool required on the pane's
+host. Claude-to-Claude only — a Codex pane on the same host cannot join a `native` team, because
+`native` is a panemux-specific protocol Codex has no knowledge of.
+
+### `agmsg`
+
+Delegates to an agmsg installation already present on the pane's host, using only the interfaces
+agmsg documents as stable for third-party use: the CLI/skill entry points (`/agmsg ...` from inside
+Claude Code, or the equivalent `$agmsg`/skill invocation for other agents) and `scripts/api.sh` for
+JSON-in/JSON-out reads and writes. panemux never reads or writes agmsg's `messages.db` or
+`teams/*/config.json` directly, matching agmsg's own README guidance that those are internal.
+
+Choosing `agmsg` for a pane means:
+
+- That pane's bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to join
+  agmsg's team instead of panemux's own, using agmsg's own `join`/`actas` semantics. Any other
+  agent already using agmsg on that host (Codex, Gemini CLI, etc.) can then exchange messages with
+  it directly through agmsg, with no panemux involvement in that same-host exchange at all.
+- agmsg has no native "status" concept, only messages. panemux's status reports map onto ordinary
+  agmsg messages addressed to a reserved agent name (e.g. `_panemux_dashboard`) inside the team;
+  `LatestStatusByAgent` for this backend reads the history addressed to that reserved name and
+  keeps only the newest row per sender. The exact `scripts/api.sh` flags this requires must be
+  confirmed against a pinned agmsg version at implementation time — this document does not assert
+  a flag surface it has not verified.
+- panemux's own dashboard reads and the cross-host relay both go through `scripts/api.sh`, not
+  through a shared schema, for the same reason panemux itself avoids the raw file.
+- **Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
+  that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
+  or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If
+  not found, panemux skips board bootstrap for that pane, logs a clear warning naming the pane, and
+  leaves the pane's shell session itself untouched — board is additive, never load-bearing for the
+  pane to function. panemux never runs `npx agmsg`, `npm i -g agmsg`, `git clone`, or any other
+  installer on the operator's behalf, on any host.
+- **Version pinning.** Because agmsg's own compatibility promise only covers `scripts/api.sh`'s
+  JSON contract (not internal storage), panemux implementation must pin a specific tested agmsg
+  version/tag range and treat a break in that script's behavior as an external dependency
+  compatibility bug, tracked the same way any other pinned dependency's breaking change would be.
 
 ## Package layout
 
@@ -102,14 +169,21 @@ type Store interface {
 }
 ```
 
-- `LocalStore` opens `~/.config/panemux/board.db` directly with a pure-Go SQLite driver (no CGO,
-  consistent with the single-binary distribution story in [overview.md](overview.md)), in WAL
+Four concrete implementations, chosen per host by that host's panes' `agent_board.backend`:
+
+- `LocalNativeStore` opens `~/.config/panemux/board.db` directly with a pure-Go SQLite driver (no
+  CGO, consistent with the single-binary distribution story in [overview.md](overview.md)), in WAL
   mode. One file is shared by every local and local-tmux pane on the host, and by panemux itself.
-- `RemoteStore` never opens a remote file directly (SQLite's WAL guarantees do not extend across a
-  network filesystem boundary). It calls the fixed remote command `panemux board recv` over the
-  existing SSH exec channel and writes the row as JSON to that command's **stdin**. It never
-  interpolates message bodies into a shell command string. See
+- `RemoteNativeStore` never opens a remote file directly (SQLite's WAL guarantees do not extend
+  across a network filesystem boundary). It calls the fixed remote command `panemux board recv`
+  over the existing SSH exec channel and writes the row as JSON to that command's **stdin**. It
+  never interpolates message bodies into a shell command string. See
   [Security model](#security-model) and [security.md](security.md).
+- `LocalAgmsgStore` shells out to the local agmsg installation's `scripts/api.sh` (see
+  [Backends](#backends)); it never touches `messages.db` directly.
+- `RemoteAgmsgStore` runs the remote host's `scripts/api.sh` over the same SSH exec channel as
+  `RemoteNativeStore`, with the same stdin-only, no-argv-interpolation discipline for message
+  bodies.
 
 ### `internal/session` capability interfaces
 
@@ -124,9 +198,10 @@ type BoardHostID interface {
     BoardHostID() string
 }
 
-// BoardExecutor is implemented by SSH-backed sessions. It runs `panemux board recv` on the remote
-// host over the session's existing exec channel, writing stdin and returning stdout, without ever
-// building a shell command string from body content.
+// BoardExecutor is implemented by SSH-backed sessions. It runs the remote board command for
+// whichever backend that pane's host uses (`panemux board recv` for native, agmsg's own
+// scripts/api.sh for agmsg) over the session's existing exec channel, writing stdin and returning
+// stdout, without ever building a shell command string from body content.
 type BoardExecutor interface {
     RunBoardCommand(ctx context.Context, args []string, stdin []byte) ([]byte, error)
 }
@@ -142,15 +217,23 @@ shared filesystem, and the two hosts may not even be able to reach each other �
 this document's revision history / PR discussion for the TURN-server analogy). panemux is the only
 node with a connection to every host, so it relays:
 
-1. A single goroutine polls every known host's `Store.Since(cursor)` every 3 seconds.
-2. `cursor` is one value per source host, persisted in a `relay_cursors(source_host TEXT PRIMARY
-   KEY, last_id INTEGER)` table in the local board so a panemux restart resumes correctly.
-3. For each new row, panemux resolves `to_agent` to its owning host via the already-known
-   pane→session config. If the destination host differs from the source host, panemux calls
-   `InsertRelayed` on the destination `Store` with `OriginHost`/`OriginID` set to the source row, so
-   a re-relay after a crash/restart is a harmless no-op against `idx_relay_dedup`.
-4. Same-host `to_agent` needs no relay: sender and receiver already share one file.
-5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every host's
+1. A single goroutine polls every known `Store.Since(cursor)` every 3 seconds. Note this is one
+   cursor per distinct `Store` instance, i.e. per (host, backend) pair — a host running both a
+   `native` pane and an `agmsg` pane has two independent stores and two cursors, not one.
+2. `cursor` is one value per source store, persisted in a `relay_cursors(source_host TEXT,
+   source_backend TEXT, last_id INTEGER, PRIMARY KEY(source_host, source_backend))` table in the
+   local native board so a panemux restart resumes correctly.
+3. For each new row, panemux resolves `to_agent` to its owning pane, and that pane's `Store` via
+   its configured `(host, backend)`, using the already-known pane→session config. If that
+   destination `Store` differs from the source `Store`, panemux calls `InsertRelayed` on it with
+   `OriginHost`/`OriginID` set to the source row, so a re-relay after a crash/restart is a harmless
+   no-op against `idx_relay_dedup`. This is why cross-*backend* messaging works the same way as
+   cross-*host* messaging even when both panes happen to be on the same host: a `native` pane and
+   an `agmsg` pane on one host are still two different stores, and a message between them still
+   goes through this same relay step, not direct sharing.
+4. A message needs no relay only when source and destination are the exact same `Store` instance
+   (same host, same backend): sender and receiver already share one file.
+5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every managed
    `Store` and are not relayed; relay only matters for agent-to-agent delivery.
 
 This makes panemux's relay role structurally similar to a TURN server (always in the data path for
@@ -162,7 +245,9 @@ always routed through it by construction.
 
 ## CLI subcommands
 
-Same binary, `panemux board <subcommand>`:
+These apply only to panes configured with `agent_board.backend: native`. A pane on `backend: agmsg`
+never calls `panemux board *`; it drives agmsg's own `/agmsg`/skill entry points instead — see
+[Backends](#backends). Same binary, `panemux board <subcommand>`:
 
 | Subcommand | Run where | Purpose |
 |---|---|---|
@@ -174,23 +259,37 @@ Same binary, `panemux board <subcommand>`:
 
 ## Bootstrap flow
 
-1. A pane config (or the global default) sets `agent_board.enabled: true` (optionally with a
-   non-default `mode`).
+Steps 1–2 are shared; step 3 branches on the pane's configured backend.
+
+1. A pane config (or the global default) sets `agent_board.enabled: true` with a `backend`
+   (`native`, the default, or `agmsg`) and optionally a non-default `mode`.
 2. panemux's existing interactive-agent process detection (already used for the Claude worktree
    override in [architecture.md](architecture.md)) notices a `claude` process start in that pane.
+   For `backend: agmsg`, panemux first runs the detection check described in
+   [Backends](#backends); if agmsg is not found on that host, it logs a warning naming the pane and
+   stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
 3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
-   used for all terminal input) telling Claude to run `panemux board join <pane-id> [--mode ...]`
-   and to start `panemux board inbox <pane-id> --watch` under the `Monitor` tool. This single PTY
-   write is what lets panemux skip the `SessionStart` hook agmsg needs for the same auto-launch
-   effect — see [Design principles](#design-principles).
-4. panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once, explicitly
-   (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be given as a
-   short slash command. Installing this skill is itself gated on `agent_board.enabled` and is
-   idempotent.
-5. If the pane was joined with `--mode turn` or `--mode both`, `join` prints the exact `Stop` hook
-   entry to add to `~/.claude/settings.json`; panemux never writes that file itself, so this step
-   requires the user (or Claude, with the user's confirmation, since editing `settings.json` is a
-   file write like any other) to apply it manually.
+   used for all terminal input):
+   - **`native`**: tells Claude to run `panemux board join <pane-id> [--mode ...]` and to start
+     `panemux board inbox <pane-id> --watch` under the `Monitor` tool.
+   - **`agmsg`**: tells Claude to join agmsg's team using agmsg's own onboarding flow (e.g.
+     `/agmsg` or the equivalent first-run prompt for that team/agent name) and to rely on agmsg's
+     own `Monitor`/hook wiring for delivery, exactly as it would if the user had set this up by
+     hand outside of panemux.
+   Either way, this single PTY write is what lets panemux skip the `SessionStart` hook agmsg itself
+   needs for the same auto-launch effect — see [Design principles](#design-principles). This step
+   only ever establishes *that pane's* participation; it never touches any other pane or any other
+   agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps working
+   exactly as it did before panemux was involved).
+4. `native` only: panemux installs one skill file, e.g. `~/.claude/commands/panemux-board.md`, once,
+   explicitly (not a silent `settings.json` hooks edit) so the bootstrap instruction can also be
+   given as a short slash command. Installing this skill is itself gated on `agent_board.enabled`
+   and is idempotent. `agmsg` panes rely on agmsg's own already-installed skill instead.
+5. `native` only: if the pane was joined with `--mode turn` or `--mode both`, `join` prints the
+   exact `Stop` hook entry to add to `~/.claude/settings.json`; panemux never writes that file
+   itself, so this step requires the user (or Claude, with the user's confirmation, since editing
+   `settings.json` is a file write like any other) to apply it manually. `agmsg` panes use agmsg's
+   own `/agmsg mode` instead, entirely outside panemux's control.
 
 ## Roles: worker and supervisor
 
@@ -205,6 +304,13 @@ executing arbitrary shell commands. This is the same class of risk called out fo
 tool in Claude Code itself: a receiving pane must not treat a board message as pre-authorized, only
 as an ordinary instruction subject to its own normal confirmation flow. This must be stated in the
 bootstrap instruction text itself, not just in this document.
+
+`role` is a `native`-backend concept enforced by panemux's own CLI. agmsg has no equivalent
+supervisor/worker distinction of its own — every team member can already read team history and
+send to any other member through agmsg's normal commands. On `backend: agmsg` panes, `role` only
+affects how panemux's bootstrap instruction phrases that pane's purpose to Claude; it grants no
+extra permission panemux itself enforces, since panemux does not intermediate agmsg's own team
+membership.
 
 ## API additions
 
@@ -232,12 +338,21 @@ panes:
     type: local
     agent_board:
       enabled: true
-      role: worker   # or supervisor; supervisor must always be explicit, never a default
-      mode: monitor  # monitor (default) | turn | both; turn/both need a manually-added Stop hook
+      backend: native  # native (default) | agmsg; explicit only, never auto-detected
+      role: worker     # or supervisor; supervisor must always be explicit, never a default
+      mode: monitor    # monitor (default) | turn | both; turn/both need a manually-added Stop hook
+
+  - id: pane-b          # e.g. a Codex pane sharing pane-a's host
+    type: ssh
+    connection: build-host
+    agent_board:
+      enabled: true
+      backend: agmsg   # required for any non-Claude agent; panemux has no native protocol for Codex
 ```
 
-A global `agent_board.enabled` default may also be supported so individual panes don't need to
-repeat it.
+A global `agent_board.enabled`/`backend` default may also be supported so individual panes don't
+need to repeat it, but `backend: agmsg` still requires agmsg to already be present on that pane's
+host — panemux will not install it, per [Backends](#backends).
 
 ## Security model
 
@@ -256,9 +371,15 @@ that shaped the design.
   `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
   be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
 - **Message bodies never reach a remote shell as an interpolated argument.** `RunBoardCommand`
-  always sends the body over the exec channel's stdin to the fixed argv `panemux board recv`, never
-  via a constructed shell string. This is the same rule already applied to `cwd` in
-  `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`), extended to board content.
+  always sends the body over the exec channel's stdin to a fixed argv (`panemux board recv` for
+  `native`, agmsg's own script invocation for `agmsg`), never via a constructed shell string. This
+  is the same rule already applied to `cwd` in `internal/session/ssh.go` (`validRemotePath` /
+  `shellQuotePath`), extended to board content, and it applies identically to both backends.
+- **agmsg is an operator-installed, unpinned-by-panemux external dependency.** panemux only detects
+  and calls it; it never bundles, vendors, or auto-installs it (see [Backends](#backends) and
+  [Design principles](#design-principles)). MIT license permits depending on it, but panemux's
+  implementation still owes itself a pinned tested version/tag and treats a break in
+  `scripts/api.sh`'s behavior as an external dependency compatibility bug.
 - **Local board files are `0600`.** `~/.config/panemux/board.db` and the remote equivalent are
   created with owner-only permissions. This does not create a new trust boundary — any other
   process running as the same OS user is already inside panemux's existing trust boundary per
@@ -280,6 +401,11 @@ that shaped the design.
   already accepts same-user process trust elsewhere.
 - Relay latency is bounded by the 3s poll interval, not real-time; cross-host messaging is not
   suitable for anything requiring sub-second delivery.
+- `backend: agmsg` panes depend on an operator-installed third-party tool panemux does not manage
+  the lifecycle of. If that installation is upgraded to a version whose `scripts/api.sh` behavior
+  has changed incompatibly, panemux's `LocalAgmsgStore`/`RemoteAgmsgStore` can fail even though
+  nothing in panemux's own config changed. This is the accepted cost of not vendoring/pinning a
+  copy of agmsg inside panemux itself.
 
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 
@@ -290,9 +416,16 @@ that shaped the design.
 - `internal/session`: `RunBoardCommand` never places body content in `exec.Command` args (mirrors
   the existing `validateShell` test pattern).
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
-  combinations are valid.
+  combinations are valid. `agent_board.backend` accepts only `native`/`agmsg`; anything else is a
+  validation error (no silent fallback to a default).
 - `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
   handshake; correct token succeeds.
+- Backend selection and detection: a pane configured with `backend: agmsg` on a host where agmsg is
+  absent skips bootstrap and logs a warning without touching the pane's session (asserted against a
+  fake/no-op `BoardExecutor`/host check, not a real agmsg install); a pane configured with
+  `backend: agmsg` where agmsg is present bootstraps through the agmsg path instead of `panemux
+  board *`; mixed-backend same-host relay (a `native` pane and an `agmsg` pane on one host,
+  addressed to each other) goes through the relay step rather than being treated as already-shared.
 
 ## Related documents
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -80,42 +80,85 @@ Agent Board replaces that inference with a small, self-reported channel:
 
 ## Architecture
 
+### System overview
+
 ```mermaid
 flowchart TB
-    subgraph UILayer["UI層（ブラウザ）"]
-        Dashboard["ダッシュボード"]
-        Palette["Spotlightパレット"]
+    Browser["Browser<br/>Dashboard + Spotlight palette"]
+
+    subgraph Local["Host panemux runs on (exactly one)"]
+        Server["panemux Go process<br/>REST/WS, Bearer-token auth"]
+        Relay["Relay goroutine<br/>polls agmsg every few seconds"]
+        Cache[("BoardCache<br/>in-memory, panemux-owned")]
+        CmdCenter["Command center<br/>claude -p --resume (per query)"]
+        LocalAgmsg[("Local agmsg<br/>(optional install)")]
     end
 
-    subgraph PanemuxBoundary["panemuxの責務範囲（唯一のホストで完結）"]
+    subgraph HostA["Remote Host A (SSH)"]
+        AgmsgA[("agmsg")]
+        ClaudeA["Claude pane"]
+    end
+
+    subgraph HostB["Remote Host B (SSH)"]
+        AgmsgB[("agmsg")]
+        CodexB["Codex pane"]
+    end
+
+    Browser <--> Server
+    Server --> Relay
+    Server --> CmdCenter
+    Relay --> Cache
+    Relay -->|"api.sh / send.sh"| LocalAgmsg
+    CmdCenter -->|"api.sh / send.sh --force"| LocalAgmsg
+    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
+    Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
+    ClaudeA -->|"Bash tool calls"| AgmsgA
+    CodexB -->|"Bash tool calls"| AgmsgB
+```
+
+Every host in this picture is either the one host panemux itself runs on, or a host panemux only
+ever reaches through an SSH exec channel it already holds for that pane's session — never a host
+panemux is installed on. See [Local vs remote resource
+placement](#local-vs-remote-resource-placement) for that constraint in more detail.
+
+### Responsibility boundaries
+
+```mermaid
+flowchart TB
+    subgraph UILayer["UI layer (browser)"]
+        Dashboard["Dashboard"]
+        Palette["Spotlight palette"]
+    end
+
+    subgraph PanemuxBoundary["panemux's responsibility (one host only)"]
         direction TB
-        AuthAPI["認証付きREST/WS<br/>Bearerトークン"]
-        BoardCache[("状態＋履歴キャッシュ<br/>インメモリ、panemuxが所有")]
-        Relay["中継ゴルーチン<br/>数秒間隔でagmsgをポーリング"]
-        CmdCenter["司令塔<br/>claude -p --resume"]
-        AgmsgClient["AgmsgClient<br/>agmsg呼び出しの唯一の窓口"]
+        AuthAPI["Authenticated REST/WS<br/>Bearer token"]
+        BoardCache[("Status + history cache<br/>in-memory, panemux-owned")]
+        Relay["Relay goroutine<br/>polls agmsg every few seconds"]
+        CmdCenter["Command center<br/>claude -p --resume"]
+        AgmsgClient["AgmsgClient<br/>the only caller of agmsg's scripts"]
 
         AuthAPI -->|"GET /api/board/status, /messages"| BoardCache
         AuthAPI --> CmdCenter
-        Relay -->|"statusと履歴を書き込み"| BoardCache
+        Relay -->|"writes status and history"| BoardCache
         Relay --> AgmsgClient
         CmdCenter --> AgmsgClient
     end
 
-    subgraph AgmsgBoundary["agmsgの責務範囲（ホストごとに独立、panemuxは所有しない）"]
+    subgraph AgmsgBoundary["agmsg's responsibility (independent per host, not owned by panemux)"]
         direction TB
-        AgmsgLocal[("ローカルagmsg<br/>（任意インストール）")]
-        AgmsgA[("agmsg（Host A）")]
+        AgmsgLocal[("Local agmsg<br/>(optional install)")]
+        AgmsgA[("agmsg (Host A)")]
         ClaudeA["Claude pane"]
-        AgmsgB[("agmsg（Host B）")]
+        AgmsgB[("agmsg (Host B)")]
         CodexB["Codex pane"]
-        ClaudeA -->|"Bashツール呼び出し"| AgmsgA
-        CodexB -->|"Bashツール呼び出し"| AgmsgB
+        ClaudeA -->|"Bash tool calls"| AgmsgA
+        CodexB -->|"Bash tool calls"| AgmsgB
     end
 
     Dashboard -->|"REST"| AuthAPI
     Palette -->|"WS"| AuthAPI
-    AgmsgClient -->|"ローカル exec.Command<br/>api.sh / send.sh"| AgmsgLocal
+    AgmsgClient -->|"local exec.Command<br/>api.sh / send.sh"| AgmsgLocal
     AgmsgClient -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
     AgmsgClient -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
 ```
@@ -125,15 +168,15 @@ here is "what agmsg owns" vs. "what panemux owns" — the one place a future agm
 break something is entirely inside `AgmsgClient`'s two call sites (`api.sh`, `send.sh`), never
 anywhere else in panemux:
 
-- **panemuxの責務範囲**: authentication, the relay, the **in-memory status cache** the dashboard
-  actually reads (see below), the command center, and the single `AgmsgClient` abstraction that is
-  the *only* code in panemux allowed to call agmsg's scripts. Everything here is panemux's own,
-  version-independent of agmsg beyond that one narrow interface.
-- **agmsgの責務範囲**: one independent agmsg installation per host, each with its own durable
-  message log, team roster, and delivery to the live agent sessions that are its actual members.
-  panemux does not own this box, does not persist a copy of its contents beyond what the cache
-  below needs, and is never a participant *inside* more than one host's agmsg installation at a
-  time — it only ever reaches a remote one through the SSH exec channel it already holds for that
+- **panemux's responsibility**: authentication, the relay, the **in-memory status cache** the
+  dashboard actually reads (see below), the command center, and the single `AgmsgClient`
+  abstraction that is the *only* code in panemux allowed to call agmsg's scripts. Everything here
+  is panemux's own, version-independent of agmsg beyond that one narrow interface.
+- **agmsg's responsibility**: one independent agmsg installation per host, each with its own
+  durable message log, team roster, and delivery to the live agent sessions that are its actual
+  members. panemux does not own this box, does not persist a copy of its contents beyond what the
+  cache below needs, and is never a participant *inside* more than one host's agmsg installation at
+  a time — it only ever reaches a remote one through the SSH exec channel it already holds for that
   pane's session, exactly as [Local vs remote resource
   placement](#local-vs-remote-resource-placement) details.
 
@@ -234,7 +277,7 @@ itself, using its own `Bash` tool, and include it as a small JSON body:
   "repo": "owner/repo",
   "pr_url": "https://github.com/owner/repo/pull/123",
   "last_tool": "Edit internal/api/handler.go",
-  "summary": "テスト修正中"
+  "summary": "fixing failing tests"
 }
 ```
 
@@ -247,27 +290,27 @@ a repository or there's no open PR; the dashboard shows what's present.
 sequenceDiagram
     participant ClaudeA as "Claude pane (Host A)"
     participant AgmsgA as "agmsg (Host A)"
-    participant Relay as "panemux 中継"
-    participant Cache as "panemux 状態キャッシュ"
+    participant Relay as "panemux relay"
+    participant Cache as "panemux BoardCache"
     participant AgmsgB as "agmsg (Host B)"
     participant CodexB as "Codex pane (Host B)"
-    participant Dash as "panemux ダッシュボード"
+    participant Dash as "panemux dashboard"
 
-    Note over ClaudeA: 状態報告（自己申告）
-    ClaudeA->>ClaudeA: git branch / gh pr view を実行
+    Note over ClaudeA: Status self-report
+    ClaudeA->>ClaudeA: run git branch / gh pr view
     ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}"
     Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
-    AgmsgA-->>Relay: 新規行（宛先が _panemux）
-    Relay->>Cache: 最新status(JSON)を書き込み
+    AgmsgA-->>Relay: new row (addressed to _panemux)
+    Relay->>Cache: write latest status (JSON)
     Dash->>Cache: GET /api/board/status
-    Cache-->>Dash: 最新status（agmsgへは問い合わせない）
+    Cache-->>Dash: latest status (no agmsg call)
 
-    Note over ClaudeA,CodexB: pane間メッセージの中継
-    ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "レビューして"
+    Note over ClaudeA,CodexB: Cross-pane message relay
+    ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "please review"
     Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
-    AgmsgA-->>Relay: 新規行（宛先が他pane）
-    Relay->>AgmsgB: send.sh team ClaudeA CodexB "レビューして" --force
-    CodexB->>AgmsgB: Monitor / watch.sh で受信
+    AgmsgA-->>Relay: new row (addressed to another pane)
+    Relay->>AgmsgB: send.sh team ClaudeA CodexB "please review" --force
+    CodexB->>AgmsgB: received via Monitor / watch.sh
 ```
 
 **Honest tradeoff, stated explicitly.** Self-report is only as good as the agent's compliance: it
@@ -374,20 +417,20 @@ type BoardExecutor interface {
 
 ```mermaid
 flowchart LR
-    subgraph PanemuxHost["panemuxホスト（1台だけ）"]
+    subgraph PanemuxHost["panemux's host (exactly one)"]
         direction TB
-        P1["panemuxバイナリ<br/>(HTTP/WSサーバー本体)"]
-        P2["ローカルagmsg（任意導入）"]
-        P3["中継カーソル<br/>(ローカルJSONファイル)"]
+        P1["panemux binary<br/>(the HTTP/WS server itself)"]
+        P2["Local agmsg (optional install)"]
+        P3["Relay cursor<br/>(local JSON file)"]
     end
 
-    subgraph RemoteHost["リモートホスト（SSH到達先、複数可）"]
+    subgraph RemoteHost["Remote host (any number of SSH-reached hosts)"]
         direction TB
-        R1["agmsg<br/>(操作者が別途導入)"]
+        R1["agmsg<br/>(installed separately by the operator)"]
         R2["Claude / Codex pane"]
     end
 
-    PanemuxHost -->|"SSH exec channel経由でapi.sh / send.shのみ実行<br/>panemuxバイナリは絶対に置かない"| RemoteHost
+    PanemuxHost -->|"SSH exec channel runs only api.sh / send.sh<br/>the panemux binary is never placed here"| RemoteHost
 ```
 
 Nothing panemux-specific is ever written to a remote host's disk: no binary, no persisted helper

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -659,6 +659,25 @@ that shaped the design.
 
 ## Known limitations
 
+- **Account-wide token/cost totals are explicitly out of scope for Agent Board.** Unlike
+  branch/PR/cwd, token usage isn't external world-state an agent can query with an ordinary command
+  (`git`, `gh`), and there's no verified way for an agent to introspect its own cumulative usage and
+  include it in a self-report. Since panemux-managed panes and the command center all run under the
+  same Claude account in the common case, Claude Code's own `/usage` already gives an accurate
+  account-wide view; Agent Board does not need to duplicate it.
+- **Per-pane usage — "which session is using disproportionately more than the others" — is a
+  different, genuinely useful question `/usage` doesn't answer, and is not ruled out by the above.**
+  Every assistant turn's `usage` field (input/output/cache tokens) is a foundational, stable part
+  of the Messages API response envelope that Claude Code's transcript already records for each
+  turn — reading and summing it is a much shallower, lower-risk read than the branch/PR/worktree
+  heuristics this redesign moved away from (those depended on deep, undocumented precedence rules
+  across `session_meta.cwd`, `turn_context.cwd`, and subagent transcript files, which is what
+  actually proved unstable in practice). This is not Agent Board's own responsibility to build,
+  though: it fits naturally as an extension of panemux's existing, pre-board per-pane transcript
+  inspection (already used for worktree/PR detection — see [architecture.md](architecture.md) and
+  [behavior.md](behavior.md)), summing a stable field rather than parsing fragile ones, not as
+  something carried through the agmsg self-report this document specifies. A future change to that
+  existing mechanism, not to `internal/board`, is the right place for it.
 - The status/history cache is in-memory only, not persisted to disk. A panemux restart starts it
   empty; `GET /api/board/status`/`/messages` show nothing until the relay's next poll cycle (which
   resumes from the persisted cursor, so it still only sees genuinely new rows, not the pane's full

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -28,7 +28,11 @@ Agent Board replaces that inference with a small, self-reported, structured chan
    bash+sqlite3 agent-messaging tool that already supports Claude Code, Codex, Gemini CLI, GitHub
    Copilot, Antigravity, OpenCode, and Hermes. Where a pane's host already runs agmsg, a
    panemux-managed pane can join the same team as a Codex pane and reuse agmsg's own Codex support
-   (boot-prompt handoff, turn-mode delivery) instead of panemux reimplementing it. See
+   (its `Stop`-hook turn-mode delivery, since Codex has no `Monitor` tool to auto-launch) instead of
+   panemux reimplementing it. Note this is about an *already-running* Codex process in a
+   panemux-managed pane joining an existing team — it does not involve agmsg's own `spawn.sh`
+   (which launches a brand-new terminal window/process itself, a separate use case panemux never
+   triggers, since panemux already owns pane creation). See
    [Backends](#backends).
 
 ## Design principles
@@ -127,7 +131,10 @@ matching agmsg's own README guidance that those are internal.
 
 `id` is returned as a string (agmsg's own future-proofing against a non-integer ID scheme, per its
 source comments), and `--agent`/`--limit`/`--before-id` are validated as plain digits before being
-used in a query, guarding against SQL injection on agmsg's own side.
+used in a query, guarding against SQL injection on agmsg's own side. Unlike agmsg's own
+human-facing `inbox.sh`/`check-inbox.sh` (which mark whatever they display as read), `api.sh` never
+writes `read_at` — panemux's dashboard polling through it cannot cause a joined agent to miss a
+message its own inbox/`Monitor` delivery would otherwise have shown it.
 
 **Writes — `scripts/send.sh`, not `api.sh`.** Signature: `send.sh <team> <from> <to> <body>
 [--force]`. Unlike `api.sh`, `send.sh` takes `body` as a **positional shell argument**, not stdin —
@@ -137,18 +144,28 @@ roster unless `--force` is passed, in which case an unregistered sender name is 
 Choosing `agmsg` for a pane means:
 
 - That pane's bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to join
-  agmsg's team instead of panemux's own, using agmsg's own `join`/`actas` semantics. Any other
-  agent already using agmsg on that host (Codex, Gemini CLI, etc.) can then exchange messages with
-  it directly through agmsg, with no panemux involvement in that same-host exchange at all.
+  agmsg's team using agmsg's own onboarding (typically the `/agmsg` skill flow a live Claude
+  session runs itself). The underlying primitive that establishes membership is `join.sh <team>
+  <agent_id> <agent_type> <project_path> [--force]`, which registers the pane into `teams/<team>
+  /config.json` — this is the "roster" `send.sh` checks `from` against. Any other agent already
+  using agmsg on that host (Codex, Gemini CLI, etc.) can then exchange messages with it directly
+  through agmsg, with no panemux involvement in that same-host exchange at all. Once joined, agmsg's
+  own `SessionStart`/`SessionEnd` hooks own that pane's `Monitor`(`watch.sh`)-process lifecycle
+  end-to-end (launch, liveness, cleanup) — panemux has no part in it and does not need to.
 - agmsg has no native "status" concept, only messages. panemux's status reports map onto ordinary
   agmsg messages addressed to a reserved agent name, `_panemux_dashboard`, inside the team;
   `LatestStatusByAgent` for this backend calls `api.sh get teams <team> messages --agent
   _panemux_dashboard --limit <N>` and keeps only the newest row per `from`.
-- **The relay and the command center are never agmsg roster members**, so any send they originate
-  into an agmsg team (relaying a `native` pane's message, or the command center instructing an
-  `agmsg` pane) always passes `send.sh ... --force`. `from` is set to the originating pane's ID (or
-  `_panemux` for the command center) exactly as with the `native` backend — `--force` only skips
-  agmsg's own roster check, it does not change how `from` is chosen.
+- **The relay and the command center are never agmsg roster members, and never go through agmsg's
+  own identity-detection layer, so any send they originate into an agmsg team always passes
+  `send.sh ... --force`.** A live Claude session's own `/agmsg send` normally resolves `from`
+  automatically — `whoami.sh` matches environment variables or, failing that, walks the process
+  tree against each agent type's known process-name patterns, then `identities.sh` reconciles that
+  against a joined team/project — but that whole chain assumes a live process to introspect. The
+  relay and command center are panemux's own Go code, not a joined Claude/Codex process, so no
+  identity-detection result would ever exist for them to look up; `--force` is what lets `send.sh`
+  accept an explicit `from` (the originating pane's ID, or `_panemux` for the command center)
+  without that lookup succeeding first.
 - **Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
   that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
   or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If
@@ -496,7 +513,10 @@ that shaped the design.
 
 - No claim/lease semantics: if two workers were both addressed by the same message (not a supported
   case today, since `to_agent` targets one pane), there is no exclusion mechanism. This mirrors
-  agmsg's own documented v1 limitation.
+  agmsg's own documented v1 limitation. Note this is distinct from agmsg's `actas-claim.sh` lock,
+  verified against its source: that lock only prevents two sessions from claiming the *same role
+  name* at once (exit code 1 if already held) — it says nothing about, and does not provide, message
+  claim/lease semantics for delivery.
 - Agents/teams are free-text identifiers with no cryptographic authentication of `from_agent`. Any
   local process that can open the board file can forge a sender. This is an integrity gap distinct
   from the transport-confidentiality concerns above and is accepted for the same reason panemux

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -87,51 +87,67 @@ flowchart TB
         Palette["Spotlightパレット"]
     end
 
-    subgraph CommLayer["通信層"]
-        RestWs["REST /api/board/*<br/>WS /ws/board-command<br/>Bearerトークン認証"]
-        LocalExec["ローカル exec.Command"]
-        ExecCh["SSH exec channel<br/>（GetCWD/InspectGitContextと共用）"]
+    subgraph PanemuxBoundary["panemuxの責務範囲（唯一のホストで完結）"]
+        direction TB
+        AuthAPI["認証付きREST/WS<br/>Bearerトークン"]
+        BoardCache[("状態＋履歴キャッシュ<br/>インメモリ、panemuxが所有")]
+        Relay["中継ゴルーチン<br/>数秒間隔でagmsgをポーリング"]
+        CmdCenter["司令塔<br/>claude -p --resume"]
+        AgmsgClient["AgmsgClient<br/>agmsg呼び出しの唯一の窓口"]
+
+        AuthAPI -->|"GET /api/board/status, /messages"| BoardCache
+        AuthAPI --> CmdCenter
+        Relay -->|"statusと履歴を書き込み"| BoardCache
+        Relay --> AgmsgClient
+        CmdCenter --> AgmsgClient
     end
 
-    subgraph ClientLayer["クライアント層（panemux Goプロセス）"]
-        Relay["中継ゴルーチン<br/>数秒間隔でポーリング"]
-        CmdCenter["司令塔<br/>claude -p --resume（クエリごとに起動）"]
-        AgmsgClient["AgmsgClient<br/>Local/RemoteAgmsgClient"]
-    end
-
-    subgraph AgentLayer["エージェント層（agmsgチーム）"]
-        LocalAgmsg[("ローカルagmsg<br/>（任意インストール）")]
+    subgraph AgmsgBoundary["agmsgの責務範囲（ホストごとに独立、panemuxは所有しない）"]
+        direction TB
+        AgmsgLocal[("ローカルagmsg<br/>（任意インストール）")]
         AgmsgA[("agmsg（Host A）")]
         ClaudeA["Claude pane"]
         AgmsgB[("agmsg（Host B）")]
         CodexB["Codex pane"]
+        ClaudeA -->|"Bashツール呼び出し"| AgmsgA
+        CodexB -->|"Bashツール呼び出し"| AgmsgB
     end
 
-    Dashboard --> RestWs
-    Palette --> RestWs
-    RestWs --> Relay
-    RestWs --> CmdCenter
-    Relay --> AgmsgClient
-    CmdCenter --> AgmsgClient
-    AgmsgClient --> LocalExec
-    AgmsgClient --> ExecCh
-    LocalExec -->|"api.sh / send.sh"| LocalAgmsg
-    ExecCh -->|"api.sh / send.sh"| AgmsgA
-    ExecCh -->|"api.sh / send.sh"| AgmsgB
-    ClaudeA -->|"Bashツール呼び出し"| AgmsgA
-    CodexB -->|"Bashツール呼び出し"| AgmsgB
+    Dashboard -->|"REST"| AuthAPI
+    Palette -->|"WS"| AuthAPI
+    AgmsgClient -->|"ローカル exec.Command<br/>api.sh / send.sh"| AgmsgLocal
+    AgmsgClient -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
+    AgmsgClient -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
 ```
 
-Four layers, top to bottom: the **UI layer** (dashboard + Spotlight palette) never talks to agmsg
-directly — everything goes through the **communication layer** (the authenticated REST/WS surface
-for the browser, plus local `exec.Command`/SSH exec channel for reaching agmsg itself). The
-**client layer** is panemux's own Go code (relay, command center, the `AgmsgClient` abstraction
-from [Package layout](#package-layout)) — it is the only thing that ever calls agmsg's scripts, and
-it is never a participant *inside* more than one host's agmsg installation at a time. The **agent
-layer** is agmsg itself (one team per host) plus the Claude/Codex panes that are its actual
-members; panemux only ever reaches a remote one through the SSH exec channel it already holds for
-that pane's session, exactly as [Local vs remote resource
-placement](#local-vs-remote-resource-placement) details.
+Two responsibility boundaries, not four generic layers, because the boundary that actually matters
+here is "what agmsg owns" vs. "what panemux owns" — the one place a future agmsg version bump can
+break something is entirely inside `AgmsgClient`'s two call sites (`api.sh`, `send.sh`), never
+anywhere else in panemux:
+
+- **panemuxの責務範囲**: authentication, the relay, the **in-memory status cache** the dashboard
+  actually reads (see below), the command center, and the single `AgmsgClient` abstraction that is
+  the *only* code in panemux allowed to call agmsg's scripts. Everything here is panemux's own,
+  version-independent of agmsg beyond that one narrow interface.
+- **agmsgの責務範囲**: one independent agmsg installation per host, each with its own durable
+  message log, team roster, and delivery to the live agent sessions that are its actual members.
+  panemux does not own this box, does not persist a copy of its contents beyond what the cache
+  below needs, and is never a participant *inside* more than one host's agmsg installation at a
+  time — it only ever reaches a remote one through the SSH exec channel it already holds for that
+  pane's session, exactly as [Local vs remote resource
+  placement](#local-vs-remote-resource-placement) details.
+
+**Where agent status actually lives.** It does not live in a database panemux owns, and it is not
+recomputed from a live agmsg call on every dashboard request either — both would be wrong for
+different reasons (the first re-introduces "panemux owns a schema," which [Design
+principles](#design-principles) rules out; the second makes every dashboard poll pay for an agmsg
+round-trip, including an SSH hop for remote hosts). Instead: the relay goroutine, which is already
+polling every host's agmsg for messages to forward, updates an **in-memory status cache** as a side
+effect whenever it sees a status report addressed to `_panemux`. `GET /api/board/status` reads only
+that cache — never agmsg directly. agmsg's own message log remains the durable source of truth (a
+lost or restarted panemux process just means the cache is empty until the next poll cycle refills
+it, per [Known limitations](#known-limitations)), but the *current, dashboard-facing view* of that
+state is unambiguously something panemux computes and holds itself.
 
 ## Integration with agmsg
 
@@ -201,8 +217,11 @@ change would be.
 
 Instead of a `kind='status'` field panemux owns (agmsg has no such column), status reports are
 ordinary agmsg messages addressed to the reserved identity `_panemux` — the same identity the
-command center uses as its own `from` when sending. panemux's dashboard reads them with `api.sh get
-teams <team> messages --agent _panemux --limit <N>` and keeps only the newest row per sender.
+command center uses as its own `from` when sending. The relay goroutine, already polling every
+host's agmsg with `api.sh get teams <team> messages --before-id <cursor>` for message forwarding,
+recognizes any row addressed to `_panemux` as a status update and writes it into panemux's own
+in-memory status cache (see [Architecture](#architecture)), keeping only the newest entry per
+sender. The dashboard never queries agmsg directly for this — it only ever reads that cache.
 
 The bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to gather this
 itself, using its own `Bash` tool, and include it as a small JSON body:
@@ -229,6 +248,7 @@ sequenceDiagram
     participant ClaudeA as "Claude pane (Host A)"
     participant AgmsgA as "agmsg (Host A)"
     participant Relay as "panemux 中継"
+    participant Cache as "panemux 状態キャッシュ"
     participant AgmsgB as "agmsg (Host B)"
     participant CodexB as "Codex pane (Host B)"
     participant Dash as "panemux ダッシュボード"
@@ -236,13 +256,16 @@ sequenceDiagram
     Note over ClaudeA: 状態報告（自己申告）
     ClaudeA->>ClaudeA: git branch / gh pr view を実行
     ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}"
-    Dash->>AgmsgA: api.sh get teams team messages --agent _panemux
-    AgmsgA-->>Dash: 最新status(JSON)
+    Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
+    AgmsgA-->>Relay: 新規行（宛先が _panemux）
+    Relay->>Cache: 最新status(JSON)を書き込み
+    Dash->>Cache: GET /api/board/status
+    Cache-->>Dash: 最新status（agmsgへは問い合わせない）
 
     Note over ClaudeA,CodexB: pane間メッセージの中継
     ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "レビューして"
     Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
-    AgmsgA-->>Relay: 新規行
+    AgmsgA-->>Relay: 新規行（宛先が他pane）
     Relay->>AgmsgB: send.sh team ClaudeA CodexB "レビューして" --force
     CodexB->>AgmsgB: Monitor / watch.sh で受信
 ```
@@ -275,14 +298,33 @@ type AgmsgClient interface {
     HostID() string
     Send(ctx context.Context, team, from, to, body string) error         // send.sh ... --force
     Since(ctx context.Context, team string, afterID int64) ([]Row, error) // api.sh get ... messages
-    LatestStatusByAgent(ctx context.Context, team string) (map[string]Status, error)
 }
+
+// BoardCache is the in-memory, panemux-owned view of recent board activity shown in Architecture.
+// Only the relay writes to it, as a side effect of the same Since polling it already does for
+// message forwarding; both dashboard-facing endpoints only ever read it, never calling
+// AgmsgClient directly at request time.
+type BoardCache struct {
+    mu      sync.RWMutex
+    status  map[string]Status // paneID -> latest self-reported status
+    history []Row             // bounded ring buffer of recent messages, most recent last
+}
+
+func (c *BoardCache) RecordStatus(paneID string, s Status)  { /* mutex-guarded write */ }
+func (c *BoardCache) AppendMessage(r Row)                   { /* mutex-guarded write */ }
+func (c *BoardCache) StatusSnapshot() map[string]Status     { /* mutex-guarded copy */ }
+func (c *BoardCache) MessagesSince(afterID int64) []Row     { /* mutex-guarded copy */ }
 ```
 
-`LatestStatusByAgent` is derived, not a separate agmsg call: it reads the same `messages` stream
-filtered to `--agent _panemux`, and parses each `body` as the JSON shape from [Status
-self-report](#status-self-report-and-message-flow); a body that isn't valid JSON in that shape is
-treated as an ordinary chat message to `_panemux`, not a status update.
+The relay inspects every `Row` it reads: if `To == "_panemux"` and `Body` parses as the JSON shape
+from [Status self-report](#status-self-report-and-message-flow), it calls `RecordStatus` and does
+*not* forward that row through the cross-host relay logic (status reports are local bookkeeping,
+not messages meant for another pane). A `Body` addressed to `_panemux` that isn't valid JSON in
+that shape is left alone as an ordinary chat message. Every row, status or not, is also appended to
+`history` via `AppendMessage`, which is what `GET /api/board/messages` reads from — that endpoint
+never calls `AgmsgClient` at request time either, for the same reason `GET /api/board/status`
+doesn't: the relay has already seen everything the dashboard needs, as a side effect of polling it
+was already doing.
 
 - `LocalAgmsgClient` shells out to the local agmsg installation's `scripts/api.sh` for reads and
   `scripts/send.sh ... --force` for writes. Because this is a local `exec.Command` invocation, Go
@@ -363,13 +405,15 @@ to reach each other). panemux is the only node with a connection to every host, 
 2. `cursor` is one value per (host, team), persisted in a small local JSON file (e.g.
    `~/.config/panemux/board-relay-cursor.json`) — not a database table, since panemux owns no
    database — so a panemux restart resumes roughly where it left off.
-3. For each new row, panemux resolves `to` to its owning pane and that pane's host via the
-   already-known pane→session config. If that host differs from the source host, panemux calls
+3. For each new row, if `to == "_panemux"`, panemux updates the [in-memory status
+   cache](#architecture) instead of relaying it — status reports never leave the host they were
+   written on. Otherwise, panemux resolves `to` to its owning pane and that pane's host via the
+   already-known pane→session config; if that host differs from the source host, panemux calls
    `Send` on the destination host's `AgmsgClient` with `--force`.
 4. Same-host `to` needs no relay: sender and receiver are already members of the same local agmsg
    team.
-5. panemux's own dashboard/status reads (`GET /api/board/status`) go directly to every host's
-   `AgmsgClient` and are not relayed; relay only matters for agent-to-agent delivery.
+5. `GET /api/board/status` never triggers an `AgmsgClient` call at all — it only reads the status
+   cache the relay already keeps current, per [Architecture](#architecture).
 
 **Delivery is at-least-once, not exactly-once — an accepted simplification, not an oversight.**
 Because agmsg's own schema has no field for panemux to mark "this row has already been relayed,"
@@ -485,7 +529,7 @@ unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it s
 
 | Endpoint | Purpose |
 |---|---|
-| `GET /api/board/status` | Latest self-reported status per pane, across every host panemux manages |
+| `GET /api/board/status` | A snapshot of panemux's in-memory status cache — no `AgmsgClient` call happens on this request (see [Architecture](#architecture)) |
 | `GET /api/board/messages?since=<id>` | History feed for the dashboard UI |
 | `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn) |
 | `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
@@ -572,6 +616,11 @@ that shaped the design.
 
 ## Known limitations
 
+- The status/history cache is in-memory only, not persisted to disk. A panemux restart starts it
+  empty; `GET /api/board/status`/`/messages` show nothing until the relay's next poll cycle (which
+  resumes from the persisted cursor, so it still only sees genuinely new rows, not the pane's full
+  history) repopulates it. This is the same accepted eventual-consistency tradeoff already made for
+  the relay cursor itself.
 - No claim/lease semantics: if two workers were both addressed by the same message (not a supported
   case today, since `to` targets one pane), there is no exclusion mechanism. This mirrors agmsg's
   own documented v1 limitation. Distinct from that: agmsg's `actas-claim.sh` lock only prevents two
@@ -604,10 +653,14 @@ that shaped the design.
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 
 - `internal/board`: status JSON parsing (valid full payload, missing optional fields, a body that
-  isn't the expected shape falls back to being treated as a plain message), `LatestStatusByAgent`
-  with multiple status rows (only the newest per sender wins), relay cursor persistence across a
-  simulated restart (including the accepted at-least-once duplicate case — assert it is delivered
-  again, not that it's silently dropped or that the relay errors), empty team.
+  isn't the expected shape falls back to being treated as a plain message and is not mistaken for a
+  status update), `BoardCache.StatusSnapshot` with multiple status rows for one pane (only the
+  newest wins) and across multiple panes, `BoardCache.MessagesSince` ordering and bounding, a row
+  addressed to `_panemux` never appearing in `MessagesSince`'s cross-pane relay path, an empty
+  cache read (fresh start / post-restart) returning a well-defined empty result rather than an
+  error, relay cursor persistence across a simulated restart (including the accepted at-least-once
+  duplicate case — assert it is delivered again, not that it's silently dropped or that the relay
+  errors), empty team.
 - `internal/session`: for `RemoteAgmsgClient`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
   literal argument, not as executed shell syntax.

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -19,9 +19,11 @@ Agent Board replaces that inference with a small, self-reported, structured chan
 
 1. Lets panemux collect accurate per-pane Claude status (idle / working / waiting for approval,
    last tool used, current summary) instead of guessing from transcripts.
-2. Lets a human (or one designated "supervisor" pane) broadcast a message to one or more panes'
-   Claude sessions without racing raw keystrokes into a live PTY.
-3. Aggregates all of the above into one dashboard and, for a supervisor pane, one queryable feed.
+2. Lets a human broadcast a message to one or more panes' Claude sessions without racing raw
+   keystrokes into a live PTY, and lets a local **command center** (see
+   [Command center](#command-center)) do the same conversationally on the human's behalf.
+3. Aggregates all of the above into one dashboard and, for the command center, one continuous,
+   reviewable conversation history.
 4. Optionally interoperates with [agmsg](https://github.com/fujibee/agmsg), an existing MIT-licensed
    bash+sqlite3 agent-messaging tool that already supports Claude Code, Codex, Gemini CLI, GitHub
    Copilot, Antigravity, OpenCode, and Hermes. Where a pane's host already runs agmsg, a
@@ -251,11 +253,16 @@ never calls `panemux board *`; it drives agmsg's own `/agmsg`/skill entry points
 
 | Subcommand | Run where | Purpose |
 |---|---|---|
-| `panemux board join <pane-id> [--role worker\|supervisor] [--mode monitor\|turn\|both]` | inside the pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
+| `panemux board join <pane-id> [--mode monitor\|turn\|both]` | inside the pane, by Claude | Prints usage (including the `Stop` hook snippet for `turn`/`both`) and writes an initial `status` row. `--mode` defaults to `monitor` |
 | `panemux board inbox <pane-id> --watch` | inside the pane, by Claude via `Monitor` (`monitor`/`both` modes) or a `Stop` hook script (`turn`/`both` modes) | Polls for unread rows addressed to `<pane-id>`, prints one line per message, marks each read after printing. Under `Monitor` this polls every ~1s; under a `Stop` hook it runs once, between turns |
-| `panemux board status <pane-id> "<summary>"` | inside the pane, by Claude | Inserts a `kind='status'` row |
-| `panemux board send <to-pane-id> "<body>"` | inside a `role: supervisor` pane, by Claude | Inserts a `kind='message'` row addressed to another pane |
+| `panemux board status <pane-id> "<summary>"` | inside the pane, by Claude | Inserts a `kind='status'` row for that pane |
+| `panemux board status --all` | on panemux's local host, by the command center | Reads `LatestStatusByAgent` across every managed `Store` |
+| `panemux board send <to-pane-id> "<body>"` | on panemux's local host, by the command center | Inserts a `kind='message'` row addressed to any pane, local or remote, native or agmsg; the existing relay (not this command) handles cross-`Store` delivery |
 | `panemux board recv` | remote host only, invoked by panemux over the exec channel | Reads one JSON row from stdin, inserts it with parameterized SQL. The only board subcommand panemux itself ever executes remotely |
+
+Every board-enabled pane can run `join`/`inbox`/`status` for itself. `status --all` and `send
+<any-pane-id>` are not pane-scoped — see [Command center](#command-center) for who actually runs
+them and how that is authorized.
 
 ## Bootstrap flow
 
@@ -291,26 +298,78 @@ Steps 1–2 are shared; step 3 branches on the pane's configured backend.
    `settings.json` is a file write like any other) to apply it manually. `agmsg` panes use agmsg's
    own `/agmsg mode` instead, entirely outside panemux's control.
 
-## Roles: worker and supervisor
+## Command center
 
-- `role: worker` (default): only reads its own inbox and reports its own status.
-- `role: supervisor` (explicit opt-in only, never default): may read every agent's latest status
-  (`panemux board status --all`) and send to any pane (`panemux board send <any-pane-id> ...`).
-  A supervisor pane is typically a local pane the user starts specifically for this purpose.
+Earlier drafts of this document modeled the orchestrator as a pane with `role: supervisor` running
+an ordinary interactive `claude` process. That is no longer the design: the intended experience is
+a local, Spotlight-style command palette the user converses with, not a terminal pane sitting in
+the layout. This section replaces the old "Roles" section.
 
-**Trust implication, stated explicitly:** giving a pane `role: supervisor` means its Claude process
-can inject instructions into every other board-enabled pane, local or remote, including ones
-executing arbitrary shell commands. This is the same class of risk called out for the `SendMessage`
-tool in Claude Code itself: a receiving pane must not treat a board message as pre-authorized, only
-as an ordinary instruction subject to its own normal confirmation flow. This must be stated in the
-bootstrap instruction text itself, not just in this document.
+### What it is
 
-`role` is a `native`-backend concept enforced by panemux's own CLI. agmsg has no equivalent
-supervisor/worker distinction of its own — every team member can already read team history and
-send to any other member through agmsg's normal commands. On `backend: agmsg` panes, `role` only
-affects how panemux's bootstrap instruction phrases that pane's purpose to Claude; it grants no
-extra permission panemux itself enforces, since panemux does not intermediate agmsg's own team
-membership.
+- A single, persistent **headless** Claude session, not a pane and not a PTY. panemux invokes it as
+  a short-lived subprocess per query — `claude -p --resume <command-center-session-id> "<prompt>"`
+  — rather than a long-running process, so this does not introduce the "new daemon" this document's
+  [Design principles](#design-principles) rule out. `--resume` against one fixed session id is what
+  gives the command center conversational continuity across separate queries.
+- It reads and writes the board through the exact same `panemux board status --all` / `panemux
+  board send <any-pane-id> "<body>"` native CLI already defined in
+  [CLI subcommands](#cli-subcommands), invoked as ordinary `Bash` tool calls within its own turn —
+  no new board primitive is needed for it.
+- `board send` always writes to the *local* native `Store` (the command center is not itself a
+  pane bound to a particular host/backend). The existing [cross-host relay](#cross-host-relay)
+  — which already routes by the destination pane's `(host, backend)` regardless of where a message
+  originated — delivers it onward to native or agmsg panes, local or remote, with no
+  command-center-specific routing logic required.
+- The reserved agent identity `_panemux` is used both as the `from_agent` when the command center
+  sends, and as the `to_agent` workers report status to for dashboard aggregation (unifying the
+  identity already introduced for the `agmsg` backend's status mapping in [Backends](#backends)
+  rather than adding a second reserved name).
+
+### Authorization
+
+The command center's privilege (it can message *any* board-enabled pane) is not granted by any
+board-level pane role — there is no pane role left in this design. It is granted the same way every
+other capability in panemux is: `POST`/WS access to the command center's own endpoint requires the
+global bearer-token auth described in [Security model](#security-model). This is a cleaner trust
+boundary than a pane self-declaring `role: supervisor` ever was, because it is enforced by
+panemux's existing authenticated API layer rather than by convention a receiving pane has to trust.
+
+**Trust implication, stated explicitly, still applies:** a message the command center sends is an
+ordinary instruction to the receiving pane, not something pre-authorized — the same caveat already
+called out for the `SendMessage` tool in Claude Code itself. The receiving pane's own normal
+confirmation flow still applies.
+
+### API and streaming
+
+- `POST /ws/board-command` (WebSocket, matching the existing `/ws/{sessionID}` streaming pattern
+  rather than a blocking REST call): the frontend sends `{"prompt": "..."}`, panemux runs `claude -p
+  --resume <id> --output-format=stream-json "<prompt>"` and streams tokens back as they're
+  generated, so the palette can show live output instead of waiting for the full response.
+- `GET /api/board/command/history`: returns the command center's own turn-by-turn history, parsed
+  from its Claude Code session transcript using the transcript-reading capability panemux already
+  has for Claude worktree resolution (see [architecture.md](architecture.md)) — reused as-is, not
+  duplicated into the board's `messages` table. Because `board send`/`board status --all` calls
+  the command center makes appear as ordinary tool calls in that same transcript, the returned
+  history already interleaves "what the user asked," "what the command center did on the board,"
+  and "what it told the user" in one chronological feed, with no extra bookkeeping required.
+
+### UI
+
+- A global keyboard shortcut opens a Spotlight-style modal palette (exact binding to be decided at
+  implementation time, avoiding conflicts with OS-level shortcuts and existing terminal bindings).
+- The palette shows recent history inline on open (via the history endpoint above) and streams the
+  live response as it's generated.
+- A separate, persistently accessible history panel (following the same UI pattern as the existing
+  workspace-summary overlay) exposes the same history outside the quick-palette flow, for scrolling
+  back further than what the palette shows inline.
+
+### Scope, kept intentionally narrow for now
+
+Exactly one command center session per panemux instance — not per-workspace, not multiple
+concurrent command centers. Nothing in this design forecloses that later, but nothing here should
+be built to anticipate it either, per this repository's own guidance against designing for
+hypothetical future requirements.
 
 ## API additions
 
@@ -324,6 +383,8 @@ unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it s
 | `GET /api/board/status` | Latest `kind='status'` row per pane, across every host panemux manages |
 | `GET /api/board/messages?since=<id>` | History feed for the dashboard UI |
 | `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; inserts directly into each target's own host `Store` (never via PTY injection, so it is safe to send to a pane mid-turn) |
+| `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
+| `GET /api/board/command/history` | Command center's own transcript-derived conversation history — see [Command center](#command-center) |
 
 ## Config additions
 
@@ -333,13 +394,15 @@ server:
   port: 8080
   auth_token: ""   # empty = auto-generate on first run, saved to ~/.config/panemux/token (0600)
 
+command_center:
+  enabled: true   # default false; spawns the headless claude -p --resume process on demand
+
 panes:
   - id: pane-a
     type: local
     agent_board:
       enabled: true
       backend: native  # native (default) | agmsg; explicit only, never auto-detected
-      role: worker     # or supervisor; supervisor must always be explicit, never a default
       mode: monitor    # monitor (default) | turn | both; turn/both need a manually-added Stop hook
 
   - id: pane-b          # e.g. a Codex pane sharing pane-a's host
@@ -389,6 +452,12 @@ that shaped the design.
   panemux↔host B), but panemux itself decrypts and re-serializes the row in between, so the
   panemux process/host must be trusted for the relay to be meaningful. There is no end-to-end
   encryption between two remote agents' Claude processes.
+- **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
+  bearer token as everything else, and that gate is the entire authorization model for
+  `board send <any-pane-id>`** — see [Command center](#command-center). There is deliberately no
+  separate, weaker permission tier for it; anyone who can authenticate to panemux at all can already
+  reach the full-shell terminal WebSocket, so a second, narrower gate here would not reduce real
+  risk, only add a second thing to keep in sync.
 
 ## Known limitations
 
@@ -406,6 +475,13 @@ that shaped the design.
   has changed incompatibly, panemux's `LocalAgmsgStore`/`RemoteAgmsgStore` can fail even though
   nothing in panemux's own config changed. This is the accepted cost of not vendoring/pinning a
   copy of agmsg inside panemux itself.
+- Exactly one command center session exists per panemux instance (see
+  [Command center](#command-center)); it is not per-workspace and does not support multiple
+  concurrent orchestrators today.
+- The command center spawns `claude -p` as a subprocess per query; response latency includes
+  process startup plus generation time, which is higher than a warm, already-running interactive
+  session would give — acceptable for a "converse with an orchestrator" UX, not for anything
+  latency-sensitive.
 
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 
@@ -426,6 +502,13 @@ that shaped the design.
   `backend: agmsg` where agmsg is present bootstraps through the agmsg path instead of `panemux
   board *`; mixed-backend same-host relay (a `native` pane and an `agmsg` pane on one host,
   addressed to each other) goes through the relay step rather than being treated as already-shared.
+- Command center: `/ws/board-command` rejects an unauthenticated connection the same way the
+  terminal WebSocket does; `board send`/`board status --all` issued from the command center's
+  subprocess reach a target pane regardless of that pane's `(host, backend)`, using a fake `Store`
+  per combination to assert routing without a real agmsg/SSH dependency; `GET
+  /api/board/command/history` parses a fixture transcript containing interleaved user turns,
+  assistant text, and `board send`/`status --all` tool calls into one ordered feed, and returns an
+  empty/well-defined result before the command center has ever been used (no transcript file yet).
 
 ## Related documents
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -8,14 +8,23 @@
 
 ## Purpose
 
-panemux currently infers what an interactive Claude process in a pane is doing by parsing
-`~/.claude/sessions/<pid>.json` and the matching transcript JSONL (see the Claude worktree
-resolution notes in [architecture.md](architecture.md) and [behavior.md](behavior.md)). In
-practice this is unreliable: it depends on undocumented, internal Claude/Codex transcript fields
-that change without notice, and pane headers frequently fail to show a branch or PR as a result.
-It is also read-only and pane-local: it cannot tell whether a session is idle or mid-turn, and it
-gives panemux no way to send an agent a message or to let two agents in different panes talk to
-each other.
+panemux already runs real `git`/`gh` commands to show branch and PR info in a pane header — that
+part is not inferred (see `docs/behavior.md`'s pane-header Git/PR section). What *is* inferred is
+**which directory to run those commands in**: for an interactive Claude/Codex pane, panemux parses
+`~/.claude/sessions/<pid>.json` and the matching transcript JSONL to decide whether the agent has
+moved into a sibling worktree, using an undocumented, internal precedence across several transcript
+fields (`session_meta.cwd`, `turn_context.cwd`, `Bash` `cd` targets, subagent transcript files —
+see [architecture.md](architecture.md)) that has already needed at least one bug fix as Claude Code
+itself evolved. When that resolution is wrong, the `git`/`gh` calls still run — just in the wrong
+directory, or nowhere confidently resolvable at all — and the header shows a stale, wrong, or
+missing branch/PR. In practice this happens often enough that a panemux user ends up asking Claude
+directly for its own PR URL instead of trusting the header. The instability is real; it just lives
+one layer deeper than "the git/PR data is inferred" — it's "the directory the real git/PR data
+comes from is inferred," which is no more stable a thing to reverse-engineer.
+
+This mechanism is also read-only and pane-local: it cannot tell whether a session is idle or
+mid-turn, and it gives panemux no way to send an agent a message or to let two agents in different
+panes talk to each other.
 
 Agent Board replaces that inference with a small, self-reported channel:
 
@@ -107,9 +116,10 @@ flowchart TB
     Browser <--> Server
     Server --> Relay
     Server --> CmdCenter
+    Server --> Cache
+    CmdCenter -->|"REST, loopback<br/>same endpoints Browser uses"| Server
     Relay --> Cache
-    Relay -->|"api.sh / send.sh"| LocalAgmsg
-    CmdCenter -->|"api.sh / send.sh --force"| LocalAgmsg
+    Relay -->|"api.sh / send.sh --force"| LocalAgmsg
     Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
     Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgB
     ClaudeA -->|"Bash tool calls"| AgmsgA
@@ -140,9 +150,9 @@ flowchart TB
 
         AuthAPI -->|"GET /api/board/status, /messages"| BoardCache
         AuthAPI --> CmdCenter
+        CmdCenter -->|"POST /api/board/broadcast<br/>(same path a browser request takes)"| AuthAPI
         Relay -->|"writes status and history"| BoardCache
         Relay --> AgmsgClient
-        CmdCenter --> AgmsgClient
     end
 
     subgraph AgmsgBoundary["agmsg's responsibility (independent per host, not owned by panemux)"]
@@ -207,64 +217,112 @@ against agmsg's source (not inferred). panemux never reads or writes agmsg's `me
 | `api.sh get teams <team> messages [--agent <name>] [--limit N] [--before-id <id>]` | `{"type":"message_sent","id","team","from","to","body","at"}` per line, JSONL, oldest-first |
 
 `id` is returned as a string (agmsg's own future-proofing against a non-integer ID scheme, per its
-source comments), and `--agent`/`--limit`/`--before-id` are validated as plain digits before being
-used in a query, guarding against SQL injection on agmsg's own side. Unlike agmsg's own
-human-facing `inbox.sh`/`check-inbox.sh` (which mark whatever they display as read), `api.sh` never
-writes `read_at` — panemux's dashboard/relay polling through it cannot cause a joined agent to miss
-a message its own inbox/`Monitor` delivery would otherwise have shown it.
+source comments) — panemux must not assume it stays a bare integer forever, even though today's
+implementation is one. Only `--limit` and `--before-id` are validated as plain digits; **`--agent`
+is not** — it is a free-text name protected only by agmsg's own internal `_agmsg_sqlesc` SQL
+escaping, not by any argument-shape check. An earlier revision of this document claimed all three
+were digit-validated; that was wrong, and the correction matters directly for [Security
+model](#security-model): panemux cannot skip its own shell-escaping on reads on the theory that
+agmsg has already validated the arguments for it. Unlike agmsg's own human-facing
+`inbox.sh`/`check-inbox.sh` (which mark whatever they display as read), `api.sh` never writes
+`read_at` — panemux's dashboard/relay polling through it cannot cause a joined agent to miss a
+message its own inbox/`Monitor` delivery would otherwise have shown it.
+
+**There is no forward/"since" read.** `--before-id` selects `id < X` — a backwards pagination
+cursor, the opposite of what an incremental poll needs — and `api.sh` has no after/since option at
+all. The relay therefore cannot use `--before-id` for its poll loop (an earlier revision of this
+document specified exactly that mistake). Instead, each poll calls `api.sh get teams <team>
+messages --limit <N>` with **no** `--before-id`, taking the `N` most recent rows (`N` defaults to a
+few hundred; see [Package layout](#package-layout)), and filters client-side to rows whose `id` is
+numerically greater than the persisted cursor. **This has a real, accepted truncation risk:** if
+more than `N` genuinely new rows land on one host between two poll cycles, the oldest of that
+overflow are silently skipped — there is no way to detect or recover them through `api.sh`'s
+documented interface. `--before-id` remains useful for one thing only: paging *backwards* through
+older history on demand (e.g. a "load more" action in the dashboard's history view), never for the
+relay's forward poll.
 
 **Writes — `scripts/send.sh`, not `api.sh`.** Signature: `send.sh <team> <from> <to> <body>
 [--force]`. Unlike `api.sh`, `send.sh` takes `body` as a **positional shell argument**, not stdin —
-there is no stdin-based write path in agmsg to delegate to. `from` is checked against that team's
-roster unless `--force` is passed, in which case an unregistered sender name is accepted as-is.
+there is no stdin-based write path in agmsg to delegate to. **Both `from` and `to` are checked
+against that team's roster unless `--force` is passed** — an earlier revision of this document said
+only `from` was checked, which is wrong and was load-bearing: it made every message in [Status
+self-report](#status-self-report-and-message-flow)'s sequence diagram fail at the source, since
+`_panemux` (the status-report recipient) and any pane on a *different* host (the cross-host relay
+target) are never registered in the sending pane's own local roster.
+
+**The fix this document adopts: every board-related `send.sh` call always passes `--force`,
+including the ones a live Claude/Codex session makes for itself.** The bootstrap instruction (see
+[Bootstrap flow](#bootstrap-flow)) tells the agent to call `send.sh <team> <from> <to> "<body>"
+--force` directly for board messages, rather than going through `/agmsg send` (which — confirmed
+against agmsg's own skill templates — has no documented way to pass `--force` through). This is a
+deliberate deviation from "just use agmsg's normal onboarding flow for everything": the roster
+check `send.sh` performs by default is fundamentally incompatible with addressing a reserved
+sentinel identity or a pane on a host that has never heard of it, so board traffic opts out of that
+check uniformly instead of trying to satisfy it. A pane can still use unforced `/agmsg send` for
+its *own*, non-board conversations with other agmsg-native agents already on that host (Codex,
+Gemini CLI, etc.) — that path is untouched and still roster-checked normally.
 
 **Panes join with `join.sh <team> <agent_id> <agent_type> <project_path> [--force]`**, typically
 via agmsg's own onboarding (the `/agmsg` skill flow a live Claude session runs itself, or the
 equivalent for another agent type) rather than the raw script directly — see [Bootstrap
-flow](#bootstrap-flow). This registers the pane into `teams/<team>/config.json`, which is the
-"roster" `send.sh` checks `from` against. Any other agent already using agmsg on that host (Codex,
-Gemini CLI, etc.) can then exchange messages with a panemux-managed pane directly through agmsg,
-with no panemux involvement in that same-host exchange at all. Once joined, agmsg's own
-`SessionStart`/`SessionEnd` hooks own that pane's `Monitor` (`watch.sh`)-process lifecycle
-end-to-end (launch, liveness, cleanup) — panemux has no part in it and does not need to.
+flow](#bootstrap-flow). This registers the pane into `teams/<team>/config.json`. Because board
+sends always pass `--force`, this registration is no longer what gates board delivery — its
+purpose is solely to let other, non-board-aware agmsg agents on the same host (Codex, Gemini CLI,
+etc.) address the pane normally, and to give the pane a working `/agmsg` identity for its own
+non-board use. Once joined, agmsg's own `SessionStart`/`SessionEnd` hooks own that pane's `Monitor`
+(`watch.sh`)-process lifecycle end-to-end (launch, liveness, cleanup) — panemux has no part in it
+and does not need to.
 
 **panemux's own relay and command center are never agmsg roster members, and never go through
-agmsg's own identity-detection layer, so any send they originate always passes `send.sh ...
---force`.** A live Claude session's own `/agmsg send` normally resolves `from` automatically —
-`whoami.sh` matches environment variables or, failing that, walks the process tree against each
-agent type's known process-name patterns, then `identities.sh` reconciles that against a joined
-team/project — but that whole chain assumes a live process to introspect. The relay and command
-center are panemux's own Go code, not a joined Claude/Codex process, so no identity-detection
-result would ever exist for them to look up; `--force` is what lets `send.sh` accept an explicit
-`from` (the originating pane's ID, or the reserved identity `_panemux` for the command center)
-without that lookup succeeding first.
+agmsg's own identity-detection layer, so any send they originate uses `--force` for the same reason
+board traffic from a live pane does.** A live Claude session's own unforced `/agmsg send` normally
+resolves `from` automatically — `whoami.sh` matches environment variables or, failing that, walks
+the process tree against each agent type's known process-name patterns, then `identities.sh`
+reconciles that against a joined team/project — but that whole chain assumes a live process to
+introspect. The relay and command center are panemux's own Go code, not a joined Claude/Codex
+process, so no identity-detection result would ever exist for them to look up.
 
 **Team naming.** All board-enabled panes on a given panemux instance join the same agmsg team by
 default (`agent_board.team`, default `"panemux"`), so message addressing is just pane IDs within
 one team — see [Config additions](#config-additions).
 
 **Detection, not installation.** At bootstrap time panemux checks whether agmsg is available on
-that pane's host (local: presence of `scripts/api.sh` under agmsg's known skill-install location,
-or `command -v agmsg`; remote: the same check run once over the existing SSH exec channel). If not
-found, panemux skips board bootstrap for that pane, logs a clear warning naming the pane, and
-leaves the pane's shell session itself untouched. panemux never runs `npx agmsg`, `npm i -g agmsg`,
-`git clone`, or any other installer on the operator's behalf, on any host.
+that pane's host by looking for `scripts/api.sh` under agmsg's configured skill-install location.
+**`command -v agmsg` must not be used for this** — the `agmsg` npm package on `PATH` is a thin
+bootstrapper whose own stated purpose is to *"reserve the agmsg name on npm and give users a
+convenient `npx agmsg install` entry point"*; its presence says nothing about whether agmsg itself
+is installed, and *invoking* it fetches and runs agmsg's real installer — exactly the auto-install
+this design forbids. There is also no single fixed "known skill-install location": `install.sh`
+prompts for a command name and installs under `~/.agents/skills/<that name>/`, and agmsg separately
+supports an `AGMSG_STORAGE_PATH` override. panemux's detection therefore needs an explicit,
+operator-set path (e.g. `agent_board.agmsg_path`, defaulting to the common `~/.agents/skills/agmsg/`
+case but overridable), not a heuristic guess. If the configured/default path doesn't contain
+`scripts/api.sh`, panemux skips board bootstrap for that pane, logs a clear warning naming the pane,
+and leaves the pane's shell session itself untouched. panemux never runs `npx agmsg`, `npm i -g
+agmsg`, `git clone`, or any other installer on the operator's behalf, on any host.
 
 **Version pinning.** agmsg's own compatibility promise (per its README) only covers reading through
-`scripts/api.sh`, not `send.sh`'s argument order or `messages.db`. panemux implementation must pin
-a specific tested agmsg version/tag and treat any change to either script's observed behavior as an
-external dependency compatibility bug, tracked the same way any other pinned dependency's breaking
-change would be.
+`scripts/api.sh`; there is no equivalent promise for `send.sh`'s argument order/behavior or for
+`messages.db`. Because this design's write path depends entirely on `send.sh`, panemux is taking on
+more exposure to agmsg's evolution than a "we only read from it" dependency would carry — see [J2
+in Known limitations](#known-limitations) for that tradeoff stated plainly. panemux implementation
+must pin a specific tested agmsg version/tag and treat any change to either script's observed
+behavior as an external dependency compatibility bug, tracked the same way any other pinned
+dependency's breaking change would be.
 
 ## Status self-report and message flow
 
 Instead of a `kind='status'` field panemux owns (agmsg has no such column), status reports are
 ordinary agmsg messages addressed to the reserved identity `_panemux` — the same identity the
-command center uses as its own `from` when sending. The relay goroutine, already polling every
-host's agmsg with `api.sh get teams <team> messages --before-id <cursor>` for message forwarding,
-recognizes any row addressed to `_panemux` as a status update and writes it into panemux's own
-in-memory status cache (see [Architecture](#architecture)), keeping only the newest entry per
-sender. The dashboard never queries agmsg directly for this — it only ever reads that cache.
+command center uses as its own `from` when sending. Because `_panemux` is never an agmsg roster
+member (see [Integration with agmsg](#integration-with-agmsg)), the agent's own `send.sh ...
+--force` call is what lets a status report reach it at all. The relay goroutine, already polling
+every host's agmsg with `api.sh get teams <team> messages --limit <N>` (no `--before-id` — see
+[Integration with agmsg](#integration-with-agmsg) for why that flag can't do this) for message
+forwarding, recognizes any row addressed to `_panemux` as a status update and writes it into
+panemux's own in-memory status cache (see [Architecture](#architecture)), keeping only the newest
+entry per sender. The dashboard never queries agmsg directly for this — it only ever reads that
+cache.
 
 The bootstrap instruction (see [Bootstrap flow](#bootstrap-flow)) tells Claude to gather this
 itself, using its own `Bash` tool, and include it as a small JSON body:
@@ -298,19 +356,19 @@ sequenceDiagram
 
     Note over ClaudeA: Status self-report
     ClaudeA->>ClaudeA: run git branch / gh pr view
-    ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}"
-    Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
-    AgmsgA-->>Relay: new row (addressed to _panemux)
+    ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}" --force
+    Relay->>AgmsgA: api.sh get teams team messages --limit N
+    AgmsgA-->>Relay: rows with id > cursor (addressed to _panemux)
     Relay->>Cache: write latest status (JSON)
     Dash->>Cache: GET /api/board/status
     Cache-->>Dash: latest status (no agmsg call)
 
     Note over ClaudeA,CodexB: Cross-pane message relay
-    ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "please review"
-    Relay->>AgmsgA: api.sh get teams team messages --before-id cursor
-    AgmsgA-->>Relay: new row (addressed to another pane)
+    ClaudeA->>AgmsgA: send.sh team ClaudeA CodexB "please review" --force
+    Relay->>AgmsgA: api.sh get teams team messages --limit N
+    AgmsgA-->>Relay: rows with id > cursor (addressed to another pane)
     Relay->>AgmsgB: send.sh team ClaudeA CodexB "please review" --force
-    CodexB->>AgmsgB: received via Monitor / watch.sh
+    AgmsgB-->>CodexB: delivered via Monitor / watch.sh
 ```
 
 **Honest tradeoff, stated explicitly.** Self-report is only as good as the agent's compliance: it
@@ -326,7 +384,8 @@ control," even though the former requires the agent's cooperation and the latter
 
 ```go
 type Row struct {
-    ID          int64
+    ID          string    // agmsg's own id, host-scoped — NOT globally unique, NOT assumed numeric
+    Host        string    // which AgmsgClient/host this row came from; required to compare/sort across hosts
     Team        string
     From, To    string
     Body        string
@@ -335,28 +394,48 @@ type Row struct {
 
 type Status struct {
     State, CWD, Branch, Repo, PRURL, LastTool, Summary string
+    UpdatedAt   time.Time // when this status was recorded, so staleness is visible to the dashboard
 }
 
 type AgmsgClient interface {
     HostID() string
-    Send(ctx context.Context, team, from, to, body string) error         // send.sh ... --force
-    Since(ctx context.Context, team string, afterID int64) ([]Row, error) // api.sh get ... messages
+    // Send always passes --force. There is no non-forced Send: every board-originated message
+    // (self-reported status, cross-host relay, command center) needs to reach a to/from identity
+    // that is not guaranteed to be in the destination team's roster — see Integration with agmsg.
+    // Escaping (shell, and for reads, agmsg's own incomplete argument validation) is this
+    // implementation's responsibility, not the caller's — see internal/session's BoardExecutor.
+    Send(ctx context.Context, team, from, to, body string) error
+    // Since has no true "after" primitive to call into (api.sh has no such flag). It calls
+    // `api.sh get teams <team> messages --limit <limit>` and returns only rows whose ID sorts
+    // after afterID; the caller must treat the possibility of dropped rows (more than `limit` new
+    // rows since the last poll) as expected, not exceptional — see Integration with agmsg.
+    Since(ctx context.Context, team, afterID string, limit int) ([]Row, error)
 }
 
 // BoardCache is the in-memory, panemux-owned view of recent board activity shown in Architecture.
 // Only the relay writes to it, as a side effect of the same Since polling it already does for
 // message forwarding; both dashboard-facing endpoints only ever read it, never calling
-// AgmsgClient directly at request time.
+// AgmsgClient directly at request time. Unlike AgmsgClient.Since's per-host afterID (an opaque
+// agmsg-native string), BoardCache assigns its own monotonically increasing, panemux-local `Seq`
+// to every row as it's appended, specifically because agmsg IDs from different hosts are not
+// comparable or even guaranteed non-colliding with each other — Seq is what GET
+// /api/board/messages?since=<id> actually paginates on.
 type BoardCache struct {
-    mu      sync.RWMutex
-    status  map[string]Status // paneID -> latest self-reported status
-    history []Row             // bounded ring buffer of recent messages, most recent last
+    mu       sync.RWMutex
+    status   map[string]Status // paneID -> latest self-reported status (pane IDs are globally unique)
+    nextSeq  int64
+    history  []cachedRow       // bounded ring buffer, most recent last
 }
 
-func (c *BoardCache) RecordStatus(paneID string, s Status)  { /* mutex-guarded write */ }
-func (c *BoardCache) AppendMessage(r Row)                   { /* mutex-guarded write */ }
-func (c *BoardCache) StatusSnapshot() map[string]Status     { /* mutex-guarded copy */ }
-func (c *BoardCache) MessagesSince(afterID int64) []Row     { /* mutex-guarded copy */ }
+type cachedRow struct {
+    Seq int64
+    Row Row
+}
+
+func (c *BoardCache) RecordStatus(paneID string, s Status) { /* mutex-guarded write; sets s.UpdatedAt */ }
+func (c *BoardCache) AppendMessage(r Row)                  { /* mutex-guarded write; assigns next Seq */ }
+func (c *BoardCache) StatusSnapshot() map[string]Status    { /* mutex-guarded copy */ }
+func (c *BoardCache) MessagesSince(afterSeq int64) []Row   { /* mutex-guarded copy, filtered by Seq */ }
 ```
 
 The relay inspects every `Row` it reads: if `To == "_panemux"` and `Body` parses as the JSON shape
@@ -371,17 +450,20 @@ was already doing.
 
 - `LocalAgmsgClient` shells out to the local agmsg installation's `scripts/api.sh` for reads and
   `scripts/send.sh ... --force` for writes. Because this is a local `exec.Command` invocation, Go
-  passes each argument as a genuine array element with no intermediate shell, so `send.sh`'s
-  argument-based `body` parameter carries no injection risk here regardless of its content.
-- `RemoteAgmsgClient` runs the same two scripts on the remote host over the SSH exec channel.
-  Reads (`api.sh get ...`) only ever take digit-validated or path-traversal-validated arguments, so
-  they need no special quoting beyond the discipline already applied everywhere else. Writes need
-  single-quote-escaping of every argument (team, from, to, body) — the same `shellQuotePath`-style
-  discipline `internal/session/ssh.go` already applies to `cwd` — before building the remote
-  command string, since `send.sh` has no stdin option to keep `body` out of it entirely. `send.sh`
-  does its own SQL escaping internally, so this is the *only* escaping layer panemux is responsible
-  for here — there is no local schema of panemux's own to also escape SQL text for. See [Security
-  model](#security-model) and [security.md](security.md).
+  passes each argument as a genuine array element with no intermediate shell, so no argument to
+  either script carries shell-injection risk here regardless of its content.
+- `RemoteAgmsgClient` runs the same two scripts on the remote host over the SSH exec channel and
+  single-quote-escapes **every** argument to **every** call — reads included, `team` and `--agent`
+  included, not just writes — before building the remote command string, using the same
+  `shellQuotePath`-style discipline `internal/session/ssh.go` already applies to `cwd`. This is a
+  correction from an earlier revision of this document, which claimed `api.sh`'s arguments were
+  all digit-validated and therefore needed no escaping; that claim was wrong for `--agent` (see
+  [Integration with agmsg](#integration-with-agmsg)), and in any case agmsg's own validation runs
+  *inside the already-started remote shell process*, after panemux's command string has already
+  been parsed — it cannot retroactively protect the string-construction step. `send.sh` does its
+  own SQL escaping internally, so panemux never needs a second, SQL-literal escaping layer of its
+  own on top of the shell layer — there is no local schema of panemux's own to escape SQL text for.
+  See [Security model](#security-model) and [security.md](security.md).
 
 Because panemux owns no schema, it needs no embedded database driver of its own at all — every
 board operation is either a local `exec.Command` or a remote exec-channel command running agmsg's
@@ -402,9 +484,13 @@ type BoardHostID interface {
 
 // BoardExecutor is implemented by SSH-backed sessions. It runs an agmsg script on the remote host
 // over the session's existing exec channel, as a single shell command string built from args.
-// Every argument must be single-quote-escaped (the same discipline internal/session/ssh.go already
-// applies to cwd) before that string is built; send.sh has no stdin-based write path (see
-// docs/agent-board.md#integration-with-agmsg).
+// RunBoardCommand itself single-quote-escapes every element of args (the same discipline
+// internal/session/ssh.go already applies to cwd) before building that string — the caller passes
+// raw, unescaped values, exactly like exec.Command's own argv contract, so there is exactly one
+// place this can be gotten wrong rather than one per call site. Neither api.sh (reads) nor send.sh
+// (writes) has a stdin option for the values this carries (see
+// docs/agent-board.md#integration-with-agmsg), so escaping the command string is the only
+// available defense for either.
 type BoardExecutor interface {
     RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
 }
@@ -444,15 +530,24 @@ Two Claude/Codex processes on two different SSH-reached hosts cannot share one a
 (agmsg is a single-host tool with no cross-host awareness, and the two hosts may not even be able
 to reach each other). panemux is the only node with a connection to every host, so it relays:
 
-1. A single goroutine polls every known host's `Since(team, cursor)` every few seconds.
-2. `cursor` is one value per (host, team), persisted in a small local JSON file (e.g.
+1. A single goroutine polls every known host's `Since(team, cursor, limit)` every few seconds (see
+   [Integration with agmsg](#integration-with-agmsg) for why this is a bounded `--limit` poll with
+   client-side filtering, not a true incremental read, and the truncation risk that implies).
+2. `cursor` is one value per (host, team) — agmsg's own opaque `id` string for that host, *not*
+   comparable across hosts — persisted in a small local JSON file (e.g.
    `~/.config/panemux/board-relay-cursor.json`) — not a database table, since panemux owns no
    database — so a panemux restart resumes roughly where it left off.
-3. For each new row, if `to == "_panemux"`, panemux updates the [in-memory status
-   cache](#architecture) instead of relaying it — status reports never leave the host they were
-   written on. Otherwise, panemux resolves `to` to its owning pane and that pane's host via the
-   already-known pane→session config; if that host differs from the source host, panemux calls
-   `Send` on the destination host's `AgmsgClient` with `--force`.
+3. For each new row, panemux first checks `from`: **if `from` is not a board-enabled pane ID
+   panemux knows about on that row's source host (or is itself `_panemux`), the row is dropped and
+   logged, never relayed and never cached.** This is a deliberate integrity check on the one field
+   `--force` makes otherwise unverifiable — see [Security model](#security-model) for the forgery
+   scenario it closes. If `from` passes that check: when `to == "_panemux"`, panemux updates the
+   [in-memory status cache](#architecture) instead of relaying it — status reports never leave the
+   host they were written on. Otherwise, panemux resolves `to` to its owning pane and that pane's
+   host via the already-known pane→session config; if that host differs from the source host,
+   panemux calls `Send` (always `--force`, per [Integration with
+   agmsg](#integration-with-agmsg)) on the destination host's `AgmsgClient`. A `to` that doesn't
+   resolve to any known pane is dropped and logged, the same as an invalid `from`.
 4. Same-host `to` needs no relay: sender and receiver are already members of the same local agmsg
    team.
 5. `GET /api/board/status` never triggers an `AgmsgClient` call at all — it only reads the status
@@ -484,15 +579,22 @@ always routed through it by construction.
    agmsg](#integration-with-agmsg). If agmsg is not found on that host, it logs a warning naming the
    pane and stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
 3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
-   used for all terminal input) telling the agent to join agmsg's team using agmsg's own onboarding
-   flow (e.g. `/agmsg` or the equivalent first-run prompt), to rely on agmsg's own `Monitor`/hook
-   wiring for delivery exactly as it would if the user had set this up by hand, and to include the
-   [status self-report](#status-self-report-and-message-flow) fields on every status update. This
-   is unaffected by local vs. remote — it is agmsg's own already-installed skill doing the work
-   either way, not something panemux provisions per pane. This step only ever establishes *that
-   pane's* participation; it never touches any other pane or any other agent already using agmsg on
-   that host (a pre-existing Codex agent, for example, keeps working exactly as it did before
-   panemux was involved).
+   used for all terminal input) telling the agent to: join agmsg's team **using the pane's own ID
+   (the same `<pane-id>` panemux's config and every other part of this document address it by) as
+   the agmsg `agent_id`** — required, and stated explicitly, because agmsg's own onboarding can
+   otherwise prompt for an arbitrary name of the agent's choosing, which would silently break every
+   cross-pane and relay address in this design (they all assume `from`/`to` *are* pane IDs) — via
+   agmsg's own onboarding flow (e.g. `/agmsg` or the equivalent first-run prompt), rely on agmsg's
+   own `Monitor`/hook wiring for delivery exactly as it would if the user had set this up by hand,
+   include the [status self-report](#status-self-report-and-message-flow) fields on every status
+   update, and — this is the one deviation from "just do what agmsg's normal flow does" — send
+   every board-related message (status reports, cross-pane messages) with the raw `send.sh <team>
+   <from> <to> "<body>" --force` invocation rather than `/agmsg send`, per [Integration with
+   agmsg](#integration-with-agmsg). Joining and non-board `/agmsg` use are unaffected by local vs.
+   remote — it is agmsg's own already-installed skill doing the work either way, not something
+   panemux provisions per pane. This step only ever establishes *that pane's* participation; it
+   never touches any other pane or any other agent already using agmsg on that host (a pre-existing
+   Codex agent, for example, keeps working exactly as it did before panemux was involved).
 4. If `mode` is `turn` or `both` (mirroring agmsg's own `/agmsg mode monitor|turn|both`, default
    `monitor`), the bootstrap instruction also tells the agent to run `/agmsg mode <value>` — this
    is agmsg's own setting, not something panemux tracks or enforces separately.
@@ -507,17 +609,26 @@ always routed through it by construction.
   introduce the "new daemon" [Design principles](#design-principles) rules out. `--resume` against
   one fixed session id is what gives the command center conversational continuity across separate
   queries.
-- It runs on panemux's own local host only (never remote), so it uses the local agmsg installation
-  directly: `send.sh <team> _panemux <to-pane-id> "<body>" --force` to instruct any pane, and
-  `api.sh get teams <team> messages --agent _panemux --limit <N>` to read status across every pane
-  — the same calls [Package layout](#package-layout)'s `AgmsgClient` already wraps, invoked as
-  ordinary `Bash` tool calls within its own turn. Enabling the command center therefore requires
-  agmsg to be present on panemux's own host, gated by the same detection (never installation) rule
-  as any other agmsg-backed pane.
-- Because the destination pane's host is resolved the same way for any `send.sh --force` call
-  regardless of who issued it, the command center needs no special-cased routing: the [cross-host
-  relay](#cross-host-relay) delivers its messages onward exactly as it would for any other pane's
-  message to a pane on a different host.
+- **It reads and writes the board through panemux's own authenticated REST API — `GET
+  /api/board/status`, `GET /api/board/messages`, `POST /api/board/broadcast` — the same endpoints
+  the browser dashboard uses, over loopback, with a token panemux injects into the subprocess's
+  environment.** This is a correction from an earlier revision of this document, which had the
+  command center shell out to `send.sh`/`api.sh` directly. That was wrong on two counts: it made
+  the LLM itself responsible for composing safely-escaped shell invocations, a second, unaudited
+  path to the same exec sink alongside `AgmsgClient`'s own (see [Security
+  model](#security-model)); and it meant the command center could only ever see the *local* agmsg
+  installation's status, never a remote pane's, because [Cross-host relay](#cross-host-relay)
+  intercepts `_panemux`-addressed status reports before they ever leave the host they were written
+  on. Reading `BoardCache` through `GET /api/board/status` (already aggregated across every host by
+  the relay) fixes both: `AgmsgClient` stays the *only* code that ever calls agmsg's scripts, and
+  the command center sees every pane's status, not just local ones.
+- **The command center therefore needs no local agmsg installation of its own** — it never calls
+  agmsg directly, so `command_center.enabled: true` is not gated on the same agmsg-presence check a
+  board-enabled pane is (see [Config additions](#config-additions)).
+- Sending a message is `POST /api/board/broadcast` with the command center's own reserved `from`
+  identity, `_panemux` — the exact same code path a human-triggered broadcast takes, which already
+  resolves the destination pane's host and calls that host's `AgmsgClient.Send` (always `--force`)
+  without the command center needing any host-routing logic of its own.
 
 ### Authorization
 
@@ -573,7 +684,7 @@ unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it s
 | Endpoint | Purpose |
 |---|---|
 | `GET /api/board/status` | A snapshot of panemux's in-memory status cache — no `AgmsgClient` call happens on this request (see [Architecture](#architecture)) |
-| `GET /api/board/messages?since=<id>` | History feed for the dashboard UI |
+| `GET /api/board/messages?since=<seq>` | History feed for the dashboard UI. `<seq>` is `BoardCache`'s own panemux-local sequence number (see [Package layout](#package-layout)), not an agmsg-native `id` — those aren't comparable across hosts |
 | `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn) |
 | `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
 | `GET /api/board/command/history` | Command center's own captured conversation history — see [Command center](#command-center) |
@@ -587,10 +698,11 @@ server:
   auth_token: ""   # empty = auto-generate on first run, saved to ~/.config/panemux/token (0600)
 
 command_center:
-  enabled: true   # default false; requires agmsg present on panemux's own host
+  enabled: true   # default false; talks only to panemux's own REST API, no local agmsg needed
 
 agent_board:
   team: "panemux"  # default; all board-enabled panes share this agmsg team unless overridden
+  agmsg_path: "~/.agents/skills/agmsg"  # default; where scripts/api.sh is expected, per-host override possible
 
 panes:
   - id: pane-a
@@ -626,14 +738,34 @@ that shaped the design.
   ultimately drive shell-executing agents). Config validation must therefore fail closed: if
   `server.host` resolves to a non-loopback address and `server.auth_token` is empty, startup must
   be rejected (`internal/config/validate.go`, alongside the existing `server.port` range check).
-- **Message bodies never reach a remote shell unescaped.** `send.sh` has no stdin-based way to
-  receive its `body` argument — verified against agmsg's own source, not assumed — so
-  `RemoteAgmsgClient` cannot avoid putting the body in the remote command string. The requirement
-  is upheld the way `cwd` already is in `internal/session/ssh.go` (`validRemotePath` /
-  `shellQuotePath`): every argument is single-quote-escaped before the command string is built,
-  never concatenated unescaped. `send.sh` does its own SQL escaping internally, so this
-  shell-escaping layer is the only one panemux is responsible for — there is no panemux-owned SQL
-  text to also escape, unlike an earlier draft of this design that had panemux building its own SQL.
+- **No argument, on any `RemoteAgmsgClient` call — reads included — ever reaches the remote shell
+  unescaped.** Neither `api.sh` nor `send.sh` has a stdin-based way to receive the values panemux
+  passes them, so the remote command string is the only place they can go, and it must be built
+  with every argument single-quote-escaped, the same discipline already applied to `cwd` in
+  `internal/session/ssh.go` (`validRemotePath` / `shellQuotePath`). Reads are **not** exempt: an
+  earlier revision of this document claimed `api.sh`'s arguments were digit-validated and therefore
+  safe to leave unescaped, which was both factually wrong (`--agent` isn't validated at all — see
+  [Integration with agmsg](#integration-with-agmsg)) and structurally wrong even where validation
+  does exist, because agmsg's own argument checks run *inside the remote shell process that only
+  exists because panemux's command string has already been parsed* — they cannot protect the
+  construction of that string. `send.sh` does its own SQL escaping internally, so shell-escaping is
+  the only layer panemux is responsible for on the write path — there is no panemux-owned SQL text
+  to also escape, unlike an earlier draft of this design that had panemux building its own SQL.
+- **Open implementation question: `shellQuotePath`-style escaping alone may not satisfy this
+  repository's own CodeQL bar for a message body.** `docs/security.md` is explicit that a quoting
+  or regex-submatch transform does not, by itself, break CodeQL's taint-tracking — the accepted
+  pattern (`cwd`) is a **regex allowlist** (`validRemotePath`) applied *before* `shellQuotePath`,
+  and the allowlist is what actually breaks the taint chain. A message body is arbitrary
+  agent-authored text; it cannot be regex-allowlisted the way a path can. Encoding the body to a
+  constrained alphabet before it ever reaches the command string (e.g. base64, then a regex check
+  that the *encoded* string is pure base64 — genuinely mirroring the `validRemotePath`-then-quote
+  shape, since a base64 alphabet cannot itself contain shell metacharacters) is the most promising
+  direction, but it requires the remote side to decode before handing the value to `send.sh` (which
+  does not accept pre-encoded input), which is its own small piece of remote shell composition to
+  get right. This document does not claim the question is resolved; implementation must either find
+  a construction that satisfies CodeQL structurally, or make a deliberate, documented, narrowly
+  scoped exception consistent with `docs/security.md`'s stated preference for structural fixes over
+  suppression — not assume plain `shellQuotePath` on a message body will pass review unremarked.
 - **panemux itself is never deployed to a remote host.** Beyond the injection-surface argument
   above, the `panemux` binary is also the server: a copy running on an SSH-reached host could start
   its own HTTP/WS listener, auth surface, and command center — a second, unmanaged instance of
@@ -650,6 +782,16 @@ that shaped the design.
   panemux↔host B), but panemux itself decrypts and re-serializes the row in between, so the
   panemux process/host must be trusted for the relay to be meaningful. There is no end-to-end
   encryption between two remote agents' Claude/Codex processes.
+- **Universal `--force` makes `from` forgeable across the whole team, including impersonating
+  `_panemux` itself, unless the relay actively checks it.** `send.sh --force` accepts any `from`
+  without checking it against a roster, and by design *every* board send uses `--force` (see
+  [Integration with agmsg](#integration-with-agmsg)) — so nothing at the agmsg layer stops an agent
+  on Host A from sending a message with `from: "_panemux"` to a pane on Host B, which
+  [Cross-host relay](#cross-host-relay) would otherwise happily forward as if the command center had
+  sent it. The relay's `from` check described there — drop and log any row whose `from` isn't a
+  known board-enabled pane ID on that row's source host, or the reserved `_panemux` identity when
+  the row is legitimately relay/command-center-originated rather than read from an agent's own
+  team — is what closes this, not anything agmsg itself enforces.
 - **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
   bearer token as everything else, and that gate is the entire authorization model for messaging
   any pane from the command center** — see [Command center](#command-center). There is deliberately
@@ -688,18 +830,31 @@ that shaped the design.
   own documented v1 limitation. Distinct from that: agmsg's `actas-claim.sh` lock only prevents two
   sessions from claiming the *same role name* at once (exit code 1 if already held) — it says
   nothing about, and does not provide, message claim/lease semantics for delivery.
-- Agents/teams are free-text identifiers with no cryptographic authentication of `from`. Any local
-  process that can reach a host's agmsg installation can forge a sender. This is an integrity gap
-  distinct from the transport-confidentiality concerns above and is accepted for the same reason
-  panemux already accepts same-user process trust elsewhere.
+- Agents/teams are free-text identifiers with no cryptographic authentication of `from`. The relay's
+  own `from` check (see [Cross-host relay](#cross-host-relay)) rejects a forged `from` that doesn't
+  match a known local pane ID or `_panemux`, but within that set there is still no proof a given
+  message actually came from the pane process it claims to — any local process that can reach a
+  host's agmsg installation and pick a real, currently-registered pane ID can forge a sender inside
+  that host. This is an integrity gap distinct from the transport-confidentiality concerns above and
+  is accepted for the same reason panemux already accepts same-user process trust elsewhere.
 - Relay delivery is at-least-once, bounded by the poll interval, not real-time or exactly-once; see
   [Cross-host relay](#cross-host-relay) for why a duplicate message after a panemux restart is an
-  accepted outcome rather than something engineered away.
-- Board features depend on an operator-installed third-party tool (agmsg) panemux does not manage
-  the lifecycle of. If that installation is upgraded to a version whose scripts behave
-  incompatibly, panemux's `AgmsgClient` can fail even though nothing in panemux's own config
-  changed. This is the accepted cost of not vendoring/pinning a copy of agmsg inside panemux
-  itself.
+  accepted outcome rather than something engineered away. Separately, and for a different reason
+  (`api.sh` has no forward/since read at all — see [Integration with
+  agmsg](#integration-with-agmsg)), delivery is also **not guaranteed-complete**: if more new rows
+  land on one host between two poll cycles than the poll's `--limit`, the oldest of that overflow
+  are silently missed rather than delivered late. This is accepted as a bound to keep the design
+  simple, not engineered around with unbounded polling or pagination.
+- **Board features' write path depends on an operator-installed third-party tool (agmsg) whose own
+  maintainer makes no compatibility promise for that path.** agmsg has real engineering discipline
+  behind it (a bats-core test suite, CI, multiple contributors) — this is not a concern about code
+  quality — but its README's stability promise explicitly covers reading through `scripts/api.sh`
+  only; `send.sh`'s argument order and behavior, which this design's entire write path depends on,
+  carries no such promise. If that script's behavior changes in a future agmsg release, panemux's
+  `AgmsgClient` can fail even though nothing in panemux's own config changed. This is a real,
+  accepted cost of not vendoring/pinning a copy of agmsg inside panemux itself, and is more exposure
+  than a read-only dependency on `api.sh` alone would have carried — worth weighing against the
+  cross-agent interoperability agmsg provides that a panemux-owned protocol never could.
 - Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
   called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
   following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops
@@ -717,29 +872,45 @@ that shaped the design.
 - `internal/board`: status JSON parsing (valid full payload, missing optional fields, a body that
   isn't the expected shape falls back to being treated as a plain message and is not mistaken for a
   status update), `BoardCache.StatusSnapshot` with multiple status rows for one pane (only the
-  newest wins) and across multiple panes, `BoardCache.MessagesSince` ordering and bounding, a row
-  addressed to `_panemux` never appearing in `MessagesSince`'s cross-pane relay path, an empty
-  cache read (fresh start / post-restart) returning a well-defined empty result rather than an
-  error, relay cursor persistence across a simulated restart (including the accepted at-least-once
-  duplicate case — assert it is delivered again, not that it's silently dropped or that the relay
-  errors), empty team.
+  newest wins, `UpdatedAt` reflects when it was recorded) and across multiple panes, `BoardCache`'s
+  own `Seq` assignment giving a stable total order across rows from different hosts even when their
+  agmsg-native `ID`s collide or aren't comparable, `MessagesSince(afterSeq)` ordering and bounding,
+  a row addressed to `_panemux` updating `status` and *not* appearing in `history`'s cross-pane
+  relay output (a plain non-status row addressed to `_panemux` correctly *does* appear, as an
+  ordinary message), an empty cache read (fresh start / post-restart) returning a well-defined empty
+  result rather than an error, relay cursor persistence across a simulated restart (including the
+  accepted at-least-once duplicate case — assert it is delivered again, not that it's silently
+  dropped or that the relay errors), the accepted truncation case (more new rows on one host than
+  one poll's `--limit` — assert the newest ones are kept and the oldest of the overflow are dropped,
+  not that everything is delivered), the relay's `from`-validation (a row whose `from` is not a
+  known local pane ID or `_panemux` is dropped and logged, never cached or relayed — this is the
+  regression test for the cross-host `_panemux` impersonation scenario in [Security
+  model](#security-model)), empty team.
 - `internal/session`: for `RemoteAgmsgClient`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
-  literal argument, not as executed shell syntax.
+  literal argument, not as executed shell syntax — and the same for a `team`/`--agent` value
+  containing metacharacters on the **read** path (`api.sh get ...`), which is the regression test
+  for the earlier, incorrect "reads are digit-validated so don't need escaping" claim; every
+  `AgmsgClient.Send` call is asserted to include `--force` unconditionally, with no code path that
+  omits it.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
   combinations are valid. `agent_board.team` defaults to `"panemux"` when unset.
 - `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
   handshake; correct token succeeds.
-- agmsg detection: a pane on a host where agmsg is absent skips bootstrap and logs a warning
-  without touching the pane's session (asserted against a fake/no-op `BoardExecutor`/host check,
-  not a real agmsg install); a pane on a host where agmsg is present bootstraps normally.
+- agmsg detection: a pane on a host where the configured/default agmsg path doesn't contain
+  `scripts/api.sh` skips bootstrap and logs a warning without touching the pane's session (asserted
+  against a fake/no-op `BoardExecutor`/host check, not a real agmsg install, and not via `command -v
+  agmsg` — see [Integration with agmsg](#integration-with-agmsg) for why that check is unreliable);
+  a pane on a host where agmsg is present bootstraps normally.
 - Command center: `/ws/board-command` rejects an unauthenticated connection the same way the
-  terminal WebSocket does; a `send.sh --force` call issued from the command center's subprocess
-  reaches a target pane regardless of that pane's host, using a fake `AgmsgClient` per host to
-  assert routing without a real agmsg/SSH dependency; `GET /api/board/command/history` returns a
-  correctly ordered feed built from a fixture `stream-json` capture containing interleaved user
-  turns, assistant text, and tool calls, and returns an empty/well-defined result before the
-  command center has ever been used.
+  terminal WebSocket does; a `POST /api/board/broadcast` call issued from the command center's own
+  HTTP client reaches a target pane regardless of that pane's host, using a fake `AgmsgClient` per
+  host to assert routing without a real agmsg/SSH dependency, and never invokes `AgmsgClient`
+  directly from the command center's own code path (it goes through the same handler a browser
+  request would); `GET /api/board/command/history` returns a correctly ordered feed built from a
+  fixture `stream-json` capture containing interleaved user turns, assistant text, and tool calls,
+  and returns an empty/well-defined result before the command center has ever been used; enabling
+  `command_center` does not require or check for a local agmsg installation.
 
 ## Related documents
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -3,8 +3,9 @@
 > **Status: design, not yet implemented.** This document specifies the target design for the
 > `internal/board` package and its supporting API, config, and security surface. Update this
 > status note (and cross-link it from [architecture.md](architecture.md), [security.md](security.md),
-> and [behavior.md](behavior.md) as appropriate) once a phase below actually ships; until then, no
-> other doc should describe `board` endpoints or config fields as current behavior.
+> [behavior.md](behavior.md), and [ui-design.md](ui-design.md) as appropriate) once a phase below
+> actually ships; until then, no other doc should describe `board` endpoints or config fields as
+> current behavior.
 
 ## Purpose
 
@@ -41,10 +42,14 @@ Agent Board replaces that inference with a small, self-reported channel:
 3. Aggregates all of the above into one dashboard and, for the command center, one continuous,
    reviewable conversation history.
 4. Is built entirely on [agmsg](https://github.com/fujibee/agmsg), an existing MIT-licensed
-   bash+sqlite3 agent-messaging tool that already supports Claude Code, Codex, Gemini CLI, GitHub
-   Copilot, Antigravity, OpenCode, and Hermes. panemux does not maintain a second, parallel
-   messaging protocol of its own — see [Design principles](#design-principles) for why, and
-   [Integration with agmsg](#integration-with-agmsg) for how.
+   bash+sqlite3 agent-messaging tool. As of this writing agmsg's own README lists Claude Code,
+   Codex, Gemini CLI, GitHub Copilot, Antigravity, OpenCode, and Hermes as supported agent types;
+   treat that as a snapshot of agmsg's documentation, not a list panemux enforces or keeps in sync
+   itself — implementation should re-check agmsg's current README rather than trust this document's
+   copy of it, since agmsg adding or renaming a supported agent type has no effect on panemux's own
+   code (panemux never branches on agent type; it only ever calls `api.sh`/`send.sh`/`join.sh`
+   generically). panemux does not maintain a second, parallel messaging protocol of its own — see
+   [Design principles](#design-principles) for why, and [Integration with agmsg](#integration-with-agmsg) for how.
 
 ## Design principles
 
@@ -69,10 +74,16 @@ Agent Board replaces that inference with a small, self-reported channel:
   offer, and every pane on `agmsg` from the start means no relay step is needed even for two panes
   that happen to both be Claude. Agent Board is therefore built entirely on agmsg; panemux owns no
   message schema of its own.
-- **No new daemon, no new listening port.** panemux talks to agmsg the same way any of its scripts
-  or a live agent session would: local `exec.Command` calls on the host panemux itself runs on,
-  and the existing SSH exec channel (`GetCWD`/`InspectGitContext` already use it) for every other
-  host. No new process listens for anything, locally or remotely.
+- **No new daemon, no new listening port — scoped to what panemux itself starts.** panemux talks to
+  agmsg the same way any of its scripts or a live agent session would: local `exec.Command` calls on
+  the host panemux itself runs on, and the existing SSH exec channel (`GetCWD`/`InspectGitContext`
+  already use it) for every other host. panemux itself starts no new process that listens for
+  anything, locally or remotely. This claim is specifically about processes *panemux* starts —
+  agmsg's own `SessionStart` hook already launches its own `Monitor`/`watch.sh` process per joined
+  pane independently of panemux (see [Integration with agmsg](#integration-with-agmsg)), exactly as
+  it would if an operator had set up agmsg by hand with no panemux involved at all. That process is
+  agmsg's, lives and dies by agmsg's own hook lifecycle, and is not a daemon this design introduces
+  or is responsible for.
 - **panemux itself is never installed on a remote host, under any circumstances.** The `panemux`
   binary is also a server: running it can start the HTTP/WS listener, the auth surface, and the
   command center. Placing a copy on every SSH-reached host that wants board features would mean
@@ -301,6 +312,35 @@ case but overridable), not a heuristic guess. If the configured/default path doe
 and leaves the pane's shell session itself untouched. panemux never runs `npx agmsg`, `npm i -g
 agmsg`, `git clone`, or any other installer on the operator's behalf, on any host.
 
+**`~` in `agmsg_path` is expanded by panemux, never left for the remote shell to expand.** A leading
+`~` in `agent_board.agmsg_path` is resolved to an absolute path before it is ever placed into a
+`RunBoardCommand` argument list — for the local host this is the ordinary `os.UserHomeDir()`-based
+expansion this repository already uses elsewhere (see `DEVELOPMENT.md`'s testability rule); for a
+remote host, panemux resolves the remote user's home directory once per SSH connection (a single
+`echo -n "$HOME"` probe over the existing exec channel, cached for the life of that connection) and
+substitutes it locally before building any command string. This is not optional: `shellQuotePath`
+single-quotes every argument specifically to *suppress* shell expansion of its contents (see
+[Security model](#security-model)), and tilde expansion only happens for an unquoted leading `~` —
+a literal `~` placed inside single quotes reaches the remote shell as the two-character string `~`,
+not the operator's home directory, silently breaking detection and every subsequent `api.sh`/
+`send.sh` call. `validRemotePath`'s own regex already only accepts paths starting with `/` for the
+same underlying reason (see [security.md](security.md)), so this expansion step is what lets an
+operator write the natural `~/...` form in config while still handing `RunBoardCommand` an
+already-absolute, already-safe-to-quote path.
+
+**Remote command execution assumes a working, if non-interactive, shell environment.** The SSH exec
+channel `RunBoardCommand` uses runs each command as a single non-login, typically non-interactive
+shell invocation — the same channel `GetCWD`/`InspectGitContext` already use — which on many systems
+does not source `~/.bashrc`, `~/.profile`, or equivalent interactive-only startup files. agmsg's own
+runtime dependencies (`bash`, `node`, `sqlite3`) must therefore already be reachable from that
+non-interactive shell's `PATH` for board detection and every subsequent command to succeed, even if
+an operator's *interactive* SSH session (where they installed agmsg by hand) has a `PATH` that
+differs — for example, a `node` made available only by an interactively-sourced version manager
+(`nvm`, `asdf`, etc.) is not guaranteed visible here. This mirrors an assumption panemux's existing
+SSH session handling already makes for the pane's own shell startup, and is not a new category of
+risk this design introduces — but it is worth stating explicitly since a working interactive SSH
+session is not sufficient evidence that board detection will also work on that host.
+
 **Version pinning.** agmsg's own compatibility promise (per its README) only covers reading through
 `scripts/api.sh`; there is no equivalent promise for `send.sh`'s argument order/behavior or for
 `messages.db`. Because this design's write path depends entirely on `send.sh`, panemux is taking on
@@ -331,6 +371,7 @@ itself, using its own `Bash` tool, and include it as a small JSON body:
 
 ```json
 {
+  "kind": "board_status",
   "state": "working",
   "cwd": "/home/user/project",
   "branch": "feature/x",
@@ -340,6 +381,17 @@ itself, using its own `Bash` tool, and include it as a small JSON body:
   "summary": "fixing failing tests"
 }
 ```
+
+**`kind: "board_status"` is a fixed, required discriminator, not an optional field.** Detecting a
+status report by *shape alone* — "does this JSON happen to have a `state` key" — has a real false-
+positive edge: a human typing an ordinary chat message to `_panemux` through the command center or
+Spotlight palette could, by coincidence or by pasting unrelated JSON, produce a body that parses as
+valid JSON and happens to contain a `state` field, and would then be silently swallowed into the
+status cache instead of showing up as a message. Requiring a literal `"kind": "board_status"` value
+removes the ambiguity: the relay treats a row as a status update only when `Body` parses as JSON
+*and* `kind` is exactly that string; every other body — including JSON that merely resembles the
+status shape — is left alone as an ordinary message, matching [Package
+layout](#package-layout)'s detection rule.
 
 `branch`/`repo`/`pr_url` come from the agent running `git branch --show-current`, `git remote get-
 url origin`, and a PR lookup (e.g. `gh pr view --json url -q .url`) itself — panemux never computes
@@ -414,6 +466,27 @@ type AgmsgClient interface {
     Since(ctx context.Context, team, afterID string, limit int) ([]Row, error)
 }
 
+// ownSendLedger is a short-lived, in-memory record of Send calls panemux itself has issued (the
+// broadcast handler and the command center — see Cross-host relay), used only to verify a row the
+// relay later observes with From == "_panemux" actually corresponds to one of panemux's own sends,
+// since send.sh --force never checks From against a roster and an ordinary board pane could
+// otherwise forge that identity. Entries expire after a few poll intervals; a body is stored only
+// as a hash, since the ledger's job is matching, not re-displaying content.
+type ownSendLedger struct {
+    mu      sync.Mutex
+    entries map[ownSendKey]time.Time // value is expiry
+}
+
+type ownSendKey struct {
+    DestHost string
+    Team     string
+    To       string
+    BodyHash string // e.g. sha256, truncated; not a security boundary by itself, only a dedup key
+}
+
+func (l *ownSendLedger) Record(destHost, team, to, body string)      { /* inserts with a short TTL */ }
+func (l *ownSendLedger) Consume(destHost, team, to, body string) bool { /* true+deletes if matched, false if expired/absent */ }
+
 // BoardCache is the in-memory, panemux-owned view of recent board activity shown in Architecture.
 // Only the relay writes to it, as a side effect of the same Since polling it already does for
 // message forwarding; both dashboard-facing endpoints only ever read it, never calling
@@ -440,11 +513,14 @@ func (c *BoardCache) StatusSnapshot() map[string]Status    { /* mutex-guarded co
 func (c *BoardCache) MessagesSince(afterSeq int64) []Row   { /* mutex-guarded copy, filtered by Seq */ }
 ```
 
-The relay inspects every `Row` it reads: if `To == "_panemux"` and `Body` parses as the JSON shape
-from [Status self-report](#status-self-report-and-message-flow), it calls `RecordStatus` and does
+The relay inspects every `Row` it reads: if `To == "_panemux"` and `Body` parses as JSON with
+`kind == "board_status"` (see [Status self-report](#status-self-report-and-message-flow) for why
+the discriminator, not shape-sniffing, is what triggers this), it calls `RecordStatus` and does
 *not* forward that row through the cross-host relay logic (status reports are local bookkeeping,
-not messages meant for another pane). A `Body` addressed to `_panemux` that isn't valid JSON in
-that shape is left alone as an ordinary chat message. Every row, status or not, is also appended to
+not messages meant for another pane). A `Body` addressed to `_panemux` that isn't valid JSON, or is
+valid JSON without that exact `kind`, is left alone as an ordinary chat message — including a body
+that happens to share some field names with the status shape by coincidence. Every row, status or
+not, is also appended to
 `history` via `AppendMessage`, which is what `GET /api/board/messages` reads from — that endpoint
 never calls `AgmsgClient` at request time either, for the same reason `GET /api/board/status`
 doesn't: the relay has already seen everything the dashboard needs, as a side effect of polling it
@@ -539,11 +615,22 @@ to reach each other). panemux is the only node with a connection to every host, 
    comparable across hosts — persisted in a small local JSON file (e.g.
    `~/.config/panemux/board-relay-cursor.json`) — not a database table, since panemux owns no
    database — so a panemux restart resumes roughly where it left off.
-3. For each new row, panemux first checks `from`: **if `from` is not a board-enabled pane ID
-   panemux knows about on that row's source host (or is itself `_panemux`), the row is dropped and
-   logged, never relayed and never cached.** This is a deliberate integrity check on the one field
-   `--force` makes otherwise unverifiable — see [Security model](#security-model) for the forgery
-   scenario it closes. If `from` passes that check: when `to == "_panemux"`, panemux updates the
+3. For each new row, panemux first checks `from`. If `from` is a board-enabled pane ID panemux
+   knows about on that row's source host, the row passes. **If `from == "_panemux"`, the row passes
+   only if it matches an entry in panemux's own short-lived "own-send ledger"** (see [Package
+   layout](#package-layout)) — a small in-memory record of `(destination host, team, to, body hash)`
+   for every `Send` panemux's own broadcast handler and command center have issued recently, kept
+   for a few poll intervals and then discarded. This is deliberately stricter than treating
+   `_panemux` as unconditionally trusted: because `send.sh --force` never checks `from` against a
+   roster, any agent on any host can locally write a row claiming `from: "_panemux"`, and nothing at
+   the agmsg layer distinguishes that from a row that reached the same host because panemux's own
+   broadcast handler really did call `Send` there — the ledger match is what tells them apart. A row
+   with `from == "_panemux"` that matches nothing in the ledger is a suspected forgery: it is dropped
+   and logged the same as any other failed check, never relayed and never cached. Any other `from` —
+   one that is neither a known local pane ID nor a ledger-matched `_panemux` — is dropped and logged
+   too. See [Security model](#security-model) for the forgery scenario this closes and why a
+   universal `_panemux` allowance (an earlier revision of this document's check) was not enough. If
+   `from` passes: when `to == "_panemux"`, panemux updates the
    [in-memory status cache](#architecture) instead of relaying it — status reports never leave the
    host they were written on. Otherwise, panemux resolves `to` to its owning pane and that pane's
    host via the already-known pane→session config; if that host differs from the source host,
@@ -554,6 +641,21 @@ to reach each other). panemux is the only node with a connection to every host, 
    team.
 5. `GET /api/board/status` never triggers an `AgmsgClient` call at all — it only reads the status
    cache the relay already keeps current, per [Architecture](#architecture).
+
+**Cold-start backfill.** `BoardCache` starts empty on every panemux process start (see [Known
+limitations](#known-limitations)), and the regular poll loop's small `--limit` (tuned for "a few
+seconds' worth of new rows," per [Package layout](#package-layout)) is the wrong size for
+repopulating a cold cache — most panes' latest status could easily be older than that small a
+window. Before entering its steady-state poll loop, the relay therefore performs exactly one
+larger-`--limit` call per (host, team) — e.g. `--limit 1000` versus the steady-state default — scans
+those rows the same way the steady-state loop would (status rows update the cache, per-pane keeping
+only the newest; ordinary messages are appended to `history`), and only then starts polling normally
+from whatever cursor position that backfill pass reached. This does not change any of the
+correctness properties above: it is still a bounded `--limit` read with the same accepted truncation
+risk if a host has produced more than the backfill limit's worth of rows since the cursor file was
+last written, and it does not retroactively fix a restart that lost the cursor file entirely (that
+case still starts from the newest rows only, same as today). It shortens, but does not eliminate,
+the window in which the dashboard shows stale or empty status after a panemux restart.
 
 **Delivery is at-least-once, not exactly-once — an accepted simplification, not an oversight.**
 Because agmsg's own schema has no field for panemux to mark "this row has already been relayed,"
@@ -597,9 +699,25 @@ always routed through it by construction.
    panemux provisions per pane. This step only ever establishes *that pane's* participation; it
    never touches any other pane or any other agent already using agmsg on that host (a pre-existing
    Codex agent, for example, keeps working exactly as it did before panemux was involved).
-4. If `mode` is `turn` or `both` (mirroring agmsg's own `/agmsg mode monitor|turn|both`, default
+4. If `mode` is `turn` or `both` (mirroring agmsg's own `/agmsg mode monitor|turn|both|off`, default
    `monitor`), the bootstrap instruction also tells the agent to run `/agmsg mode <value>` — this
-   is agmsg's own setting, not something panemux tracks or enforces separately.
+   is agmsg's own setting, not something panemux tracks or enforces separately. agmsg's own docs
+   mark `turn` as a legacy mode kept for backward compatibility rather than the recommended one;
+   this document does not steer operators toward it, and `mode: turn` in panemux's config is a
+   pass-through of an operator's explicit choice, not a default panemux picks. `off` is agmsg's own
+   way to disable its hook-driven delivery for a pane without leaving the team — panemux's config
+   equivalent is `agent_board.enabled: false`, which is the preferred way to keep a pane out of
+   board features entirely, since it skips bootstrap for that pane rather than bootstrapping it and
+   then telling it to turn itself back off. **This step has a real repo-local side effect worth
+   stating plainly: `/agmsg mode` writes hook wiring into the pane's own project
+   `.claude/settings.local.json`, a file that outlives the pane session and is scoped to that Git
+   repository, not to panemux or to this one pane.** "Additive, never load-bearing" (see [Design
+   principles](#design-principles)) describes what happens when board features are *unavailable* —
+   the pane's shell keeps working normally — not a claim that bootstrap makes zero changes outside
+   panemux's own state. Because this write is agmsg's own onboarding behavior, not something panemux
+   scripts itself, panemux does not attempt to undo it if a pane later disables
+   `agent_board.enabled`; an operator who wants that hook wiring removed does so the same way they
+   would for any other agmsg-managed repo, outside panemux entirely.
 
 ## Command center
 
@@ -614,7 +732,10 @@ always routed through it by construction.
 - **It reads and writes the board through panemux's own authenticated REST API — `GET
   /api/board/status`, `GET /api/board/messages`, `POST /api/board/broadcast` — the same endpoints
   the browser dashboard uses, over loopback, with a token panemux injects into the subprocess's
-  environment.** This is a correction from an earlier revision of this document, which had the
+  environment.** The LLM itself never composes the HTTP call: panemux points the subprocess at a
+  narrow MCP server it provides (see [Process lifecycle](#process-lifecycle)) that exposes exactly
+  those three operations as tools and makes the actual authenticated request on the model's behalf.
+  This is a correction from an earlier revision of this document, which had the
   command center shell out to `send.sh`/`api.sh` directly. That was wrong on two counts: it made
   the LLM itself responsible for composing safely-escaped shell invocations, a second, unaudited
   path to the same exec sink alongside `AgmsgClient`'s own (see [Security
@@ -631,6 +752,39 @@ always routed through it by construction.
   identity, `_panemux` — the exact same code path a human-triggered broadcast takes, which already
   resolves the destination pane's host and calls that host's `AgmsgClient.Send` (always `--force`)
   without the command center needing any host-routing logic of its own.
+
+### Process lifecycle
+
+- **First run.** No persisted command-center session id exists yet the first time a query arrives.
+  panemux invokes `claude -p --output-format=stream-json --verbose "<prompt>"` — note `--verbose` is
+  required alongside `-p --output-format=stream-json`; the CLI refuses to stream structured output
+  in print mode without it — omitting `--resume` entirely, captures the `session_id` the stream-json
+  output reports for that first exchange, and persists it to a small local file (e.g.
+  `~/.config/panemux/command-center-session.json`, the same kind of local bookkeeping file as the
+  relay cursor in [Cross-host relay](#cross-host-relay)). Every later query reuses that id:
+  `claude -p --resume <id> --output-format=stream-json --verbose "<prompt>"`.
+- **Permissions.** The subprocess never receives `--dangerously-skip-permissions`. It has no PTY to
+  surface an interactive approval prompt through, and this design does not substitute a blanket
+  bypass for that missing prompt. Instead panemux runs a narrow, purpose-built MCP server exposing
+  exactly three tools — `board_status`, `board_messages`, `board_broadcast`, thin wrappers around the
+  three REST endpoints in [API additions](#api-additions) — and launches the command center with
+  `--allowedTools` scoped to only those three, no `Bash`, no filesystem tools, and no other MCP
+  servers an interactive Claude Code session might otherwise have configured. This is also why the
+  command center goes through an MCP server rather than a `Bash`+`curl` tool call: an MCP tool can be
+  individually allow-listed ahead of time, while a generic `Bash` grant cannot be scoped down to "only
+  run curl against this one loopback endpoint" — granting `Bash` at all would hand the command center
+  everything `Bash` can do, which is exactly the blanket-bypass outcome this design avoids.
+- **Concurrency.** At most one query may be in flight against the command center's session id at a
+  time. A `WS /ws/board-command` request that arrives while one is already running is rejected
+  immediately with an explicit "command center busy" error rather than queued — two concurrent
+  `claude -p --resume <same-id>` invocations against one session id have no ordering guarantee from
+  the CLI itself, and building a queue would add state-machine complexity this design deliberately
+  avoids for a feature kept to [one session per instance](#scope-kept-intentionally-narrow-for-now).
+- **Failure modes.** A subprocess that exits non-zero, emits malformed `stream-json`, or times out
+  surfaces as an explicit error frame on the WS connection — never a silently empty response, so the
+  frontend can distinguish "no output yet" from "the query failed." A failed query never corrupts
+  `--resume` continuity for the next one: the persisted session id is replaced only by a fresh
+  first-run capture, never derived from a failed query's absent or partial output.
 
 ### Authorization
 
@@ -669,6 +823,10 @@ flow still applies.
   workspace-summary overlay) exposes the same history outside the quick-palette flow, for scrolling
   back further than what the palette shows inline.
 
+See [ui-design.md's Agent Board UI section](ui-design.md#agent-board-ui-planned) for how these
+surfaces are meant to reuse this repository's existing dialog/overlay patterns and status vocabulary
+instead of introducing a parallel visual language.
+
 ### Scope, kept intentionally narrow for now
 
 Exactly one command center session per panemux instance — not per-workspace, not multiple
@@ -687,7 +845,7 @@ unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it s
 |---|---|
 | `GET /api/board/status` | A snapshot of panemux's in-memory status cache — no `AgmsgClient` call happens on this request (see [Architecture](#architecture)) |
 | `GET /api/board/messages?since=<seq>` | History feed for the dashboard UI. `<seq>` is `BoardCache`'s own panemux-local sequence number (see [Package layout](#package-layout)), not an agmsg-native `id` — those aren't comparable across hosts |
-| `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn) |
+| `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn); delivery to the pane is immediate, but the message appears in `GET /api/board/messages`' history only after the relay's next poll cycle reads it back — see [Known limitations](#known-limitations) |
 | `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
 | `GET /api/board/command/history` | Command center's own captured conversation history — see [Command center](#command-center) |
 
@@ -711,7 +869,7 @@ panes:
     type: local
     agent_board:
       enabled: true
-      mode: monitor    # monitor (default) | turn | both, mirrors agmsg's own /agmsg mode
+      mode: monitor    # monitor (default) | turn (legacy) | both | off, mirrors agmsg's own /agmsg mode
 
   - id: pane-b          # e.g. a Codex pane
     type: ssh
@@ -723,6 +881,25 @@ panes:
 A global `agent_board.enabled` default may also be supported so individual panes don't need to
 repeat it, but board features on any given host still require agmsg to already be present there —
 panemux will not install it, per [Integration with agmsg](#integration-with-agmsg).
+
+**Why `command_center` is a top-level key, not nested under `agent_board`, despite both belonging to
+the same Agent Board feature.** Nesting it would imply command_center depends on agent_board/agmsg
+being configured too, which is false by design: the command center never calls agmsg directly (see
+[Command center](#command-center)) and works with every pane's `agent_board.enabled` left `false`.
+The two keys are siblings in this config because their actual dependency graph is siblings — not
+because they're unrelated features that happen to share a document.
+
+**`_panemux` is reserved and validated where panemux can actually enforce it.** `internal/config/
+validate.go` rejects any pane config whose `id` is literally `_panemux`, the same way it already
+rejects duplicate pane IDs (see [architecture.md](architecture.md)) — panemux will not let itself be
+configured into a collision with its own reserved sentinel. This is a real but partial guarantee:
+nothing stops an operator or a live agent from running agmsg's own `join.sh <team> _panemux ...`
+by hand, outside any pane panemux bootstrapped, since agmsg's roster is agmsg's own state and
+`join.sh` is not gated by panemux at all. That gap is exactly why the [own-send
+ledger](#package-layout) check in [Cross-host relay](#cross-host-relay) does not trust the
+`_panemux` string by itself even after this validation — config-time reservation closes the
+"panemux accidentally misconfigures itself" case, not the "an agmsg team member deliberately
+registers the reserved name" case, which only the ledger check closes.
 
 ## Security model
 
@@ -790,10 +967,14 @@ that shaped the design.
   [Integration with agmsg](#integration-with-agmsg)) — so nothing at the agmsg layer stops an agent
   on Host A from sending a message with `from: "_panemux"` to a pane on Host B, which
   [Cross-host relay](#cross-host-relay) would otherwise happily forward as if the command center had
-  sent it. The relay's `from` check described there — drop and log any row whose `from` isn't a
-  known board-enabled pane ID on that row's source host, or the reserved `_panemux` identity when
-  the row is legitimately relay/command-center-originated rather than read from an agent's own
-  team — is what closes this, not anything agmsg itself enforces.
+  sent it. Unconditionally trusting any row with `from == "_panemux"` would not close this — that
+  string carries no more authority than any other free-text `from` value once `--force` is
+  universal, so treating it as automatically legitimate is exactly the gap being described, not a
+  fix for it. The actual check the relay performs — matching the row against panemux's own
+  short-lived **own-send ledger** of `Send` calls it issued itself (see [Cross-host
+  relay](#cross-host-relay) and [Package layout](#package-layout)) — is what closes this: a
+  `_panemux`-attributed row is only accepted if it corresponds to a send panemux's own broadcast
+  handler or command center actually made, never on the strength of the string alone.
 - **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
   bearer token as everything else, and that gate is the entire authorization model for messaging
   any pane from the command center** — see [Command center](#command-center). There is deliberately
@@ -816,17 +997,27 @@ that shaped the design.
   turn — reading and summing it is a much shallower, lower-risk read than the branch/PR/worktree
   heuristics this redesign moved away from (those depended on deep, undocumented precedence rules
   across `session_meta.cwd`, `turn_context.cwd`, and subagent transcript files, which is what
-  actually proved unstable in practice). This is not Agent Board's own responsibility to build,
-  though: it fits naturally as an extension of panemux's existing, pre-board per-pane transcript
-  inspection (already used for worktree/PR detection — see [architecture.md](architecture.md) and
-  [behavior.md](behavior.md)), summing a stable field rather than parsing fragile ones, not as
-  something carried through the agmsg self-report this document specifies. A future change to that
-  existing mechanism, not to `internal/board`, is the right place for it.
+  actually proved unstable in practice). **This looks like it contradicts [Design
+  principles](#design-principles)'s "ask the agent, don't reverse-engineer its internal state" rule
+  — it isn't, and the distinction matters.** That rule targets *inference*: guessing a fact (which
+  directory the agent is really in) from a schema panemux does not control and that has already
+  drifted once. Reading `usage` is not inference — it is summing a documented, versioned field of
+  the Messages API response envelope itself, the same envelope Claude Code's own transcript already
+  stores verbatim per turn. There is no guessing step, no precedence chain across several
+  loosely-related fields, and no plausible "wrong directory" analogue: a turn's `usage` object either
+  is present with the numbers the API returned, or it isn't. This is not Agent Board's own
+  responsibility to build, though: it fits naturally as an extension of panemux's existing, pre-board
+  per-pane transcript inspection (already used for worktree/PR detection — see
+  [architecture.md](architecture.md) and [behavior.md](behavior.md)), summing a stable field rather
+  than parsing fragile ones, not as something carried through the agmsg self-report this document
+  specifies. A future change to that existing mechanism, not to `internal/board`, is the right place
+  for it.
 - The status/history cache is in-memory only, not persisted to disk. A panemux restart starts it
-  empty; `GET /api/board/status`/`/messages` show nothing until the relay's next poll cycle (which
-  resumes from the persisted cursor, so it still only sees genuinely new rows, not the pane's full
-  history) repopulates it. This is the same accepted eventual-consistency tradeoff already made for
-  the relay cursor itself.
+  empty; the relay's [cold-start backfill](#cross-host-relay) pass shortens the gap before
+  `GET /api/board/status`/`/messages` show current data again, but it is still a bounded `--limit`
+  read, not a full replay — a host that produced more rows than the backfill limit since the cursor
+  was last persisted still shows a gap. This is the same accepted eventual-consistency tradeoff
+  already made for the relay cursor itself.
 - No claim/lease semantics: if two workers were both addressed by the same message (not a supported
   case today, since `to` targets one pane), there is no exclusion mechanism. This mirrors agmsg's
   own documented v1 limitation. Distinct from that: agmsg's `actas-claim.sh` lock only prevents two
@@ -839,6 +1030,16 @@ that shaped the design.
   host's agmsg installation and pick a real, currently-registered pane ID can forge a sender inside
   that host. This is an integrity gap distinct from the transport-confidentiality concerns above and
   is accepted for the same reason panemux already accepts same-user process trust elsewhere.
+- **A broadcast's delivery and its appearance in dashboard history are decoupled.**
+  `POST /api/board/broadcast` calls `AgmsgClient.Send` directly, so the destination pane receives it
+  immediately through agmsg's own hook delivery — but `BoardCache.AppendMessage` is only ever called
+  from the relay's own poll loop, not from the broadcast handler itself, so the dashboard's history
+  view of that same message lags by up to one poll interval, same as any other row. This is a
+  deliberate choice to keep `BoardCache` populated from exactly one code path (the relay) rather than
+  give the broadcast handler a second, racing write path into the same cache that would need its own
+  reconciliation against the row the relay later reads back for the same send. The [own-send
+  ledger](#package-layout) used for `_panemux` forgery detection intentionally is not repurposed to
+  paper over this lag: it exists for that one security check, not as a second history source.
 - Relay delivery is at-least-once, bounded by the poll interval, not real-time or exactly-once; see
   [Cross-host relay](#cross-host-relay) for why a duplicate message after a panemux restart is an
   accepted outcome rather than something engineered away. Separately, and for a different reason
@@ -859,6 +1060,10 @@ that shaped the design.
   cross-agent interoperability agmsg provides that a panemux-owned protocol never could. See [agmsg
   compatibility contract](#agmsg-compatibility-contract) for how this exposure is meant to be
   caught mechanically rather than discovered by a user.
+- Bootstrap is not free of side effects outside panemux's own state: `/agmsg mode turn|both` (see
+  [Bootstrap flow](#bootstrap-flow)) writes hook wiring into the pane's project
+  `.claude/settings.local.json`, which persists in that Git repository after the pane closes and is
+  never reverted by panemux, including when a pane later disables `agent_board.enabled`.
 - Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
   called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
   following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops
@@ -921,9 +1126,12 @@ documented behavior changed.
 
 ## Testing plan (see DEVELOPMENT.md for the TDD/coverage rules this must follow)
 
-- `internal/board`: status JSON parsing (valid full payload, missing optional fields, a body that
-  isn't the expected shape falls back to being treated as a plain message and is not mistaken for a
-  status update), `BoardCache.StatusSnapshot` with multiple status rows for one pane (only the
+- `internal/board`: status JSON parsing (valid full payload with `kind: "board_status"`, missing
+  optional fields, a body that isn't valid JSON falls back to being treated as a plain message, and
+  — the regression test for the shape-sniffing ambiguity this document used to have — a body that
+  *is* valid JSON, contains a `state` field, but is missing or has the wrong `kind` is also treated
+  as a plain message rather than mistaken for a status update), `BoardCache.StatusSnapshot` with
+  multiple status rows for one pane (only the
   newest wins, `UpdatedAt` reflects when it was recorded) and across multiple panes, `BoardCache`'s
   own `Seq` assignment giving a stable total order across rows from different hosts even when their
   agmsg-native `ID`s collide or aren't comparable, `MessagesSince(afterSeq)` ordering and bounding,
@@ -934,10 +1142,15 @@ documented behavior changed.
   accepted at-least-once duplicate case — assert it is delivered again, not that it's silently
   dropped or that the relay errors), the accepted truncation case (more new rows on one host than
   one poll's `--limit` — assert the newest ones are kept and the oldest of the overflow are dropped,
-  not that everything is delivered), the relay's `from`-validation (a row whose `from` is not a
-  known local pane ID or `_panemux` is dropped and logged, never cached or relayed — this is the
-  regression test for the cross-host `_panemux` impersonation scenario in [Security
-  model](#security-model)), empty team.
+  not that everything is delivered), the relay's `from`-validation (a row whose `from` is neither a
+  known local pane ID on its source host nor a ledger-matched `_panemux` is dropped and logged, never
+  cached or relayed), the own-send ledger specifically (a `from == "_panemux"` row that matches a
+  recently recorded `Send` is accepted; a `from == "_panemux"` row with no matching ledger entry —
+  including one crafted with a `to`/`body` that doesn't match any real recent send — is dropped and
+  logged, never treated as legitimate on the strength of the string alone; an entry past its TTL is
+  no longer matchable — this is the regression test for the cross-host `_panemux` impersonation
+  scenario in [Security model](#security-model), and for why an earlier revision's blanket
+  `_panemux` allowance was insufficient), empty team.
 - `internal/session`: for `RemoteAgmsgClient`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
   literal argument, not as executed shell syntax — and the same for a `team`/`--agent` value
@@ -946,14 +1159,40 @@ documented behavior changed.
   `AgmsgClient.Send` call is asserted to include `--force` unconditionally, with no code path that
   omits it.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
-  combinations are valid. `agent_board.team` defaults to `"panemux"` when unset.
+  combinations are valid. `agent_board.team` defaults to `"panemux"` when unset. A pane config with
+  `id: "_panemux"` is a validation error, both alone and alongside otherwise-valid other panes.
 - `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
   handshake; correct token succeeds.
+- `internal/ws`: `/ws/board-command` is new surface under the same package as the existing terminal
+  WebSocket handler, so it is covered by `coverage-go`'s existing `internal/ws` gate (see
+  `DEVELOPMENT.md`) — no separate coverage carve-out is introduced for it. Its handshake rejection
+  and message-framing tests follow the same pattern as the terminal socket's existing tests.
+- Frontend (schema-first, per `DEVELOPMENT.md`): `frontend/src/schemas/index.ts` gets Zod schemas
+  for every board API shape before any component consumes it — `BoardStatus`, `BoardMessage` (the
+  `GET /api/board/messages` row shape), and the `board-command` WS frame shapes (prompt, streamed
+  assistant text/tool-use chunks, error frame) — with acceptance tests for a valid payload and
+  rejection tests for a payload missing a required field or carrying an unexpected type, matching
+  the existing coverage pattern for other API schemas. The Spotlight-style command palette and the
+  separate history panel (see [Command center](#command-center)) each need component tests covering:
+  opening the palette renders inline history from a fixture history response; a streamed response
+  updates the visible output incrementally as WS frames arrive; an error frame renders a visible
+  error state rather than leaving the palette silently stuck; the history panel's empty state before
+  the command center has ever been used; and dismiss/close behavior returning focus to the
+  previously focused pane. These fall under `coverage-frontend`'s existing `frontend/src/hooks/` and
+  `frontend/src/schemas/` gates for the schema and any new hook, plus ordinary component tests for
+  the palette/history UI itself, matching the existing project convention rather than introducing a
+  new coverage carve-out.
 - agmsg detection: a pane on a host where the configured/default agmsg path doesn't contain
   `scripts/api.sh` skips bootstrap and logs a warning without touching the pane's session (asserted
   against a fake/no-op `BoardExecutor`/host check, not a real agmsg install, and not via `command -v
   agmsg` — see [Integration with agmsg](#integration-with-agmsg) for why that check is unreliable);
   a pane on a host where agmsg is present bootstraps normally.
+- `agmsg_path` expansion: a config value with a leading `~` resolves to a fully expanded absolute
+  path for a local host (via the injectable home-dir override, per `DEVELOPMENT.md`'s testability
+  rule) and for a remote host (via a fake exec channel returning a fixed `$HOME` probe response)
+  before it reaches any `RunBoardCommand` call, asserted by inspecting the built argument list
+  directly rather than the final shell string — this is the regression test for a literal `~`
+  reaching the remote shell inside single quotes and failing to expand.
 - Command center: `/ws/board-command` rejects an unauthenticated connection the same way the
   terminal WebSocket does; a `POST /api/board/broadcast` call issued from the command center's own
   HTTP client reaches a target pane regardless of that pane's host, using a fake `AgmsgClient` per
@@ -963,10 +1202,20 @@ documented behavior changed.
   fixture `stream-json` capture containing interleaved user turns, assistant text, and tool calls,
   and returns an empty/well-defined result before the command center has ever been used; enabling
   `command_center` does not require or check for a local agmsg installation.
+- Command center [process lifecycle](#process-lifecycle): a first query with no persisted session id
+  invokes the subprocess without `--resume` and persists the `session_id` captured from a fixture
+  stream-json response; a subsequent query reuses that persisted id with `--resume`; a second query
+  arriving while one is still in flight is rejected with the "busy" error and never spawns a second
+  subprocess; the invoked command line always includes `--verbose` whenever `--output-format=stream-
+  json` is present; the subprocess is always launched with `--allowedTools` scoped to exactly the
+  three board MCP tools and never with `--dangerously-skip-permissions`; a non-zero subprocess exit
+  and a malformed `stream-json` line each surface as a distinct WS error frame rather than an empty
+  or hung response, and neither overwrites the previously persisted session id.
 
 ## Related documents
 
 - Implementation structure: [architecture.md](architecture.md)
 - Security requirements for implementation: [security.md](security.md)
 - Runtime behavior and API specification: [behavior.md](behavior.md)
+- UI intent for the dashboard, palette, and history panel: [ui-design.md](ui-design.md#agent-board-ui-planned)
 - Developer workflow rules: [../DEVELOPMENT.md](../DEVELOPMENT.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,9 +72,18 @@ calls rather than inferred by panemux) and exchange messages through an operator
 hosts. panemux owns no message schema or storage of its own — it is only ever a client of agmsg's
 own documented scripts (`scripts/api.sh`, `scripts/send.sh`), never a reader of its internal
 SQLite file. Two new optional session capability interfaces, `BoardHostID` and `BoardExecutor`,
-extend the same pattern as `CWDGetter`/`ActiveWorkdirGetter` above. Full design and rationale live
-in [agent-board.md](agent-board.md); do not treat that document's API/config surface as implemented
-until its status note says so.
+extend the same pattern as `CWDGetter`/`ActiveWorkdirGetter` above.
+
+The same design also specifies a **command center**: a single headless `claude -p --resume`
+subprocess, invoked per query, that reads and writes the board exclusively through panemux's own
+authenticated REST API (never agmsg directly) via a narrow, purpose-built MCP server panemux
+provides — so `internal/board` stays the only code that ever calls agmsg's scripts even though the
+command center is a second, independent consumer of the board's data. This is a substantial part of
+the design's own scope (its own process lifecycle, permission model, and streaming API), not a minor
+addendum to the messaging/relay piece described above.
+
+Full design and rationale for both pieces live in [agent-board.md](agent-board.md); do not treat
+that document's API/config surface as implemented until its status note says so.
 
 ### `internal/api`
 
@@ -322,3 +331,4 @@ Architecture-level security summary:
 - All workspace panes are started at backend startup, including panes in inactive workspaces. This keeps tab switching fast and preserves terminal state, at the cost of using resources for hidden workspaces.
 - Dynamic session creation exists, but current UI behavior mainly creates new local panes; this is not yet a full remote session orchestration product.
 - The planned `internal/board` cross-host relay (see [agent-board.md](agent-board.md)) makes panemux a persistent relay for agent-to-agent messages between hosts it cannot make talk to each other directly, closer to a TURN server than a STUN server: panemux stays in the data path for the life of the exchange rather than helping two hosts connect directly and stepping aside, and it sees each relayed message as plaintext in process memory between the two encrypted SSH hops.
+- The same planned design's command center spawns a `claude -p` subprocess per query rather than keeping one warm — simpler process lifecycle and no persistent extra process, at the cost of response latency that includes subprocess startup on every query (see [agent-board.md's Process lifecycle](agent-board.md#process-lifecycle)).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,11 +66,14 @@ Optional capability interfaces extend the base `Session` contract without breaki
 ### `internal/board` (design, not yet implemented)
 
 A planned package that replaces transcript-based Claude activity inference with a self-reported
-channel: a per-host SQLite file that panemux and the Claude process running in that host's panes
-both read/write directly, plus a relay for messages addressed across hosts. Two new optional
-session capability interfaces, `BoardHostID` and `BoardExecutor`, extend the same pattern as
-`CWDGetter`/`ActiveWorkdirGetter` above. Full design, schema, and rationale live in
-[agent-board.md](agent-board.md); do not treat that document's API/config surface as implemented
+channel: panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh`
+calls rather than inferred by panemux) and exchange messages through an operator-installed
+[agmsg](https://github.com/fujibee/agmsg) instance, plus a relay for messages addressed across
+hosts. panemux owns no message schema or storage of its own — it is only ever a client of agmsg's
+own documented scripts (`scripts/api.sh`, `scripts/send.sh`), never a reader of its internal
+SQLite file. Two new optional session capability interfaces, `BoardHostID` and `BoardExecutor`,
+extend the same pattern as `CWDGetter`/`ActiveWorkdirGetter` above. Full design and rationale live
+in [agent-board.md](agent-board.md); do not treat that document's API/config surface as implemented
 until its status note says so.
 
 ### `internal/api`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,6 +63,16 @@ Optional capability interfaces extend the base `Session` contract without breaki
 - `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
 
+### `internal/board` (design, not yet implemented)
+
+A planned package that replaces transcript-based Claude activity inference with a self-reported
+channel: a per-host SQLite file that panemux and the Claude process running in that host's panes
+both read/write directly, plus a relay for messages addressed across hosts. Two new optional
+session capability interfaces, `BoardHostID` and `BoardExecutor`, extend the same pattern as
+`CWDGetter`/`ActiveWorkdirGetter` above. Full design, schema, and rationale live in
+[agent-board.md](agent-board.md); do not treat that document's API/config surface as implemented
+until its status note says so.
+
 ### `internal/api`
 
 REST endpoints expose workspaces, layout compatibility, display settings, session lifecycle operations, and editor integrations.
@@ -300,6 +310,7 @@ Architecture-level security summary:
 - remote shell entrypoints validate SSH working directories before interpolating them into shell commands
 - host-key handling intentionally preserves compatibility with OpenSSH hashed `known_hosts` entries
 - shipped code should structurally avoid `gosec` findings rather than suppress them
+- panemux does not terminate TLS; non-loopback exposure is expected to sit behind operator-managed infrastructure (reverse proxy, tunnel, VPN), and the planned `internal/board` auth token is only meaningful once that transport is encrypted — see [agent-board.md](agent-board.md#security-model)
 
 ## Tradeoffs and Intentional Limits
 
@@ -307,3 +318,4 @@ Architecture-level security summary:
 - Open CORS and permissive WebSocket origin checks reduce friction for local use, but are not suitable as-is for an untrusted deployment.
 - All workspace panes are started at backend startup, including panes in inactive workspaces. This keeps tab switching fast and preserves terminal state, at the cost of using resources for hidden workspaces.
 - Dynamic session creation exists, but current UI behavior mainly creates new local panes; this is not yet a full remote session orchestration product.
+- The planned `internal/board` cross-host relay (see [agent-board.md](agent-board.md)) makes panemux a persistent relay for agent-to-agent messages between hosts it cannot make talk to each other directly, closer to a TURN server than a STUN server: panemux stays in the data path for the life of the exchange rather than helping two hosts connect directly and stepping aside, and it sees each relayed message as plaintext in process memory between the two encrypted SSH hops.

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,16 +43,28 @@ After validation, the path is wrapped with `shellQuotePath`, which single-quotes
 The planned `internal/board` package (full design in [agent-board.md](agent-board.md)) writes
 cross-pane agent messages into a remote host's message store over the SSH exec channel already used
 by `GetCWD`/`InspectGitContext`. Two backends are planned, `native` (panemux's own SQLite file) and
-`agmsg` (delegating to an operator-installed [agmsg](https://github.com/fujibee/agmsg) instance via
-its `scripts/api.sh`); the same rule applies to both. Message bodies are arbitrary text written by a
-Claude (or other agent) process, not a trusted value, so the same discipline as `cwd` above applies:
-`RunBoardCommand` must send the body over the remote command's **stdin** as a JSON payload to a
-fixed argv (`panemux board recv` for `native`, agmsg's own script entry point for `agmsg`), and must
-never build a shell command string that interpolates the body. These are the only board-related
-commands panemux itself ever executes remotely; each performs a parameterized write against that
-backend's own local store on that host. panemux only ever detects an existing agmsg installation —
-it never installs, updates, or otherwise manages agmsg on the operator's behalf, locally or
-remotely.
+`agmsg` (delegating to an operator-installed [agmsg](https://github.com/fujibee/agmsg) instance).
+Message bodies are arbitrary text written by a Claude (or other agent) process, not a trusted value,
+so both backends must ensure no unescaped body content reaches a remote shell — but they satisfy
+that requirement by different means, verified against each tool's actual argument contract rather
+than assumed to match:
+
+- `native`: `RunBoardCommand` sends the body over the remote command's **stdin** as a JSON payload
+  to the fixed argv `panemux board recv`, the same discipline as `cwd` above. The body never
+  appears in the command string at all.
+- `agmsg`: reads go through `scripts/api.sh`, which only takes digit- or
+  path-traversal-validated arguments. Writes go through `scripts/api.sh`'s sibling script,
+  `scripts/send.sh <team> <from> <to> <body> [--force]`, which — per agmsg's own source — takes
+  `body` as a positional argument with **no stdin option**. For this script only, `RunBoardCommand`
+  must single-quote-escape every argument (`shellQuotePath`-style, matching the existing `cwd`
+  discipline) before building the remote command string, since keeping the body out of the command
+  string entirely is not possible here. This is a documented exception driven by `send.sh`'s own
+  contract, not a relaxation of the "no unescaped user content in a remote shell" requirement.
+
+These are the only board-related commands panemux itself ever executes remotely; each performs a
+write against that backend's own local store on that host. panemux only ever detects an existing
+agmsg installation — it never installs, updates, or otherwise manages agmsg on the operator's
+behalf, locally or remotely.
 
 ### Auth token and transport encryption (design, not yet implemented)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,13 +41,18 @@ After validation, the path is wrapped with `shellQuotePath`, which single-quotes
 ### Agent board remote writes (design, not yet implemented)
 
 The planned `internal/board` package (full design in [agent-board.md](agent-board.md)) writes
-cross-pane agent messages into a remote host's SQLite file over the SSH exec channel already used
-by `GetCWD`/`InspectGitContext`. Message bodies are arbitrary text written by a Claude process, not
-a trusted value, so the same discipline as `cwd` above applies: `RunBoardCommand` must send the
-body over the remote command's **stdin** as a JSON payload to the fixed argv `panemux board recv`,
-and must never build a shell command string that interpolates the body. `panemux board recv` is the
-only board subcommand panemux itself executes remotely; it performs a parameterized SQL insert
-against the local SQLite file on that host.
+cross-pane agent messages into a remote host's message store over the SSH exec channel already used
+by `GetCWD`/`InspectGitContext`. Two backends are planned, `native` (panemux's own SQLite file) and
+`agmsg` (delegating to an operator-installed [agmsg](https://github.com/fujibee/agmsg) instance via
+its `scripts/api.sh`); the same rule applies to both. Message bodies are arbitrary text written by a
+Claude (or other agent) process, not a trusted value, so the same discipline as `cwd` above applies:
+`RunBoardCommand` must send the body over the remote command's **stdin** as a JSON payload to a
+fixed argv (`panemux board recv` for `native`, agmsg's own script entry point for `agmsg`), and must
+never build a shell command string that interpolates the body. These are the only board-related
+commands panemux itself ever executes remotely; each performs a parameterized write against that
+backend's own local store on that host. panemux only ever detects an existing agmsg installation —
+it never installs, updates, or otherwise manages agmsg on the operator's behalf, locally or
+remotely.
 
 ### Auth token and transport encryption (design, not yet implemented)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -42,34 +42,23 @@ After validation, the path is wrapped with `shellQuotePath`, which single-quotes
 
 The planned `internal/board` package (full design in [agent-board.md](agent-board.md)) writes
 cross-pane agent messages into a remote host's message store over the SSH exec channel already used
-by `GetCWD`/`InspectGitContext`. Two backends are planned, `native` (panemux's own SQLite file) and
-`agmsg` (delegating to an operator-installed [agmsg](https://github.com/fujibee/agmsg) instance).
-The `panemux` binary itself is never installed on a remote host under any circumstances — it is
-also a server, and a stray copy on an SSH-reached host could start its own HTTP/WS listener and
-command center. `native`'s remote support is therefore built entirely on `sqlite3`, the same tool
-`agmsg` already depends on, invoked directly over the exec channel rather than through any
-panemux-provided remote binary.
+by `GetCWD`/`InspectGitContext`, by running an operator-installed
+[agmsg](https://github.com/fujibee/agmsg) instance's own scripts. panemux owns no message schema or
+storage of its own — it is a client of agmsg only. The `panemux` binary itself is never installed
+on a remote host under any circumstances — it is also a server, and a stray copy on an SSH-reached
+host could start its own HTTP/WS listener and command center.
 
 Message bodies are arbitrary text written by a Claude (or other agent) process, not a trusted
-value, so both backends must ensure no unescaped body content reaches a remote shell — but neither
-has a stdin-based write path to fall back on (verified against each tool's actual argument contract,
-not assumed), so both build a remote command string and both must escape it correctly:
+value. Reads go through `scripts/api.sh`, which only takes digit- or path-traversal-validated
+arguments. Writes go through `scripts/api.sh`'s sibling script, `scripts/send.sh <team> <from> <to>
+<body> [--force]`, which — per agmsg's own source, verified rather than assumed — takes `body` as a
+positional argument with **no stdin option**, so it cannot be kept out of the remote command
+string. `send.sh` does its own SQL escaping internally, so `RunBoardCommand` is responsible only for
+POSIX shell escaping (`shellQuotePath`-style, matching the existing `cwd` discipline) of every
+argument before the remote command string is built — never unescaped concatenation.
 
-- `native`: `RunBoardCommand` builds a `sqlite3 <path> "<SQL>"` invocation itself, so it needs two
-  escaping layers — SQL string-literal escaping (doubling embedded `'`) for every value placed in
-  the SQL text, then POSIX shell escaping (`shellQuotePath`-style, matching the existing `cwd`
-  discipline) around that SQL text as a whole before it becomes part of the remote command string.
-  Skipping either layer alone is a real injection path.
-- `agmsg`: reads go through `scripts/api.sh`, which only takes digit- or
-  path-traversal-validated arguments. Writes go through `scripts/api.sh`'s sibling script,
-  `scripts/send.sh <team> <from> <to> <body> [--force]`, which — per agmsg's own source — takes
-  `body` as a positional argument with **no stdin option**, but does its own SQL escaping
-  internally. `RunBoardCommand` therefore only needs the shell-escaping layer here, not the
-  SQL-literal one `native` also needs.
-
-These are the only board-related commands panemux itself ever executes remotely; each performs a
-write against that backend's own local store on that host, using only `sqlite3` or agmsg's own
-scripts — never a copy of panemux itself. panemux only ever detects an existing agmsg
+`send.sh` and `api.sh` are the only board-related commands panemux itself ever executes remotely;
+each runs against agmsg's own local store on that host. panemux only ever detects an existing agmsg
 installation — it never installs, updates, or otherwise manages agmsg on the operator's behalf,
 locally or remotely.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -44,27 +44,34 @@ The planned `internal/board` package (full design in [agent-board.md](agent-boar
 cross-pane agent messages into a remote host's message store over the SSH exec channel already used
 by `GetCWD`/`InspectGitContext`. Two backends are planned, `native` (panemux's own SQLite file) and
 `agmsg` (delegating to an operator-installed [agmsg](https://github.com/fujibee/agmsg) instance).
-Message bodies are arbitrary text written by a Claude (or other agent) process, not a trusted value,
-so both backends must ensure no unescaped body content reaches a remote shell — but they satisfy
-that requirement by different means, verified against each tool's actual argument contract rather
-than assumed to match:
+The `panemux` binary itself is never installed on a remote host under any circumstances — it is
+also a server, and a stray copy on an SSH-reached host could start its own HTTP/WS listener and
+command center. `native`'s remote support is therefore built entirely on `sqlite3`, the same tool
+`agmsg` already depends on, invoked directly over the exec channel rather than through any
+panemux-provided remote binary.
 
-- `native`: `RunBoardCommand` sends the body over the remote command's **stdin** as a JSON payload
-  to the fixed argv `panemux board recv`, the same discipline as `cwd` above. The body never
-  appears in the command string at all.
+Message bodies are arbitrary text written by a Claude (or other agent) process, not a trusted
+value, so both backends must ensure no unescaped body content reaches a remote shell — but neither
+has a stdin-based write path to fall back on (verified against each tool's actual argument contract,
+not assumed), so both build a remote command string and both must escape it correctly:
+
+- `native`: `RunBoardCommand` builds a `sqlite3 <path> "<SQL>"` invocation itself, so it needs two
+  escaping layers — SQL string-literal escaping (doubling embedded `'`) for every value placed in
+  the SQL text, then POSIX shell escaping (`shellQuotePath`-style, matching the existing `cwd`
+  discipline) around that SQL text as a whole before it becomes part of the remote command string.
+  Skipping either layer alone is a real injection path.
 - `agmsg`: reads go through `scripts/api.sh`, which only takes digit- or
   path-traversal-validated arguments. Writes go through `scripts/api.sh`'s sibling script,
   `scripts/send.sh <team> <from> <to> <body> [--force]`, which — per agmsg's own source — takes
-  `body` as a positional argument with **no stdin option**. For this script only, `RunBoardCommand`
-  must single-quote-escape every argument (`shellQuotePath`-style, matching the existing `cwd`
-  discipline) before building the remote command string, since keeping the body out of the command
-  string entirely is not possible here. This is a documented exception driven by `send.sh`'s own
-  contract, not a relaxation of the "no unescaped user content in a remote shell" requirement.
+  `body` as a positional argument with **no stdin option**, but does its own SQL escaping
+  internally. `RunBoardCommand` therefore only needs the shell-escaping layer here, not the
+  SQL-literal one `native` also needs.
 
 These are the only board-related commands panemux itself ever executes remotely; each performs a
-write against that backend's own local store on that host. panemux only ever detects an existing
-agmsg installation — it never installs, updates, or otherwise manages agmsg on the operator's
-behalf, locally or remotely.
+write against that backend's own local store on that host, using only `sqlite3` or agmsg's own
+scripts — never a copy of panemux itself. panemux only ever detects an existing agmsg
+installation — it never installs, updates, or otherwise manages agmsg on the operator's behalf,
+locally or remotely.
 
 ### Auth token and transport encryption (design, not yet implemented)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,6 +38,27 @@ It accepts only absolute Unix paths and rejects shell metacharacters and control
 
 After validation, the path is wrapped with `shellQuotePath`, which single-quotes the value and escapes any interior single quotes. This keeps paths containing spaces or unusual but allowed characters safe when embedded in a shell string.
 
+### Agent board remote writes (design, not yet implemented)
+
+The planned `internal/board` package (full design in [agent-board.md](agent-board.md)) writes
+cross-pane agent messages into a remote host's SQLite file over the SSH exec channel already used
+by `GetCWD`/`InspectGitContext`. Message bodies are arbitrary text written by a Claude process, not
+a trusted value, so the same discipline as `cwd` above applies: `RunBoardCommand` must send the
+body over the remote command's **stdin** as a JSON payload to the fixed argv `panemux board recv`,
+and must never build a shell command string that interpolates the body. `panemux board recv` is the
+only board subcommand panemux itself executes remotely; it performs a parameterized SQL insert
+against the local SQLite file on that host.
+
+### Auth token and transport encryption (design, not yet implemented)
+
+panemux does not terminate TLS itself. `server.host` defaults to `127.0.0.1`; if it is set to a
+non-loopback address, `server.auth_token` must also be set, or startup must fail validation
+(`internal/config/validate.go`, alongside the existing `server.port` range check). An auth token
+sent over an unencrypted non-loopback hop can be replayed and the request it authenticates can be
+tampered with in transit, so the token only provides real protection once the operator has placed a
+TLS-terminating reverse proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
+[agent-board.md](agent-board.md#security-model) for the full rationale.
+
 ## General Rules
 
 - When adding new session types or new `exec.Command` calls, the command value passed as the first argument must come from a hardcoded literal or from a trusted system source such as a file or registry with no data-flow path to user input.

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -240,3 +240,32 @@ Agent-attention highlighting remains visually distinct from layout-editing affor
 - move targets use blue overlays instead of gold
 
 Using separate colors avoids mixing "this needs your attention" with "you can drop here".
+
+---
+
+## Agent Board UI (planned)
+
+> **Status: design, not yet implemented.** This section only cross-links the UI-facing pieces of a
+> larger design; it does not add new interaction principles of its own. Full design lives in
+> [agent-board.md](agent-board.md); do not treat any of this as current behavior until that
+> document's status note says so.
+
+Agent Board (see [agent-board.md](agent-board.md)) introduces two new UI surfaces, both layered on
+top of the principles above rather than replacing them:
+
+- A **dashboard** view of per-pane self-reported status (state, branch, PR, summary — see
+  [agent-board.md's Status self-report](agent-board.md#status-self-report-and-message-flow)),
+  intended to extend the existing workspace-bar/pane-card status vocabulary (**Integrated workspace
+  summaries** and **Workspace pane groups**, above) rather than introduce a competing status
+  language — connection-state dots, attention framing, and repo/branch/PR chrome should read the
+  same way in Agent Board's dashboard as they already do in the pane header and workspace bar.
+- A **Spotlight-style command palette** and **history panel** for the [command
+  center](agent-board.md#command-center), following this document's existing **Modal Dialogs**
+  pattern for the palette itself (a higher-friction, focused interaction that shouldn't be
+  compressed into inline chrome) and the existing overlay-panel pattern already used for the
+  workspace-summary overlay for the persistent history view.
+
+Concrete visual decisions (palette keybinding, color treatment, streaming-response layout, error
+presentation) are deferred to implementation time and belong in this document once they're made —
+this section exists so that work doesn't start from a blank page on cross-cutting concerns
+(status-language consistency, dialog/overlay pattern reuse) that are already settled here.


### PR DESCRIPTION
Design docs/agent-board.md: a cross-pane Claude/Codex messaging and status-
aggregation feature ("Agent Board") built entirely on the existing
MIT-licensed [agmsg](https://github.com/fujibee/agmsg) tool, not a
panemux-owned message schema. Panes self-report status (branch/PR/cwd,
gathered by the agent's own git/gh calls) and exchange messages by calling
agmsg's own scripts/api.sh and scripts/send.sh; panemux relays messages
across hosts over the existing SSH exec channel and never installs
anything on a remote host, including panemux itself. A headless "command
center" (`claude -p --resume`) lets a human converse with an orchestrator
that reads/writes the board through panemux's own authenticated REST API
via a narrow MCP server, never touching agmsg directly.

This design went through an adversarial review (a separate, model-isolated
pass verified against agmsg's real source) that found and fixed several
blocking defects in the original draft: `send.sh` checks both `from` and
`to` against the team roster (fixed with a universal `--force` plus a
compensating sender-identity check); `api.sh` has no forward/since read
(fixed with a bounded `--limit` poll and an accepted, documented
truncation risk); and the command center originally bypassed panemux's own
`AgmsgClient` abstraction (fixed by routing it through panemux's own REST
API instead). A two-tier "agmsg compatibility contract" (fixture-based
unit tests in `make check`, plus a separate real-agmsg CI job) is
specified so an agmsg upgrade that changes `send.sh`/`join.sh` behavior
surfaces as a CI signal instead of a silently broken pane.

Cross-links the security requirements into `security.md`, the
package/tradeoff summary into `architecture.md`, and the dashboard/palette
UI intent into `ui-design.md`. No code yet; `docs/agent-board.md` is
explicitly marked design-only until a phase ships.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BzjVXV6HZmLGDVNCrWujTa