### PR TITLE
feat: add Agent Board foundation (config, session capabilities, internal/board)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,7 +96,7 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 
 ### Coverage
 
-- `make coverage-go` enforces at least 80% combined coverage across `internal/config`, `internal/api`, `internal/ws`, and `internal/server`.
+- `make coverage-go` enforces at least 80% combined coverage across `internal/config`, `internal/api`, `internal/ws`, `internal/server`, and `internal/board`.
 - `make coverage-frontend` enforces at least 80% coverage across `frontend/src/hooks/` and `frontend/src/schemas/`.
 
 ### Quality gate

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-e2e:
 
 # ── Coverage (≥ 80 %) ─────────────────────────────────────────────────────────
 #
-# Go: measures config / api / ws / server (business-logic packages).
+# Go: measures config / api / ws / server / board (business-logic packages).
 #     session/local uses a real PTY and is covered separately.
 #     session/ssh and session/tmux* require live SSH / tmux and are
 #     integration-tested outside the unit-test suite.
@@ -45,7 +45,7 @@ test-e2e:
 #           UI components (App, SplitContainer, TerminalPane …) require a real
 #           browser renderer and are covered by integration / E2E tests.
 
-COVERAGE_PKGS := ./internal/config/...,./internal/api/...,./internal/ws/...,./internal/server/...
+COVERAGE_PKGS := ./internal/config/...,./internal/api/...,./internal/ws/...,./internal/server/...,./internal/board/...
 
 coverage: coverage-go coverage-frontend
 
@@ -55,6 +55,7 @@ coverage-go:
 	  ./internal/api/... \
 	  ./internal/ws/... \
 	  ./internal/server/... \
+	  ./internal/board/... \
 	  -coverprofile=coverage.out \
 	  -coverpkg=$(COVERAGE_PKGS) \
 	  -count=1 -timeout 30s

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -987,21 +987,25 @@ that shaped the design.
   construction of that string. `send.sh` does its own SQL escaping internally, so shell-escaping is
   the only layer panemux is responsible for on the write path — there is no panemux-owned SQL text
   to also escape, unlike an earlier draft of this design that had panemux building its own SQL.
-- **Open implementation question: `shellQuotePath`-style escaping alone may not satisfy this
-  repository's own CodeQL bar for a message body.** `docs/security.md` is explicit that a quoting
-  or regex-submatch transform does not, by itself, break CodeQL's taint-tracking — the accepted
-  pattern (`cwd`) is a **regex allowlist** (`validRemotePath`) applied *before* `shellQuotePath`,
-  and the allowlist is what actually breaks the taint chain. A message body is arbitrary
-  agent-authored text; it cannot be regex-allowlisted the way a path can. Encoding the body to a
-  constrained alphabet before it ever reaches the command string (e.g. base64, then a regex check
-  that the *encoded* string is pure base64 — genuinely mirroring the `validRemotePath`-then-quote
-  shape, since a base64 alphabet cannot itself contain shell metacharacters) is the most promising
-  direction, but it requires the remote side to decode before handing the value to `send.sh` (which
-  does not accept pre-encoded input), which is its own small piece of remote shell composition to
-  get right. This document does not claim the question is resolved; implementation must either find
-  a construction that satisfies CodeQL structurally, or make a deliberate, documented, narrowly
-  scoped exception consistent with `docs/security.md`'s stated preference for structural fixes over
-  suppression — not assume plain `shellQuotePath` on a message body will pass review unremarked.
+- **Implementation status: attempted resolution, not a verified one.** `shellQuotePath`-style
+  escaping alone does not satisfy this repository's own CodeQL bar for a message body — `docs/security.md`
+  is explicit that a quoting or regex-submatch transform does not, by itself, break CodeQL's
+  taint-tracking; the accepted pattern (`cwd`) is a **regex allowlist** (`validRemotePath`) applied
+  *before* `shellQuotePath`. A message body is arbitrary agent-authored text; it cannot be
+  regex-allowlisted the way a path can. `internal/board/remote_client.go`'s `RemoteAgmsgClient.Send`
+  base64-encodes the body, regex-checks the *encoded* string against `^[A-Za-z0-9+/]*={0,2}$`, and
+  only then places it in the `RunBoardCommand` argument list; a fixed wrapper script
+  (`sendBase64WrapperScript`) decodes it back to the original bytes on the remote host via shell
+  positional parameters, immediately before `send.sh` sees it — proven correct end to end against a
+  real `/bin/sh` (`internal/board/wrapper_script_integration_test.go`).
+  **What this construction does not establish**, and what a reviewer should not assume from the code
+  alone: Go's `base64.StdEncoding` output is, by construction, always a subset of the checked
+  alphabet, so the `MatchString` branch that gates it can never actually fail for correctly-encoded
+  input — it is a regex-allowlist branch in *shape* (mirroring `validRemotePath`'s structure), but no
+  CodeQL scan has actually been run against this code in the environment that implemented it to
+  confirm it is recognized as one in *practice*. Treat the taint chain as *plausibly* broken by
+  structural analogy to `validRemotePath`, not as confirmed broken by an actual scan, until a real
+  CodeQL run against this code says otherwise.
 - **panemux itself is never deployed to a remote host.** Beyond the injection-surface argument
   above, the `panemux` binary is also the server: a copy running on an SSH-reached host could start
   its own HTTP/WS listener, auth surface, and command center — a second, unmanaged instance of

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -1,11 +1,16 @@
 # Agent Board: Cross-Pane Claude Messaging and Status Aggregation
 
-> **Status: design, not yet implemented.** This document specifies the target design for the
-> `internal/board` package and its supporting API, config, and security surface. Update this
-> status note (and cross-link it from [architecture.md](architecture.md), [security.md](security.md),
-> [behavior.md](behavior.md), and [ui-design.md](ui-design.md) as appropriate) once a phase below
-> actually ships; until then, no other doc should describe `board` endpoints or config fields as
-> current behavior.
+> **Status: foundation implemented, feature not yet usable.** The `internal/board` package's core
+> types (`Row`, `Status`, `AgmsgClient`, `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`,
+> `RemoteAgmsgClient`), the `BoardHostID`/`BoardExecutor` session capability interfaces, and the
+> `agent_board`/`command_center`/`server.auth_token` config surface described below are implemented
+> and tested — see [architecture.md](architecture.md)'s `internal/board` section and
+> [security.md](security.md#agent-board-remote-writes) for what actually ships today. The relay
+> goroutine, the PTY bootstrap flow, the `/api/board/*` and `/ws/board-command` endpoints, the
+> command center, and wiring the bearer auth middleware into any route are still design-only — none
+> of them exist yet, so this document's API/UI surface below is not reachable through any current
+> config or endpoint. Update this note (and its cross-links) again once a later phase closes that
+> gap; until then, no other doc should describe `board` REST/WS endpoints as current behavior.
 
 ## Purpose
 
@@ -259,7 +264,7 @@ different reasons (the first re-introduces "panemux owns a schema," which [Desig
 principles](#design-principles) rules out; the second makes every dashboard poll pay for an agmsg
 round-trip, including an SSH hop for remote hosts). Instead: the relay goroutine, which is already
 polling every host's agmsg for messages to forward, updates an **in-memory status cache** as a side
-effect whenever it sees a status report addressed to `_panemux`. `GET /api/board/status` reads only
+effect whenever it sees a status report addressed to `_system`. `GET /api/board/status` reads only
 that cache — never agmsg directly. agmsg's own message log remains the durable source of truth (a
 lost or restarted panemux process just means the cache is empty until the next poll cycle refills
 it, per [Known limitations](#known-limitations)), but the *current, dashboard-facing view* of that
@@ -310,7 +315,7 @@ there is no stdin-based write path in agmsg to delegate to. **Both `from` and `t
 against that team's roster unless `--force` is passed** — an earlier revision of this document said
 only `from` was checked, which is wrong and was load-bearing: it made every message in [Status
 self-report](#status-self-report-and-message-flow)'s sequence diagram fail at the source, since
-`_panemux` (the status-report recipient) and any pane on a *different* host (the cross-host relay
+`_system` (the status-report recipient) and any pane on a *different* host (the cross-host relay
 target) are never registered in the sending pane's own local roster.
 
 **The fix this document adopts: every board-related `send.sh` call always passes `--force`,
@@ -407,13 +412,13 @@ contract](#agmsg-compatibility-contract).
 ## Status self-report and message flow
 
 Instead of a `kind='status'` field panemux owns (agmsg has no such column), status reports are
-ordinary agmsg messages addressed to the reserved identity `_panemux` — the same identity the
-command center uses as its own `from` when sending. Because `_panemux` is never an agmsg roster
+ordinary agmsg messages addressed to the reserved identity `_system` — the same identity the
+command center uses as its own `from` when sending. Because `_system` is never an agmsg roster
 member (see [Integration with agmsg](#integration-with-agmsg)), the agent's own `send.sh ...
 --force` call is what lets a status report reach it at all. The relay goroutine, already polling
 every host's agmsg with `api.sh get teams <team> messages --limit <N>` (no `--before-id` — see
 [Integration with agmsg](#integration-with-agmsg) for why that flag can't do this) for message
-forwarding, recognizes any row addressed to `_panemux` as a status update and writes it into
+forwarding, recognizes any row addressed to `_system` as a status update and writes it into
 panemux's own in-memory status cache (see [Architecture](#architecture)), keeping only the newest
 entry per sender. The dashboard never queries agmsg directly for this — it only ever reads that
 cache.
@@ -436,7 +441,7 @@ itself, using its own `Bash` tool, and include it as a small JSON body:
 
 **`kind: "board_status"` is a fixed, required discriminator, not an optional field.** Detecting a
 status report by *shape alone* — "does this JSON happen to have a `state` key" — has a real false-
-positive edge: a human typing an ordinary chat message to `_panemux` through the command center or
+positive edge: a human typing an ordinary chat message to `_system` through the command center or
 Spotlight palette could, by coincidence or by pasting unrelated JSON, produce a body that parses as
 valid JSON and happens to contain a `state` field, and would then be silently swallowed into the
 status cache instead of showing up as a message. Requiring a literal `"kind": "board_status"` value
@@ -462,9 +467,9 @@ sequenceDiagram
 
     Note over ClaudeA: Status self-report
     ClaudeA->>ClaudeA: run git branch / gh pr view
-    ClaudeA->>AgmsgA: send.sh team ClaudeA _panemux "{branch,pr_url,state,...}" --force
+    ClaudeA->>AgmsgA: send.sh team ClaudeA _system "{branch,pr_url,state,...}" --force
     Relay->>AgmsgA: api.sh get teams team messages --limit N
-    AgmsgA-->>Relay: rows with id > cursor (addressed to _panemux)
+    AgmsgA-->>Relay: rows with id > cursor (addressed to _system)
     Relay->>Cache: write latest status (JSON)
     Dash->>Cache: GET /api/board/status
     Cache-->>Dash: latest status (no agmsg call)
@@ -520,7 +525,7 @@ type AgmsgClient interface {
 
 // ownSendLedger is a short-lived, in-memory record of Send calls panemux itself has issued (the
 // broadcast handler and the command center — see Cross-host relay), used only to verify a row the
-// relay later observes with From == "_panemux" actually corresponds to one of panemux's own sends,
+// relay later observes with From == "_system" actually corresponds to one of panemux's own sends,
 // since send.sh --force never checks From against a roster and an ordinary board pane could
 // otherwise forge that identity. Entries expire after a few poll intervals; a body is stored only
 // as a hash, since the ledger's job is matching, not re-displaying content.
@@ -565,11 +570,11 @@ func (c *BoardCache) StatusSnapshot() map[string]Status    { /* mutex-guarded co
 func (c *BoardCache) MessagesSince(afterSeq int64) []Row   { /* mutex-guarded copy, filtered by Seq */ }
 ```
 
-The relay inspects every `Row` it reads: if `To == "_panemux"` and `Body` parses as JSON with
+The relay inspects every `Row` it reads: if `To == "_system"` and `Body` parses as JSON with
 `kind == "board_status"` (see [Status self-report](#status-self-report-and-message-flow) for why
 the discriminator, not shape-sniffing, is what triggers this), it calls `RecordStatus` and does
 *not* forward that row through the cross-host relay logic (status reports are local bookkeeping,
-not messages meant for another pane). A `Body` addressed to `_panemux` that isn't valid JSON, or is
+not messages meant for another pane). A `Body` addressed to `_system` that isn't valid JSON, or is
 valid JSON without that exact `kind`, is left alone as an ordinary chat message — including a body
 that happens to share some field names with the status shape by coincidence. Every row, status or
 not, is also appended to
@@ -668,21 +673,21 @@ to reach each other). panemux is the only node with a connection to every host, 
    `~/.config/panemux/board-relay-cursor.json`) — not a database table, since panemux owns no
    database — so a panemux restart resumes roughly where it left off.
 3. For each new row, panemux first checks `from`. If `from` is a board-enabled pane ID panemux
-   knows about on that row's source host, the row passes. **If `from == "_panemux"`, the row passes
+   knows about on that row's source host, the row passes. **If `from == "_system"`, the row passes
    only if it matches an entry in panemux's own short-lived "own-send ledger"** (see [Package
    layout](#package-layout)) — a small in-memory record of `(destination host, team, to, body hash)`
    for every `Send` panemux's own broadcast handler and command center have issued recently, kept
    for a few poll intervals and then discarded. This is deliberately stricter than treating
-   `_panemux` as unconditionally trusted: because `send.sh --force` never checks `from` against a
-   roster, any agent on any host can locally write a row claiming `from: "_panemux"`, and nothing at
+   `_system` as unconditionally trusted: because `send.sh --force` never checks `from` against a
+   roster, any agent on any host can locally write a row claiming `from: "_system"`, and nothing at
    the agmsg layer distinguishes that from a row that reached the same host because panemux's own
    broadcast handler really did call `Send` there — the ledger match is what tells them apart. A row
-   with `from == "_panemux"` that matches nothing in the ledger is a suspected forgery: it is dropped
+   with `from == "_system"` that matches nothing in the ledger is a suspected forgery: it is dropped
    and logged the same as any other failed check, never relayed and never cached. Any other `from` —
-   one that is neither a known local pane ID nor a ledger-matched `_panemux` — is dropped and logged
+   one that is neither a known local pane ID nor a ledger-matched `_system` — is dropped and logged
    too. See [Security model](#security-model) for the forgery scenario this closes and why a
-   universal `_panemux` allowance (an earlier revision of this document's check) was not enough. If
-   `from` passes: when `to == "_panemux"`, panemux updates the
+   universal `_system` allowance (an earlier revision of this document's check) was not enough. If
+   `from` passes: when `to == "_system"`, panemux updates the
    [in-memory status cache](#architecture) instead of relaying it — status reports never leave the
    host they were written on. Otherwise, panemux resolves `to` to its owning pane and that pane's
    host via the already-known pane→session config; if that host differs from the source host,
@@ -793,7 +798,7 @@ always routed through it by construction.
   path to the same exec sink alongside `AgmsgClient`'s own (see [Security
   model](#security-model)); and it meant the command center could only ever see the *local* agmsg
   installation's status, never a remote pane's, because [Cross-host relay](#cross-host-relay)
-  intercepts `_panemux`-addressed status reports before they ever leave the host they were written
+  intercepts `_system`-addressed status reports before they ever leave the host they were written
   on. Reading `BoardCache` through `GET /api/board/status` (already aggregated across every host by
   the relay) fixes both: `AgmsgClient` stays the *only* code that ever calls agmsg's scripts, and
   the command center sees every pane's status, not just local ones.
@@ -801,7 +806,7 @@ always routed through it by construction.
   agmsg directly, so `command_center.enabled: true` is not gated on the same agmsg-presence check a
   board-enabled pane is (see [Config additions](#config-additions)).
 - Sending a message is `POST /api/board/broadcast` with the command center's own reserved `from`
-  identity, `_panemux` — the exact same code path a human-triggered broadcast takes, which already
+  identity, `_system` — the exact same code path a human-triggered broadcast takes, which already
   resolves the destination pane's host and calls that host's `AgmsgClient.Send` (always `--force`)
   without the command center needing any host-routing logic of its own.
 
@@ -941,15 +946,15 @@ being configured too, which is false by design: the command center never calls a
 The two keys are siblings in this config because their actual dependency graph is siblings — not
 because they're unrelated features that happen to share a document.
 
-**`_panemux` is reserved and validated where panemux can actually enforce it.** `internal/config/
-validate.go` rejects any pane config whose `id` is literally `_panemux`, the same way it already
+**`_system` is reserved and validated where panemux can actually enforce it.** `internal/config/
+validate.go` rejects any pane config whose `id` is literally `_system`, the same way it already
 rejects duplicate pane IDs (see [architecture.md](architecture.md)) — panemux will not let itself be
 configured into a collision with its own reserved sentinel. This is a real but partial guarantee:
-nothing stops an operator or a live agent from running agmsg's own `join.sh <team> _panemux ...`
+nothing stops an operator or a live agent from running agmsg's own `join.sh <team> _system ...`
 by hand, outside any pane panemux bootstrapped, since agmsg's roster is agmsg's own state and
 `join.sh` is not gated by panemux at all. That gap is exactly why the [own-send
 ledger](#package-layout) check in [Cross-host relay](#cross-host-relay) does not trust the
-`_panemux` string by itself even after this validation — config-time reservation closes the
+`_system` string by itself even after this validation — config-time reservation closes the
 "panemux accidentally misconfigures itself" case, not the "an agmsg team member deliberately
 registers the reserved name" case, which only the ledger check closes.
 
@@ -1014,18 +1019,18 @@ that shaped the design.
   panemux process/host must be trusted for the relay to be meaningful. There is no end-to-end
   encryption between two remote agents' Claude/Codex processes.
 - **Universal `--force` makes `from` forgeable across the whole team, including impersonating
-  `_panemux` itself, unless the relay actively checks it.** `send.sh --force` accepts any `from`
+  `_system` itself, unless the relay actively checks it.** `send.sh --force` accepts any `from`
   without checking it against a roster, and by design *every* board send uses `--force` (see
   [Integration with agmsg](#integration-with-agmsg)) — so nothing at the agmsg layer stops an agent
-  on Host A from sending a message with `from: "_panemux"` to a pane on Host B, which
+  on Host A from sending a message with `from: "_system"` to a pane on Host B, which
   [Cross-host relay](#cross-host-relay) would otherwise happily forward as if the command center had
-  sent it. Unconditionally trusting any row with `from == "_panemux"` would not close this — that
+  sent it. Unconditionally trusting any row with `from == "_system"` would not close this — that
   string carries no more authority than any other free-text `from` value once `--force` is
   universal, so treating it as automatically legitimate is exactly the gap being described, not a
   fix for it. The actual check the relay performs — matching the row against panemux's own
   short-lived **own-send ledger** of `Send` calls it issued itself (see [Cross-host
   relay](#cross-host-relay) and [Package layout](#package-layout)) — is what closes this: a
-  `_panemux`-attributed row is only accepted if it corresponds to a send panemux's own broadcast
+  `_system`-attributed row is only accepted if it corresponds to a send panemux's own broadcast
   handler or command center actually made, never on the strength of the string alone.
 - **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
   bearer token as everything else, and that gate is the entire authorization model for messaging
@@ -1077,7 +1082,7 @@ that shaped the design.
   nothing about, and does not provide, message claim/lease semantics for delivery.
 - Agents/teams are free-text identifiers with no cryptographic authentication of `from`. The relay's
   own `from` check (see [Cross-host relay](#cross-host-relay)) rejects a forged `from` that doesn't
-  match a known local pane ID or `_panemux`, but within that set there is still no proof a given
+  match a known local pane ID or `_system`, but within that set there is still no proof a given
   message actually came from the pane process it claims to — any local process that can reach a
   host's agmsg installation and pick a real, currently-registered pane ID can forge a sender inside
   that host. This is an integrity gap distinct from the transport-confidentiality concerns above and
@@ -1090,7 +1095,7 @@ that shaped the design.
   deliberate choice to keep `BoardCache` populated from exactly one code path (the relay) rather than
   give the broadcast handler a second, racing write path into the same cache that would need its own
   reconciliation against the row the relay later reads back for the same send. The [own-send
-  ledger](#package-layout) used for `_panemux` forgery detection intentionally is not repurposed to
+  ledger](#package-layout) used for `_system` forgery detection intentionally is not repurposed to
   paper over this lag: it exists for that one security check, not as a second history source.
 - Relay delivery is at-least-once, bounded by the poll interval, not real-time or exactly-once; see
   [Cross-host relay](#cross-host-relay) for why a duplicate message after a panemux restart is an
@@ -1187,22 +1192,22 @@ documented behavior changed.
   newest wins, `UpdatedAt` reflects when it was recorded) and across multiple panes, `BoardCache`'s
   own `Seq` assignment giving a stable total order across rows from different hosts even when their
   agmsg-native `ID`s collide or aren't comparable, `MessagesSince(afterSeq)` ordering and bounding,
-  a row addressed to `_panemux` updating `status` and *not* appearing in `history`'s cross-pane
-  relay output (a plain non-status row addressed to `_panemux` correctly *does* appear, as an
+  a row addressed to `_system` updating `status` and *not* appearing in `history`'s cross-pane
+  relay output (a plain non-status row addressed to `_system` correctly *does* appear, as an
   ordinary message), an empty cache read (fresh start / post-restart) returning a well-defined empty
   result rather than an error, relay cursor persistence across a simulated restart (including the
   accepted at-least-once duplicate case — assert it is delivered again, not that it's silently
   dropped or that the relay errors), the accepted truncation case (more new rows on one host than
   one poll's `--limit` — assert the newest ones are kept and the oldest of the overflow are dropped,
   not that everything is delivered), the relay's `from`-validation (a row whose `from` is neither a
-  known local pane ID on its source host nor a ledger-matched `_panemux` is dropped and logged, never
-  cached or relayed), the own-send ledger specifically (a `from == "_panemux"` row that matches a
-  recently recorded `Send` is accepted; a `from == "_panemux"` row with no matching ledger entry —
+  known local pane ID on its source host nor a ledger-matched `_system` is dropped and logged, never
+  cached or relayed), the own-send ledger specifically (a `from == "_system"` row that matches a
+  recently recorded `Send` is accepted; a `from == "_system"` row with no matching ledger entry —
   including one crafted with a `to`/`body` that doesn't match any real recent send — is dropped and
   logged, never treated as legitimate on the strength of the string alone; an entry past its TTL is
-  no longer matchable — this is the regression test for the cross-host `_panemux` impersonation
+  no longer matchable — this is the regression test for the cross-host `_system` impersonation
   scenario in [Security model](#security-model), and for why an earlier revision's blanket
-  `_panemux` allowance was insufficient), empty team.
+  `_system` allowance was insufficient), empty team.
 - `internal/session`: for `RemoteAgmsgClient`, a body containing shell metacharacters (`'`, `;`,
   `` ` ``, `$(...)`) round-trips through the built `send.sh` command string as a single escaped
   literal argument, not as executed shell syntax — and the same for a `team`/`--agent` value
@@ -1212,7 +1217,7 @@ documented behavior changed.
   omits it.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
   combinations are valid. `agent_board.team` defaults to `"panemux"` when unset. A pane config with
-  `id: "_panemux"` is a validation error, both alone and alongside otherwise-valid other panes.
+  `id: "_system"` is a validation error, both alone and alongside otherwise-valid other panes.
 - `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
   handshake; correct token succeeds.
 - `internal/ws`: `/ws/board-command` is new surface under the same package as the existing terminal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,16 +63,34 @@ Optional capability interfaces extend the base `Session` contract without breaki
 - `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
 
-### `internal/board` (design, not yet implemented)
+### `internal/board` (foundation implemented; relay, bootstrap, and API surface still planned)
 
-A planned package that replaces transcript-based Claude activity inference with a self-reported
-channel: panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh`
-calls rather than inferred by panemux) and exchange messages through an operator-installed
+A package that replaces transcript-based Claude activity inference with a self-reported channel:
+panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh` calls rather
+than inferred by panemux) and exchange messages through an operator-installed
 [agmsg](https://github.com/fujibee/agmsg) instance, plus a relay for messages addressed across
 hosts. panemux owns no message schema or storage of its own — it is only ever a client of agmsg's
 own documented scripts (`scripts/api.sh`, `scripts/send.sh`), never a reader of its internal
-SQLite file. Two new optional session capability interfaces, `BoardHostID` and `BoardExecutor`,
-extend the same pattern as `CWDGetter`/`ActiveWorkdirGetter` above.
+SQLite file.
+
+The package's foundational pieces are implemented and tested: `Row`/`Status` and the
+`board_status`-discriminated status-report parsing, `BoardCache` (the in-memory status/history view
+[agent-board.md's Architecture section](agent-board.md#architecture) describes), `ownSendLedger`
+(the forgery-detection primitive [Security
+model](agent-board.md#security-model) describes), and the two `AgmsgClient` implementations —
+`LocalAgmsgClient` (plain `exec.Command`, no shell involved) and `RemoteAgmsgClient` (the SSH exec
+channel, with the base64-encode-then-allowlist body escaping and identifier allowlisting
+[security.md](security.md#agent-board-remote-writes) describes). Two new optional session capability
+interfaces, `BoardHostID` and `BoardExecutor`, extend the same pattern as
+`CWDGetter`/`ActiveWorkdirGetter` above and are implemented on all four session types
+(`BoardHostID`) and on `SSHSession`/`TmuxSSHSession` (`BoardExecutor`'s `RunBoardCommand`).
+
+Not yet implemented: the relay goroutine that polls every host's agmsg on a schedule and populates
+`BoardCache` as a side effect, the bootstrap flow that writes a one-time onboarding instruction into
+a pane's PTY, the `/api/board/*` and `/ws/board-command` REST/WS surface, and the command center.
+The `server.auth_token` config field, its non-loopback validation rule, and a constant-time bearer
+auth middleware are implemented (see [security.md](security.md#auth-token-and-transport-encryption)),
+but that middleware is not yet connected to any route.
 
 The same design also specifies a **command center**: a single headless `claude -p --resume`
 subprocess, invoked per query, that reads and writes the board exclusively through panemux's own
@@ -322,7 +340,7 @@ Architecture-level security summary:
 - remote shell entrypoints validate SSH working directories before interpolating them into shell commands
 - host-key handling intentionally preserves compatibility with OpenSSH hashed `known_hosts` entries
 - shipped code should structurally avoid `gosec` findings rather than suppress them
-- panemux does not terminate TLS; non-loopback exposure is expected to sit behind operator-managed infrastructure (reverse proxy, tunnel, VPN), and the planned `internal/board` auth token is only meaningful once that transport is encrypted — see [agent-board.md](agent-board.md#security-model)
+- panemux does not terminate TLS; non-loopback exposure is expected to sit behind operator-managed infrastructure (reverse proxy, tunnel, VPN), and the `server.auth_token` config field (implemented, but not yet enforced by any route — see this document's `internal/board` section above) is only meaningful once that transport is encrypted — see [agent-board.md](agent-board.md#security-model)
 
 ## Tradeoffs and Intentional Limits
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -54,9 +54,17 @@ value, and plain `shellQuotePath`-style quoting of that value alone does not sat
 repository's `go/command-injection` CodeQL bar (a quoting transform does not itself break a taint
 chain; only a preceding regex-allowlist branch does — see `validateShell`'s explanation above).
 Because a message body is free text and cannot be regex-allowlisted directly the way a path can,
-`RemoteAgmsgClient.Send` base64-encodes the body, regex-allowlists the *encoded* string against
-`^[A-Za-z0-9+/]*={0,2}$` (mirroring `validRemotePath`'s accepted shape for a value that couldn't
-otherwise take it), and only then places it in the `RunBoardCommand` argument list. `team`/`from`/`to`
+`RemoteAgmsgClient.Send` base64-encodes the body, regex-checks the *encoded* string against
+`^[A-Za-z0-9+/]*={0,2}$`, and only then places it in the `RunBoardCommand` argument list — structurally
+mirroring `validRemotePath`'s accepted shape (a regex-allowlist branch gating a value before it reaches
+the exec sink) for a value that couldn't otherwise take it. **Caveat, stated plainly:** because
+`base64.StdEncoding`'s output is by construction always within that alphabet, the `MatchString` branch
+can never actually fail for correctly-encoded input — it is a regex-allowlist branch in *shape*, not
+one that can reject real input. No CodeQL scan has been run against this code to confirm the taint
+chain is actually recognized as broken in practice; treat it as a structurally-motivated best effort,
+not a verified one, until a real scan says otherwise — see
+[agent-board.md's Security model](agent-board.md#security-model) for the same caveat stated in more
+detail. `team`/`from`/`to`
 identifiers are regex-allowlisted directly (`^[A-Za-z0-9_.-]+$`) for the same reason, since agmsg's
 own `--agent` argument validation is not a claim panemux can rely on — it runs inside the remote
 shell process that only exists because panemux's own command string has already been parsed, so it

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,39 +38,65 @@ It accepts only absolute Unix paths and rejects shell metacharacters and control
 
 After validation, the path is wrapped with `shellQuotePath`, which single-quotes the value and escapes any interior single quotes. This keeps paths containing spaces or unusual but allowed characters safe when embedded in a shell string.
 
-### Agent board remote writes (design, not yet implemented)
+### Agent board remote writes
 
-The planned `internal/board` package (full design in [agent-board.md](agent-board.md)) writes
+`internal/board`'s `RemoteAgmsgClient` (full design in [agent-board.md](agent-board.md)) writes
 cross-pane agent messages into a remote host's message store over the SSH exec channel already used
-by `GetCWD`/`InspectGitContext`, by running an operator-installed
+by `GetCWD`/`InspectGitContext` — `internal/session`'s `BoardExecutor.RunBoardCommand`, implemented
+on `SSHSession`/`TmuxSSHSession` — by running an operator-installed
 [agmsg](https://github.com/fujibee/agmsg) instance's own scripts. panemux owns no message schema or
 storage of its own — it is a client of agmsg only. The `panemux` binary itself is never installed
 on a remote host under any circumstances — it is also a server, and a stray copy on an SSH-reached
 host could start its own HTTP/WS listener and command center.
 
 Message bodies are arbitrary text written by a Claude (or other agent) process, not a trusted
-value. Reads go through `scripts/api.sh`, which only takes digit- or path-traversal-validated
-arguments. Writes go through `scripts/api.sh`'s sibling script, `scripts/send.sh <team> <from> <to>
-<body> [--force]`, which — per agmsg's own source, verified rather than assumed — takes `body` as a
-positional argument with **no stdin option**, so it cannot be kept out of the remote command
-string. `send.sh` does its own SQL escaping internally, so `RunBoardCommand` is responsible only for
-POSIX shell escaping (`shellQuotePath`-style, matching the existing `cwd` discipline) of every
-argument before the remote command string is built — never unescaped concatenation.
+value, and plain `shellQuotePath`-style quoting of that value alone does not satisfy this
+repository's `go/command-injection` CodeQL bar (a quoting transform does not itself break a taint
+chain; only a preceding regex-allowlist branch does — see `validateShell`'s explanation above).
+Because a message body is free text and cannot be regex-allowlisted directly the way a path can,
+`RemoteAgmsgClient.Send` base64-encodes the body, regex-allowlists the *encoded* string against
+`^[A-Za-z0-9+/]*={0,2}$` (mirroring `validRemotePath`'s accepted shape for a value that couldn't
+otherwise take it), and only then places it in the `RunBoardCommand` argument list. `team`/`from`/`to`
+identifiers are regex-allowlisted directly (`^[A-Za-z0-9_.-]+$`) for the same reason, since agmsg's
+own `--agent` argument validation is not a claim panemux can rely on — it runs inside the remote
+shell process that only exists because panemux's own command string has already been parsed, so it
+cannot retroactively protect that string's construction. Writes go through `scripts/api.sh`'s
+sibling script, `scripts/send.sh <team> <from> <to> <body> [--force]`, which — per agmsg's own
+source, verified rather than assumed — takes `body` as a positional argument with **no stdin
+option**, so a fixed, non-tainted wrapper script (`sendBase64WrapperScript` in
+`internal/board/remote_client.go`) decodes the base64 body back to its original bytes remotely,
+via shell positional parameters (`$1`..`$5`), immediately before the one call site that needs the
+raw value — never through unquoted string interpolation. `send.sh` does its own SQL escaping
+internally, so `RunBoardCommand` remains responsible only for the POSIX shell escaping
+(`shellQuotePath`-style, matching the existing `cwd` discipline) that wraps every argument,
+including the wrapper script text itself, before the remote command string is built.
 
 `send.sh` and `api.sh` are the only board-related commands panemux itself ever executes remotely;
 each runs against agmsg's own local store on that host. panemux only ever detects an existing agmsg
 installation — it never installs, updates, or otherwise manages agmsg on the operator's behalf,
-locally or remotely.
+locally or remotely. The relay goroutine that actually drives this on a schedule, the bootstrap flow
+that writes an onboarding instruction into a pane's PTY, and the `/api/board/*` REST surface are not
+yet implemented — see [agent-board.md](agent-board.md)'s status note.
 
-### Auth token and transport encryption (design, not yet implemented)
+### Auth token and transport encryption
 
-panemux does not terminate TLS itself. `server.host` defaults to `127.0.0.1`; if it is set to a
-non-loopback address, `server.auth_token` must also be set, or startup must fail validation
-(`internal/config/validate.go`, alongside the existing `server.port` range check). An auth token
-sent over an unencrypted non-loopback hop can be replayed and the request it authenticates can be
-tampered with in transit, so the token only provides real protection once the operator has placed a
-TLS-terminating reverse proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
+`internal/config`'s `ServerConfig.AuthToken` (`server.auth_token` in `config.yaml`) and the
+non-loopback-requires-token validation rule are implemented: panemux does not terminate TLS itself,
+`server.host` defaults to `127.0.0.1`, and if it is set to a non-loopback address,
+`server.auth_token` must also be set, or startup fails validation (`internal/config/validate.go`,
+alongside the existing `server.port` range check). When left empty, `Config.Load`/`Default`
+auto-generate a token on first run and persist it to `~/.config/panemux/token` (`0600`), read back
+on later runs, and never write it into `config.yaml` itself. An auth token sent over an unencrypted
+non-loopback hop can be replayed and the request it authenticates can be tampered with in transit,
+so the token only provides real protection once the operator has placed a TLS-terminating reverse
+proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
 [agent-board.md](agent-board.md#security-model) for the full rationale.
+
+`internal/server`'s constant-time bearer-token middleware (`bearerAuthMiddleware`) is also
+implemented and unit-tested, but it is **not yet wired into `registerRoutes`** — connecting it to
+today's `/api/*` and `/ws/{sessionID}` routes without a matching frontend change would break every
+existing, currently-unauthenticated request. It is connected once board endpoints exist to protect
+and the frontend sends the token; see [agent-board.md](agent-board.md)'s status note.
 
 ## General Rules
 

--- a/internal/board/agmsg_fixture_test.go
+++ b/internal/board/agmsg_fixture_test.go
@@ -1,0 +1,122 @@
+package board
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureDir holds Tier 1 of the agmsg compatibility contract (see
+// docs/agent-board.md#agmsg-compatibility-contract): fast, hermetic tests
+// that assert panemux's own parsing against frozen, versioned fixture
+// output. See fixtureDir/README.md for why these particular fixtures are
+// hand-written rather than captured from a real agmsg install.
+const fixtureDir = "testdata/agmsg-unpinned-handwritten"
+
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fixtureDir, name))
+	require.NoError(t, err)
+	return data
+}
+
+func TestAgmsgFixture_TeamMessages_ParsesAllRowsInOrder(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+
+	rows := parseAgmsgMessageRows(data, "local")
+	require.Len(t, rows, 4)
+
+	assert.Equal(t, "1", rows[0].ID)
+	assert.Equal(t, "pane-a", rows[0].From)
+	assert.Equal(t, "pane-b", rows[0].To)
+	assert.Equal(t, "please review my latest commit", rows[0].Body)
+	assert.Equal(t, "local", rows[0].Host)
+	assert.Equal(t, "panemux", rows[0].Team)
+	assert.Equal(t, time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC), rows[0].At)
+
+	assert.Equal(t, "4", rows[3].ID)
+	assert.Equal(t, "lgtm, merging now", rows[3].Body)
+}
+
+func TestAgmsgFixture_TeamMessages_StatusRowRecognized(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+	rows := parseAgmsgMessageRows(data, "local")
+	require.Len(t, rows, 4)
+
+	status, ok := IsStatusRow(rows[1])
+	require.True(t, ok, "row 2 (addressed to _system with kind=board_status) must be recognized as a status report")
+	assert.Equal(t, "working", status.State)
+	assert.Equal(t, "/home/user/project", status.CWD)
+	assert.Equal(t, "feature/x", status.Branch)
+	assert.Equal(t, "owner/repo", status.Repo)
+	assert.Equal(t, "https://github.com/owner/repo/pull/123", status.PRURL)
+}
+
+func TestAgmsgFixture_TeamMessages_CoincidentalJSONNotMistakenForStatus(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+	rows := parseAgmsgMessageRows(data, "local")
+	require.Len(t, rows, 4)
+
+	// Row 3 is addressed to _system and happens to be valid JSON with a
+	// "state" field, but has no "kind": "board_status" discriminator — it
+	// must be left alone as an ordinary message, not swallowed into status.
+	_, ok := IsStatusRow(rows[2])
+	assert.False(t, ok)
+}
+
+func TestAgmsgFixture_TeamMessages_OrdinaryRowsNotMistakenForStatus(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+	rows := parseAgmsgMessageRows(data, "local")
+	require.Len(t, rows, 4)
+
+	for _, i := range []int{0, 3} {
+		_, ok := IsStatusRow(rows[i])
+		assert.False(t, ok, "row %d is not addressed to _system and must never be treated as status", i)
+	}
+}
+
+func TestAgmsgFixture_TeamMessages_FilterRowsAfterCursor(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+	rows := parseAgmsgMessageRows(data, "local")
+
+	newRows := filterRowsAfter(rows, "2")
+	require.Len(t, newRows, 2)
+	assert.Equal(t, "3", newRows[0].ID)
+	assert.Equal(t, "4", newRows[1].ID)
+}
+
+func TestAgmsgFixture_TeamMessages_BoardCacheIntegration(t *testing.T) {
+	data := readFixture(t, "get_team_messages.jsonl")
+	rows := parseAgmsgMessageRows(data, "local")
+
+	cache := NewBoardCache()
+	for _, r := range rows {
+		if status, ok := IsStatusRow(r); ok {
+			cache.RecordStatus(r.From, status)
+			continue
+		}
+		cache.AppendMessage(r)
+	}
+
+	snapshot := cache.StatusSnapshot()
+	require.Contains(t, snapshot, "pane-a")
+	assert.Equal(t, "working", snapshot["pane-a"].State)
+
+	// Only the two ordinary messages (rows 1 and 4) should have been
+	// appended to history — the status row (2) and the coincidental-JSON
+	// row (3, addressed to _system but not a status report) are handled
+	// differently: 2 goes to RecordStatus and never AppendMessage; 3 is an
+	// ordinary message and IS appended.
+	history := cache.MessagesSince(0)
+	require.Len(t, history, 3)
+	bodies := []string{history[0].Body, history[1].Body, history[2].Body}
+	assert.Equal(t, []string{
+		"please review my latest commit",
+		`{"state":"looks like status but has no kind field"}`,
+		"lgtm, merging now",
+	}, bodies)
+}

--- a/internal/board/agmsg_parse.go
+++ b/internal/board/agmsg_parse.go
@@ -1,0 +1,92 @@
+package board
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+// agmsgMessageRow is the JSONL shape api.sh's "messages" verb emits per
+// line: {"type":"message_sent","id","team","from","to","body","at"}. See
+// docs/agent-board.md's Integration with agmsg section.
+type agmsgMessageRow struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Team string `json:"team"`
+	From string `json:"from"`
+	To   string `json:"to"`
+	Body string `json:"body"`
+	At   string `json:"at"`
+}
+
+const agmsgMessageSentType = "message_sent"
+
+// parseAgmsgMessageRows decodes JSONL output from `api.sh get teams <team>
+// messages`, tagging every row with host (which AgmsgClient/host it came
+// from — not part of agmsg's own schema). A line that isn't valid JSON, or
+// doesn't parse as a message_sent record, is skipped rather than failing
+// the whole poll — matching this repository's existing JSONL-tolerance
+// convention (see internal/session/local.go's forEachJSONLRecord).
+func parseAgmsgMessageRows(data []byte, host string) []Row {
+	var rows []Row
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var raw agmsgMessageRow
+		if err := json.Unmarshal(line, &raw); err != nil {
+			continue
+		}
+		if raw.Type != agmsgMessageSentType {
+			continue
+		}
+		at, _ := time.Parse(time.RFC3339, raw.At)
+		rows = append(rows, Row{
+			ID:   raw.ID,
+			Host: host,
+			Team: raw.Team,
+			From: raw.From,
+			To:   raw.To,
+			Body: raw.Body,
+			At:   at,
+		})
+	}
+	return rows
+}
+
+// parseAgmsgID parses agmsg's own row id as the integer it is in today's
+// implementation. agmsg's source comments describe this as future-proofing
+// against a non-integer ID scheme; a row whose id doesn't parse this way is
+// signaled via ok == false rather than assumed to sort anywhere in
+// particular.
+func parseAgmsgID(id string) (int64, bool) {
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// filterRowsAfter returns the rows whose id sorts numerically after
+// afterID. There is no true "after" primitive in api.sh (see
+// docs/agent-board.md's Integration with agmsg section) — this is the
+// client-side filtering step every poll performs. An afterID that doesn't
+// parse (including the empty string used before any cursor exists) means
+// every row is "new". A row whose own id doesn't parse is conservatively
+// kept rather than dropped, since panemux cannot safely order it.
+func filterRowsAfter(rows []Row, afterID string) []Row {
+	afterN, ok := parseAgmsgID(afterID)
+	if !ok {
+		return rows
+	}
+	var out []Row
+	for _, r := range rows {
+		n, ok := parseAgmsgID(r.ID)
+		if !ok || n > afterN {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -1,0 +1,113 @@
+// Package board implements Agent Board: cross-pane Claude/Codex messaging
+// and status aggregation built entirely on agmsg (github.com/fujibee/agmsg).
+// See docs/agent-board.md for the full design this package implements.
+package board
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// SystemID is the reserved agmsg identity panemux's own relay and command
+// center use as their from/to for status reports and broadcasts. It is
+// deliberately not derived from the product name so a future rename of the
+// application would not need to change it. internal/config independently
+// rejects this same literal as a pane ID (see its own reservedSystemID);
+// the two are kept in sync by convention since internal/board must not
+// import internal/config.
+const SystemID = "_system"
+
+// statusKind is the required discriminator value for a status self-report.
+// Detecting a status update by JSON shape alone ("does this body happen to
+// have a state field") has a real false-positive edge — see
+// docs/agent-board.md's Status self-report section — so a literal
+// "kind": "board_status" is required, not merely permitted.
+const statusKind = "board_status"
+
+// Row is a single agmsg message, either an ordinary cross-pane message or a
+// status self-report addressed to SystemID.
+type Row struct {
+	At   time.Time
+	ID   string // agmsg's own id, host-scoped — NOT globally unique, NOT assumed numeric
+	Host string // which AgmsgClient/host this row came from
+	Team string
+	From string
+	To   string
+	Body string
+}
+
+// Status is a pane's self-reported state, decoded from a Row whose Body is
+// a board_status JSON payload.
+type Status struct {
+	UpdatedAt time.Time
+	State     string
+	CWD       string
+	Branch    string
+	Repo      string
+	PRURL     string
+	LastTool  string
+	Summary   string
+}
+
+// AgmsgClient is the only interface in panemux allowed to call agmsg's
+// scripts. LocalAgmsgClient and RemoteAgmsgClient are its two
+// implementations.
+type AgmsgClient interface {
+	HostID() string
+	// Send always passes --force. There is no non-forced Send: every
+	// board-originated message needs to reach a to/from identity that is
+	// not guaranteed to be in the destination team's roster.
+	Send(ctx context.Context, team, from, to, body string) error
+	// Since has no true "after" primitive to call into (api.sh has no such
+	// flag). It calls `api.sh get teams <team> messages --limit <limit>`
+	// and returns only rows whose ID sorts after afterID; the caller must
+	// treat the possibility of dropped rows as expected, not exceptional.
+	Since(ctx context.Context, team, afterID string, limit int) ([]Row, error)
+}
+
+type statusPayload struct {
+	Kind     string `json:"kind"`
+	State    string `json:"state"`
+	CWD      string `json:"cwd"`
+	Branch   string `json:"branch"`
+	Repo     string `json:"repo"`
+	PRURL    string `json:"pr_url"`
+	LastTool string `json:"last_tool"`
+	Summary  string `json:"summary"`
+}
+
+// ParseStatus decodes body as a status self-report. It returns ok == false
+// whenever body is not valid JSON, or is valid JSON but its "kind" field is
+// not exactly "board_status" — including JSON that merely resembles the
+// status shape (e.g. has a "state" field) by coincidence. This is
+// deliberate: a human typing an ordinary chat message that happens to parse
+// as JSON must never be silently swallowed into the status cache.
+func ParseStatus(body string) (Status, bool) {
+	var p statusPayload
+	if err := json.Unmarshal([]byte(body), &p); err != nil {
+		return Status{}, false
+	}
+	if p.Kind != statusKind {
+		return Status{}, false
+	}
+	return Status{
+		State:    p.State,
+		CWD:      p.CWD,
+		Branch:   p.Branch,
+		Repo:     p.Repo,
+		PRURL:    p.PRURL,
+		LastTool: p.LastTool,
+		Summary:  p.Summary,
+	}, true
+}
+
+// IsStatusRow reports whether row is a status self-report (addressed to
+// SystemID with a body_status-shaped body) rather than an ordinary
+// cross-pane message, returning the decoded Status when it is.
+func IsStatusRow(row Row) (Status, bool) {
+	if row.To != SystemID {
+		return Status{}, false
+	}
+	return ParseStatus(row.Body)
+}

--- a/internal/board/board_test.go
+++ b/internal/board/board_test.go
@@ -1,0 +1,104 @@
+package board
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStatus_ValidFullPayload(t *testing.T) {
+	body := `{
+		"kind": "board_status",
+		"state": "working",
+		"cwd": "/home/user/project",
+		"branch": "feature/x",
+		"repo": "owner/repo",
+		"pr_url": "https://github.com/owner/repo/pull/123",
+		"last_tool": "Edit internal/api/handler.go",
+		"summary": "fixing failing tests"
+	}`
+
+	got, ok := ParseStatus(body)
+	assert.True(t, ok)
+	assert.Equal(t, Status{
+		State:    "working",
+		CWD:      "/home/user/project",
+		Branch:   "feature/x",
+		Repo:     "owner/repo",
+		PRURL:    "https://github.com/owner/repo/pull/123",
+		LastTool: "Edit internal/api/handler.go",
+		Summary:  "fixing failing tests",
+	}, got)
+}
+
+func TestParseStatus_MissingOptionalFields(t *testing.T) {
+	got, ok := ParseStatus(`{"kind":"board_status","state":"idle"}`)
+	assert.True(t, ok)
+	assert.Equal(t, "idle", got.State)
+	assert.Empty(t, got.CWD)
+	assert.Empty(t, got.Branch)
+	assert.Empty(t, got.PRURL)
+}
+
+func TestParseStatus_NotValidJSON_FalseNotError(t *testing.T) {
+	_, ok := ParseStatus("hello there, not json at all")
+	assert.False(t, ok)
+}
+
+func TestParseStatus_ValidJSONMissingKind_TreatedAsPlainMessage(t *testing.T) {
+	// Regression test for the shape-sniffing ambiguity: a JSON body that
+	// happens to have a "state" field but no "kind" must not be mistaken
+	// for a status report.
+	_, ok := ParseStatus(`{"state":"working","cwd":"/tmp"}`)
+	assert.False(t, ok)
+}
+
+func TestParseStatus_ValidJSONWrongKind_TreatedAsPlainMessage(t *testing.T) {
+	_, ok := ParseStatus(`{"kind":"something_else","state":"working"}`)
+	assert.False(t, ok)
+}
+
+func TestParseStatus_EmptyBody_False(t *testing.T) {
+	_, ok := ParseStatus("")
+	assert.False(t, ok)
+}
+
+func TestIsStatusRow_AddressedToSystemWithStatusBody_True(t *testing.T) {
+	row := Row{
+		To:   SystemID,
+		Body: `{"kind":"board_status","state":"idle"}`,
+		At:   time.Now(),
+	}
+	status, ok := IsStatusRow(row)
+	require.True(t, ok)
+	assert.Equal(t, "idle", status.State)
+}
+
+func TestIsStatusRow_AddressedToOtherPane_False(t *testing.T) {
+	row := Row{
+		To:   "some-other-pane",
+		Body: `{"kind":"board_status","state":"idle"}`,
+	}
+	_, ok := IsStatusRow(row)
+	assert.False(t, ok)
+}
+
+func TestIsStatusRow_AddressedToSystemButPlainMessage_False(t *testing.T) {
+	row := Row{
+		To:   SystemID,
+		Body: "just chatting with the command center",
+	}
+	_, ok := IsStatusRow(row)
+	assert.False(t, ok)
+}
+
+func TestIsStatusRow_AddressedToSystemWithCoincidentalJSON_False(t *testing.T) {
+	row := Row{
+		To:   SystemID,
+		Body: `{"state":"looks like status but isn't"}`,
+	}
+	_, ok := IsStatusRow(row)
+	assert.False(t, ok)
+}

--- a/internal/board/cache.go
+++ b/internal/board/cache.go
@@ -1,0 +1,93 @@
+package board
+
+import (
+	"sync"
+	"time"
+)
+
+// defaultBoardCacheHistoryLimit bounds the in-memory history ring buffer.
+// It comfortably exceeds the relay's cold-start backfill limit (see
+// docs/agent-board.md's Cross-host relay section) so a freshly repopulated
+// cache isn't immediately trimmed back down.
+const defaultBoardCacheHistoryLimit = 2000
+
+type cachedRow struct {
+	Row Row
+	Seq int64
+}
+
+// BoardCache is the in-memory, panemux-owned view of recent board activity.
+// Only the relay (added in a later phase) writes to it, as a side effect of
+// its own polling; dashboard-facing endpoints only ever read it, never
+// calling AgmsgClient directly at request time. Seq is BoardCache's own
+// monotonically increasing, panemux-local sequence number — assigned here
+// because agmsg IDs from different hosts are not comparable or even
+// guaranteed non-colliding with each other.
+type BoardCache struct {
+	status     map[string]Status
+	now        func() time.Time
+	history    []cachedRow
+	nextSeq    int64
+	maxHistory int
+	mu         sync.RWMutex
+}
+
+// NewBoardCache returns an empty BoardCache, as it is on every panemux
+// process start (the cache is never persisted to disk).
+func NewBoardCache() *BoardCache {
+	return &BoardCache{
+		status:     make(map[string]Status),
+		now:        time.Now,
+		maxHistory: defaultBoardCacheHistoryLimit,
+	}
+}
+
+// RecordStatus stores s as paneID's latest self-reported status, overwriting
+// any previous status for that pane. UpdatedAt is set here, not by the
+// caller, to when the write actually happened.
+func (c *BoardCache) RecordStatus(paneID string, s Status) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s.UpdatedAt = c.now()
+	c.status[paneID] = s
+}
+
+// AppendMessage appends r to the history ring buffer, assigning it the next
+// Seq. When the buffer exceeds its bound, the oldest rows are dropped —
+// the same accepted truncation tradeoff the relay's own bounded polling
+// already makes (see docs/agent-board.md).
+func (c *BoardCache) AppendMessage(r Row) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextSeq++
+	c.history = append(c.history, cachedRow{Seq: c.nextSeq, Row: r})
+	if overflow := len(c.history) - c.maxHistory; overflow > 0 {
+		c.history = c.history[overflow:]
+	}
+}
+
+// StatusSnapshot returns a copy of the current pane-ID -> Status map.
+func (c *BoardCache) StatusSnapshot() map[string]Status {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make(map[string]Status, len(c.status))
+	for k, v := range c.status {
+		out[k] = v
+	}
+	return out
+}
+
+// MessagesSince returns every history row whose Seq is greater than
+// afterSeq, oldest first. An empty or fully-consumed history returns nil,
+// never an error.
+func (c *BoardCache) MessagesSince(afterSeq int64) []Row {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	var out []Row
+	for _, cr := range c.history {
+		if cr.Seq > afterSeq {
+			out = append(out, cr.Row)
+		}
+	}
+	return out
+}

--- a/internal/board/cache_test.go
+++ b/internal/board/cache_test.go
@@ -1,0 +1,137 @@
+package board
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoardCache_StatusSnapshot_EmptyOnFreshCache(t *testing.T) {
+	c := NewBoardCache()
+	assert.Empty(t, c.StatusSnapshot())
+}
+
+func TestBoardCache_RecordStatus_NewestWinsPerPane(t *testing.T) {
+	tick := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	c := NewBoardCache()
+	c.now = func() time.Time { return tick }
+
+	c.RecordStatus("pane-a", Status{State: "working"})
+	tick = tick.Add(time.Minute)
+	c.RecordStatus("pane-a", Status{State: "idle"})
+
+	snap := c.StatusSnapshot()
+	require.Contains(t, snap, "pane-a")
+	assert.Equal(t, "idle", snap["pane-a"].State)
+	assert.Equal(t, tick, snap["pane-a"].UpdatedAt)
+}
+
+func TestBoardCache_RecordStatus_AcrossMultiplePanes(t *testing.T) {
+	c := NewBoardCache()
+	c.RecordStatus("pane-a", Status{State: "working"})
+	c.RecordStatus("pane-b", Status{State: "idle"})
+
+	snap := c.StatusSnapshot()
+	require.Len(t, snap, 2)
+	assert.Equal(t, "working", snap["pane-a"].State)
+	assert.Equal(t, "idle", snap["pane-b"].State)
+}
+
+func TestBoardCache_RecordStatus_SetsUpdatedAt(t *testing.T) {
+	fixed := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	c := NewBoardCache()
+	c.now = func() time.Time { return fixed }
+
+	// UpdatedAt in the input Status must be overwritten by the cache's own
+	// clock, not trusted from the caller.
+	c.RecordStatus("pane-a", Status{State: "working", UpdatedAt: time.Time{}})
+
+	assert.Equal(t, fixed, c.StatusSnapshot()["pane-a"].UpdatedAt)
+}
+
+func TestBoardCache_AppendMessage_AssignsIncreasingSeq(t *testing.T) {
+	c := NewBoardCache()
+	c.AppendMessage(Row{ID: "1", Host: "host-a", Body: "first"})
+	c.AppendMessage(Row{ID: "1", Host: "host-b", Body: "second"}) // colliding agmsg ID, different host
+
+	rows := c.MessagesSince(0)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "first", rows[0].Body)
+	assert.Equal(t, "second", rows[1].Body)
+}
+
+func TestBoardCache_MessagesSince_FiltersByAfterSeq(t *testing.T) {
+	c := NewBoardCache()
+	c.AppendMessage(Row{Body: "one"})
+	c.AppendMessage(Row{Body: "two"})
+	c.AppendMessage(Row{Body: "three"})
+
+	rows := c.MessagesSince(1)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "two", rows[0].Body)
+	assert.Equal(t, "three", rows[1].Body)
+}
+
+func TestBoardCache_MessagesSince_EmptyHistory_ReturnsNilNotError(t *testing.T) {
+	c := NewBoardCache()
+	assert.Nil(t, c.MessagesSince(0))
+}
+
+func TestBoardCache_MessagesSince_AllConsumed_ReturnsNil(t *testing.T) {
+	c := NewBoardCache()
+	c.AppendMessage(Row{Body: "one"})
+	assert.Nil(t, c.MessagesSince(1))
+}
+
+func TestBoardCache_AppendMessage_BoundedHistory_DropsOldest(t *testing.T) {
+	c := NewBoardCache()
+	c.maxHistory = 3
+
+	for i := 0; i < 5; i++ {
+		c.AppendMessage(Row{Body: string(rune('a' + i))})
+	}
+
+	rows := c.MessagesSince(0)
+	require.Len(t, rows, 3)
+	assert.Equal(t, "c", rows[0].Body)
+	assert.Equal(t, "d", rows[1].Body)
+	assert.Equal(t, "e", rows[2].Body)
+}
+
+func TestBoardCache_AppendMessage_BoundedHistory_SeqKeepsIncreasingPastBound(t *testing.T) {
+	c := NewBoardCache()
+	c.maxHistory = 2
+
+	c.AppendMessage(Row{Body: "a"})
+	c.AppendMessage(Row{Body: "b"})
+	c.AppendMessage(Row{Body: "c"})
+
+	// Seq 1 ("a") was dropped by the bound; MessagesSince(0) must return
+	// only what survived (b, c), not error or resurrect the dropped row.
+	rows := c.MessagesSince(0)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "b", rows[0].Body)
+	assert.Equal(t, "c", rows[1].Body)
+}
+
+func TestBoardCache_ConcurrentReadWrite_NoRace(t *testing.T) {
+	c := NewBoardCache()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			c.AppendMessage(Row{Body: "x"})
+			c.RecordStatus("pane", Status{State: "working"})
+		}(i)
+		go func() {
+			defer wg.Done()
+			c.StatusSnapshot()
+			c.MessagesSince(0)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/board/ledger.go
+++ b/internal/board/ledger.go
@@ -1,0 +1,76 @@
+package board
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// defaultOwnSendLedgerTTL is how long a recorded Send stays matchable
+// against a later-observed row. "A few poll intervals" per
+// docs/agent-board.md's Package layout section — the relay this ledger
+// backs polls every few seconds, so this comfortably covers a handful of
+// poll cycles without accumulating stale entries indefinitely.
+const defaultOwnSendLedgerTTL = 30 * time.Second
+
+// ownSendKey identifies one Send call for own-send-ledger matching purposes.
+// Body is stored only as a hash, since the ledger's job is matching, not
+// re-displaying content.
+type ownSendKey struct {
+	DestHost string
+	Team     string
+	To       string
+	BodyHash string
+}
+
+// ownSendLedger is a short-lived, in-memory record of Send calls panemux
+// itself has issued (the broadcast handler and the command center), used
+// only to verify a row the relay later observes with From == SystemID
+// actually corresponds to one of panemux's own sends — send.sh --force
+// never checks From against a roster, so an ordinary board pane could
+// otherwise forge that identity. See docs/agent-board.md's Cross-host
+// relay and Security model sections.
+type ownSendLedger struct {
+	entries map[ownSendKey]time.Time // value is expiry
+	now     func() time.Time
+	mu      sync.Mutex
+	ttl     time.Duration
+}
+
+func newOwnSendLedger() *ownSendLedger {
+	return &ownSendLedger{
+		entries: make(map[ownSendKey]time.Time),
+		ttl:     defaultOwnSendLedgerTTL,
+		now:     time.Now,
+	}
+}
+
+func bodyHash(body string) string {
+	sum := sha256.Sum256([]byte(body))
+	return hex.EncodeToString(sum[:])
+}
+
+// Record inserts an entry for a Send panemux itself just issued, matchable
+// until it expires after l.ttl.
+func (l *ownSendLedger) Record(destHost, team, to, body string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
+	l.entries[key] = l.now().Add(l.ttl)
+}
+
+// Consume reports whether a matching, unexpired entry exists for the given
+// send parameters, deleting it either way (a consumed entry cannot be
+// matched twice, and an expired one is stale bookkeeping either way).
+func (l *ownSendLedger) Consume(destHost, team, to, body string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
+	expiry, ok := l.entries[key]
+	if !ok {
+		return false
+	}
+	delete(l.entries, key)
+	return !l.now().After(expiry)
+}

--- a/internal/board/ledger_test.go
+++ b/internal/board/ledger_test.go
@@ -1,0 +1,94 @@
+package board
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func TestOwnSendLedger_RecordThenConsume_Matches(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_ConsumeIsOneShot(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	require := assert.New(t)
+	require.True(l.Consume("host-b", "team", "pane-x", "hello"))
+	require.False(l.Consume("host-b", "team", "pane-x", "hello"), "a consumed entry must not match twice")
+}
+
+func TestOwnSendLedger_Consume_NoMatchingEntry_False(t *testing.T) {
+	l := newOwnSendLedger()
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_Consume_BodyMismatch_False(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "the real body")
+
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "a forged body"))
+}
+
+func TestOwnSendLedger_Consume_DestHostMismatch_False(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	assert.False(t, l.Consume("host-c", "team", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_Consume_TeamMismatch_False(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	assert.False(t, l.Consume("host-b", "other-team", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_Consume_ToMismatch_False(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	assert.False(t, l.Consume("host-b", "team", "pane-y", "hello"))
+}
+
+func TestOwnSendLedger_EmptyTeam_StillMatches(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "", "pane-x", "hello")
+
+	assert.True(t, l.Consume("host-b", "", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_ExpiredEntry_NoLongerMatchable(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := &ownSendLedger{
+		entries: make(map[ownSendKey]time.Time),
+		ttl:     time.Second,
+		now:     fixedClock(start),
+	}
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	l.now = fixedClock(start.Add(2 * time.Second))
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"), "expired entry must not match")
+}
+
+func TestOwnSendLedger_UnexpiredEntry_StillMatchable(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := &ownSendLedger{
+		entries: make(map[ownSendKey]time.Time),
+		ttl:     10 * time.Second,
+		now:     fixedClock(start),
+	}
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	l.now = fixedClock(start.Add(2 * time.Second))
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"))
+}

--- a/internal/board/local_client.go
+++ b/internal/board/local_client.go
@@ -1,0 +1,70 @@
+package board
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+)
+
+const boardHostIDLocal = "local"
+
+var _ AgmsgClient = (*LocalAgmsgClient)(nil)
+
+// runLocalCommandFn is injectable for tests.
+type runLocalCommandFn func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// execLocalCommand runs name/args as discrete argv elements with no
+// intermediate shell — see LocalAgmsgClient's own doc comment for why that
+// makes their content shell-injection-safe regardless of source.
+func execLocalCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	//nolint:gosec // G204: panemux-controlled agmsg script path, literal argv
+	out, err := exec.CommandContext(ctx, name, args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("exec %s: %w", name, err)
+	}
+	return out, nil
+}
+
+// LocalAgmsgClient shells out to the local agmsg installation's own
+// scripts: scripts/api.sh for reads, scripts/send.sh --force for writes.
+// Because this is a local exec.Command invocation, Go passes each argument
+// as a genuine array element with no intermediate shell, so no argument to
+// either script carries shell-injection risk here regardless of its
+// content.
+type LocalAgmsgClient struct {
+	run       runLocalCommandFn
+	agmsgPath string // directory containing scripts/api.sh, scripts/send.sh
+}
+
+// NewLocalAgmsgClient returns a client for the local agmsg installation
+// rooted at agmsgPath (already ~-expanded to an absolute path).
+func NewLocalAgmsgClient(agmsgPath string) *LocalAgmsgClient {
+	return &LocalAgmsgClient{agmsgPath: agmsgPath, run: execLocalCommand}
+}
+
+func (c *LocalAgmsgClient) HostID() string { return boardHostIDLocal }
+
+func (c *LocalAgmsgClient) apiScript() string { return filepath.Join(c.agmsgPath, "scripts", "api.sh") }
+func (c *LocalAgmsgClient) sendScript() string {
+	return filepath.Join(c.agmsgPath, "scripts", "send.sh")
+}
+
+// Send always passes --force — see docs/agent-board.md's Integration with
+// agmsg section for why every board-originated send does.
+func (c *LocalAgmsgClient) Send(ctx context.Context, team, from, to, body string) error {
+	_, err := c.run(ctx, c.sendScript(), team, from, to, body, "--force")
+	if err != nil {
+		return fmt.Errorf("agmsg send.sh: %w", err)
+	}
+	return nil
+}
+
+func (c *LocalAgmsgClient) Since(ctx context.Context, team, afterID string, limit int) ([]Row, error) {
+	out, err := c.run(ctx, c.apiScript(), "get", "teams", team, "messages", "--limit", strconv.Itoa(limit))
+	if err != nil {
+		return nil, fmt.Errorf("agmsg api.sh: %w", err)
+	}
+	return filterRowsAfter(parseAgmsgMessageRows(out, c.HostID()), afterID), nil
+}

--- a/internal/board/local_client_test.go
+++ b/internal/board/local_client_test.go
@@ -1,0 +1,144 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type localRunCall struct {
+	name string
+	args []string
+}
+
+func fakeLocalRun(calls *[]localRunCall, outputs map[string][]byte, errs map[string]error) runLocalCommandFn {
+	return func(_ context.Context, name string, args ...string) ([]byte, error) {
+		key := strings.Join(append([]string{name}, args...), " ")
+		*calls = append(*calls, localRunCall{name: name, args: args})
+		if err, ok := errs[key]; ok {
+			return outputs[key], err
+		}
+		if out, ok := outputs[key]; ok {
+			return out, nil
+		}
+		return nil, fmt.Errorf("unexpected local command: %s", key)
+	}
+}
+
+func TestLocalAgmsgClient_HostID(t *testing.T) {
+	c := NewLocalAgmsgClient("/opt/agmsg")
+	assert.Equal(t, "local", c.HostID())
+}
+
+func TestLocalAgmsgClient_Send_BuildsExpectedArgv(t *testing.T) {
+	var calls []localRunCall
+	sendScript := filepath.Join("/opt/agmsg", "scripts", "send.sh")
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, map[string][]byte{
+			sendScript + " team-a from-a to-a hello --force": []byte(""),
+		}, nil),
+	}
+
+	err := c.Send(context.Background(), "team-a", "from-a", "to-a", "hello")
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	assert.Equal(t, sendScript, calls[0].name)
+	assert.Equal(t, []string{"team-a", "from-a", "to-a", "hello", "--force"}, calls[0].args)
+}
+
+func TestLocalAgmsgClient_Send_MetacharacterBody_PassedAsSingleArgvElement(t *testing.T) {
+	var calls []localRunCall
+	body := `it's; $(evil) && ` + "`echo hi`"
+	sendScript := filepath.Join("/opt/agmsg", "scripts", "send.sh")
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, map[string][]byte{
+			sendScript + " team from to " + body + " --force": []byte(""),
+		}, nil),
+	}
+
+	err := c.Send(context.Background(), "team", "from", "to", body)
+	require.NoError(t, err)
+	require.Len(t, calls, 1)
+	// The body arrives as ONE argv element, unmodified — exec.Command
+	// passes discrete array elements with no intermediate shell, so
+	// metacharacters inside it are inert data, never shell syntax.
+	assert.Equal(t, body, calls[0].args[3])
+}
+
+func TestLocalAgmsgClient_Send_RunError_Wrapped(t *testing.T) {
+	var calls []localRunCall
+	sendScript := filepath.Join("/opt/agmsg", "scripts", "send.sh")
+	wantErr := errors.New("exit status 1")
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, nil, map[string]error{
+			sendScript + " team from to body --force": wantErr,
+		}),
+	}
+
+	err := c.Send(context.Background(), "team", "from", "to", "body")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestLocalAgmsgClient_Since_ParsesRowsAndFiltersByAfterID(t *testing.T) {
+	var calls []localRunCall
+	apiScript := filepath.Join("/opt/agmsg", "scripts", "api.sh")
+	jsonl := `{"type":"message_sent","id":"1","team":"t","from":"a","to":"b","body":"first","at":"2026-01-01T00:00:00Z"}
+{"type":"message_sent","id":"2","team":"t","from":"a","to":"b","body":"second","at":"2026-01-01T00:01:00Z"}
+`
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, map[string][]byte{
+			apiScript + " get teams t messages --limit 100": []byte(jsonl),
+		}, nil),
+	}
+
+	rows, err := c.Since(context.Background(), "t", "1", 100)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "second", rows[0].Body)
+	assert.Equal(t, "local", rows[0].Host)
+}
+
+func TestLocalAgmsgClient_Since_EmptyAfterID_ReturnsAllRows(t *testing.T) {
+	var calls []localRunCall
+	apiScript := filepath.Join("/opt/agmsg", "scripts", "api.sh")
+	jsonl := `{"type":"message_sent","id":"1","team":"t","from":"a","to":"b","body":"first","at":"2026-01-01T00:00:00Z"}
+`
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, map[string][]byte{
+			apiScript + " get teams t messages --limit 50": []byte(jsonl),
+		}, nil),
+	}
+
+	rows, err := c.Since(context.Background(), "t", "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+}
+
+func TestLocalAgmsgClient_Since_RunError_Wrapped(t *testing.T) {
+	var calls []localRunCall
+	apiScript := filepath.Join("/opt/agmsg", "scripts", "api.sh")
+	wantErr := errors.New("no such team")
+	c := &LocalAgmsgClient{
+		agmsgPath: "/opt/agmsg",
+		run: fakeLocalRun(&calls, nil, map[string]error{
+			apiScript + " get teams missing messages --limit 10": wantErr,
+		}),
+	}
+
+	rows, err := c.Since(context.Background(), "missing", "", 10)
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/internal/board/remote_client.go
+++ b/internal/board/remote_client.go
@@ -47,6 +47,12 @@ var validBase64 = regexp.MustCompile(`^[A-Za-z0-9+/]*={0,2}$`)
 const sendBase64WrapperScript = `send="$1"; team="$2"; from="$3"; to="$4"; ` +
 	`body=$(printf '%s' "$5" | base64 -d) && exec "$send" "$team" "$from" "$to" "$body" --force`
 
+// sendBase64WrapperScriptName is the dummy $0 value passed to the `sh -c`
+// invocation that runs sendBase64WrapperScript — it becomes the script's
+// $0, never inspected by the script itself, only present because `sh -c`
+// requires a name argument before the real positional parameters ($1..$5).
+const sendBase64WrapperScriptName = "board-send"
+
 func validateAgmsgIdentifier(label, value string) error {
 	if !validAgmsgIdentifier.MatchString(value) {
 		return fmt.Errorf("agmsg: invalid %s %q: must match %s", label, value, validAgmsgIdentifier)
@@ -89,7 +95,7 @@ func (c *RemoteAgmsgClient) Send(ctx context.Context, team, from, to, body strin
 	}
 
 	args := []string{
-		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"sh", "-c", sendBase64WrapperScript, sendBase64WrapperScriptName,
 		c.sendScript(), team, from, to, encoded,
 	}
 	if _, err := c.executor.RunBoardCommand(ctx, args); err != nil {

--- a/internal/board/remote_client.go
+++ b/internal/board/remote_client.go
@@ -1,0 +1,125 @@
+package board
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// BoardExecutor is satisfied by any session capable of running a command on
+// a remote host over its own exec channel. internal/session's SSHSession
+// and TmuxSSHSession both implement this structurally; internal/board does
+// not import internal/session to avoid a dependency it does not otherwise
+// need — see docs/agent-board.md's internal/session capability interfaces
+// section for the canonical definition this mirrors.
+type BoardExecutor interface {
+	RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
+}
+
+// validAgmsgIdentifier constrains team/from/to values (pane IDs, the
+// configured team name, or SystemID) to a safe, constrained alphabet before
+// they are ever placed in a RunBoardCommand argument list — the same
+// regex-allowlist-then-quote shape internal/session/ssh.go's
+// validRemotePath already applies to cwd.
+var validAgmsgIdentifier = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+
+// validBase64 constrains an already base64-encoded message body to its own
+// alphabet before it is placed in a RunBoardCommand argument list. A
+// message body is arbitrary agent-authored text and cannot be
+// regex-allowlisted directly the way an identifier or path can — encoding
+// it to a fixed alphabet first, then allowlisting the *encoded* string,
+// mirrors validRemotePath's accepted shape for a value that couldn't
+// otherwise take it. See docs/security.md and docs/agent-board.md's
+// Security model section.
+var validBase64 = regexp.MustCompile(`^[A-Za-z0-9+/]*={0,2}$`)
+
+// sendBase64WrapperScript is a fixed script string, never built from
+// tainted input: every piece of caller-supplied data ($1 through $5) is
+// delivered as a separate, already-quoted shell positional parameter by
+// RunBoardCommand/quoteArgs, never interpolated into this script text.
+// send.sh has no stdin option for its body argument (see
+// docs/agent-board.md's Integration with agmsg section), so this decodes
+// the base64-encoded body back to its original bytes remotely, immediately
+// before the one call site that needs the raw value.
+const sendBase64WrapperScript = `send="$1"; team="$2"; from="$3"; to="$4"; ` +
+	`body=$(printf '%s' "$5" | base64 -d) && exec "$send" "$team" "$from" "$to" "$body" --force`
+
+func validateAgmsgIdentifier(label, value string) error {
+	if !validAgmsgIdentifier.MatchString(value) {
+		return fmt.Errorf("agmsg: invalid %s %q: must match %s", label, value, validAgmsgIdentifier)
+	}
+	return nil
+}
+
+var _ AgmsgClient = (*RemoteAgmsgClient)(nil)
+
+// RemoteAgmsgClient runs agmsg's scripts on a remote host over the SSH exec
+// channel a session's BoardExecutor already exposes.
+type RemoteAgmsgClient struct {
+	executor  BoardExecutor
+	hostID    string
+	agmsgPath string // remote directory containing scripts/api.sh, scripts/send.sh (already ~-expanded)
+}
+
+// NewRemoteAgmsgClient returns a client for the agmsg installation rooted
+// at agmsgPath on the host identified by hostID, reached through executor.
+func NewRemoteAgmsgClient(hostID, agmsgPath string, executor BoardExecutor) *RemoteAgmsgClient {
+	return &RemoteAgmsgClient{hostID: hostID, agmsgPath: agmsgPath, executor: executor}
+}
+
+func (c *RemoteAgmsgClient) HostID() string { return c.hostID }
+
+func (c *RemoteAgmsgClient) apiScript() string  { return c.agmsgPath + "/scripts/api.sh" }
+func (c *RemoteAgmsgClient) sendScript() string { return c.agmsgPath + "/scripts/send.sh" }
+
+// Send always passes --force (via sendBase64WrapperScript's fixed "exec ...
+// --force" tail) — see docs/agent-board.md's Integration with agmsg
+// section for why every board-originated send does.
+func (c *RemoteAgmsgClient) Send(ctx context.Context, team, from, to, body string) error {
+	if err := validateIdentifiers(team, from, to); err != nil {
+		return err
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+	if !validBase64.MatchString(encoded) {
+		return errors.New("agmsg: encoded body failed base64 allowlist validation")
+	}
+
+	args := []string{
+		"sh", "-c", sendBase64WrapperScript, "board-send",
+		c.sendScript(), team, from, to, encoded,
+	}
+	if _, err := c.executor.RunBoardCommand(ctx, args); err != nil {
+		return fmt.Errorf("agmsg send.sh (remote): %w", err)
+	}
+	return nil
+}
+
+func (c *RemoteAgmsgClient) Since(ctx context.Context, team, afterID string, limit int) ([]Row, error) {
+	if err := validateAgmsgIdentifier("team", team); err != nil {
+		return nil, err
+	}
+
+	args := []string{c.apiScript(), "get", "teams", team, "messages", "--limit", strconv.Itoa(limit)}
+	out, err := c.executor.RunBoardCommand(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("agmsg api.sh (remote): %w", err)
+	}
+	return filterRowsAfter(parseAgmsgMessageRows(out, c.HostID()), afterID), nil
+}
+
+func validateIdentifiers(team, from, to string) error {
+	if err := validateAgmsgIdentifier("team", team); err != nil {
+		return err
+	}
+	if err := validateAgmsgIdentifier("from", from); err != nil {
+		return err
+	}
+	if err := validateAgmsgIdentifier("to", to); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/board/remote_client_test.go
+++ b/internal/board/remote_client_test.go
@@ -40,7 +40,7 @@ func TestRemoteAgmsgClient_Send_BuildsWrapperScriptArgs(t *testing.T) {
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("hello"))
 	key := strings.Join([]string{
-		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"sh", "-c", sendBase64WrapperScript, sendBase64WrapperScriptName,
 		"/opt/agmsg/scripts/send.sh", "team-a", "from-a", "to-a", encoded,
 	}, "\x00")
 	exec.outputs[key] = []byte("")
@@ -60,7 +60,7 @@ func TestRemoteAgmsgClient_Send_MetacharacterBody_RoundTripsViaBase64(t *testing
 	body := `it's; $(evil) && ` + "`echo hi`" + ` | rm -rf /`
 	encoded := base64.StdEncoding.EncodeToString([]byte(body))
 	key := strings.Join([]string{
-		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"sh", "-c", sendBase64WrapperScript, sendBase64WrapperScriptName,
 		"/opt/agmsg/scripts/send.sh", "team", "from", "to", encoded,
 	}, "\x00")
 	exec.outputs[key] = []byte("")
@@ -113,7 +113,7 @@ func TestRemoteAgmsgClient_Send_ValidSystemIDIdentifier_Accepted(t *testing.T) {
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("status"))
 	key := strings.Join([]string{
-		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"sh", "-c", sendBase64WrapperScript, sendBase64WrapperScriptName,
 		"/opt/agmsg/scripts/send.sh", "panemux", "pane-a", SystemID, encoded,
 	}, "\x00")
 	exec.outputs[key] = []byte("")

--- a/internal/board/remote_client_test.go
+++ b/internal/board/remote_client_test.go
@@ -1,0 +1,169 @@
+package board
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeBoardExecutor struct {
+	outputs map[string][]byte
+	err     error
+	calls   [][]string
+}
+
+func (f *fakeBoardExecutor) RunBoardCommand(_ context.Context, args []string) ([]byte, error) {
+	f.calls = append(f.calls, args)
+	if f.err != nil {
+		return nil, f.err
+	}
+	key := strings.Join(args, "\x00")
+	if out, ok := f.outputs[key]; ok {
+		return out, nil
+	}
+	return nil, errors.New("unexpected board command args: " + strings.Join(args, " "))
+}
+
+func TestRemoteAgmsgClient_HostID(t *testing.T) {
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", &fakeBoardExecutor{})
+	assert.Equal(t, "host-a", c.HostID())
+}
+
+func TestRemoteAgmsgClient_Send_BuildsWrapperScriptArgs(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{}}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("hello"))
+	key := strings.Join([]string{
+		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"/opt/agmsg/scripts/send.sh", "team-a", "from-a", "to-a", encoded,
+	}, "\x00")
+	exec.outputs[key] = []byte("")
+
+	err := c.Send(context.Background(), "team-a", "from-a", "to-a", "hello")
+	require.NoError(t, err)
+	require.Len(t, exec.calls, 1)
+	assert.Equal(t, "sh", exec.calls[0][0])
+	assert.Equal(t, "-c", exec.calls[0][1])
+	assert.Equal(t, sendBase64WrapperScript, exec.calls[0][2])
+}
+
+func TestRemoteAgmsgClient_Send_MetacharacterBody_RoundTripsViaBase64(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{}}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	body := `it's; $(evil) && ` + "`echo hi`" + ` | rm -rf /`
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+	key := strings.Join([]string{
+		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"/opt/agmsg/scripts/send.sh", "team", "from", "to", encoded,
+	}, "\x00")
+	exec.outputs[key] = []byte("")
+
+	err := c.Send(context.Background(), "team", "from", "to", body)
+	require.NoError(t, err)
+	require.Len(t, exec.calls, 1)
+
+	// The encoded token itself must be pure base64 alphabet — no
+	// metacharacter from body may leak into the argument RunBoardCommand
+	// receives.
+	sentToken := exec.calls[0][8]
+	assert.True(t, validBase64.MatchString(sentToken))
+
+	decoded, decErr := base64.StdEncoding.DecodeString(sentToken)
+	require.NoError(t, decErr)
+	assert.Equal(t, body, string(decoded))
+}
+
+func TestRemoteAgmsgClient_Send_InvalidTeam_RejectedBeforeExecutorCall(t *testing.T) {
+	exec := &fakeBoardExecutor{}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	err := c.Send(context.Background(), "team; rm -rf /", "from", "to", "body")
+	require.Error(t, err)
+	assert.Empty(t, exec.calls, "executor must never be invoked once identifier validation fails")
+}
+
+func TestRemoteAgmsgClient_Send_InvalidFrom_Rejected(t *testing.T) {
+	exec := &fakeBoardExecutor{}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	err := c.Send(context.Background(), "team", "from $(evil)", "to", "body")
+	require.Error(t, err)
+	assert.Empty(t, exec.calls)
+}
+
+func TestRemoteAgmsgClient_Send_InvalidTo_Rejected(t *testing.T) {
+	exec := &fakeBoardExecutor{}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	err := c.Send(context.Background(), "team", "from", "to`whoami`", "body")
+	require.Error(t, err)
+	assert.Empty(t, exec.calls)
+}
+
+func TestRemoteAgmsgClient_Send_ValidSystemIDIdentifier_Accepted(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{}}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte("status"))
+	key := strings.Join([]string{
+		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"/opt/agmsg/scripts/send.sh", "panemux", "pane-a", SystemID, encoded,
+	}, "\x00")
+	exec.outputs[key] = []byte("")
+
+	err := c.Send(context.Background(), "panemux", "pane-a", SystemID, "status")
+	assert.NoError(t, err)
+}
+
+func TestRemoteAgmsgClient_Send_ExecutorError_Wrapped(t *testing.T) {
+	wantErr := errors.New("ssh: connection lost")
+	exec := &fakeBoardExecutor{err: wantErr}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	err := c.Send(context.Background(), "team", "from", "to", "body")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestRemoteAgmsgClient_Since_BuildsExpectedArgs(t *testing.T) {
+	jsonl := `{"type":"message_sent","id":"5","team":"t","from":"a","to":"b","body":"hi","at":"2026-01-01T00:00:00Z"}
+`
+	wantArgs := []string{"/opt/agmsg/scripts/api.sh", "get", "teams", "t", "messages", "--limit", "100"}
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		strings.Join(wantArgs, "\x00"): []byte(jsonl),
+	}}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	rows, err := c.Since(context.Background(), "t", "1", 100)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "hi", rows[0].Body)
+	assert.Equal(t, "host-a", rows[0].Host)
+}
+
+func TestRemoteAgmsgClient_Since_InvalidTeam_RejectedBeforeExecutorCall(t *testing.T) {
+	exec := &fakeBoardExecutor{}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	_, err := c.Since(context.Background(), "team with spaces", "", 100)
+	require.Error(t, err)
+	assert.Empty(t, exec.calls)
+}
+
+func TestRemoteAgmsgClient_Since_ExecutorError_Wrapped(t *testing.T) {
+	wantErr := errors.New("ssh: connection lost")
+	exec := &fakeBoardExecutor{err: wantErr}
+	c := NewRemoteAgmsgClient("host-a", "/opt/agmsg", exec)
+
+	rows, err := c.Since(context.Background(), "t", "", 10)
+	require.Error(t, err)
+	assert.Nil(t, rows)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/internal/board/testdata/agmsg-unpinned-handwritten/README.md
+++ b/internal/board/testdata/agmsg-unpinned-handwritten/README.md
@@ -1,0 +1,20 @@
+# Hand-written agmsg fixtures — awaiting real capture
+
+The fixtures in this directory are **not** captured from a real, pinned
+agmsg install. Attempting that in this session's sandbox failed on two
+independent grounds: `sqlite3` (one of agmsg's own runtime dependencies) is
+not installed, and this environment's network policy returns `403` for
+`github.com/fujibee/agmsg`, so neither installing agmsg nor cloning its
+source to verify script behavior against a real run was possible here.
+
+These files were instead written by hand to match the JSONL shape
+documented in [docs/agent-board.md](../../../../docs/agent-board.md)'s
+"Integration with agmsg" section, which is itself sourced from a prior
+reading of agmsg's own script source. They satisfy Tier 1 of the [agmsg
+compatibility contract](../../../../docs/agent-board.md#agmsg-compatibility-contract)
+— fast, hermetic parsing tests — but they cannot substitute for Tier 2 (a
+real, pinned agmsg install exercised in CI), and this directory's name
+(`agmsg-unpinned-handwritten`, not `agmsg-<real-version-tag>`) reflects
+that. Replace this directory's contents with real captured output the next
+time an environment with network access to GitHub and a working `sqlite3`
+is available, then rename it to the actual pinned version tag.

--- a/internal/board/testdata/agmsg-unpinned-handwritten/get_team_members.jsonl
+++ b/internal/board/testdata/agmsg-unpinned-handwritten/get_team_members.jsonl
@@ -1,0 +1,2 @@
+{"name": "pane-a", "types": "claude", "project": "/home/user/project"}
+{"name": "pane-b", "types": "codex", "project": "/home/user/other-project"}

--- a/internal/board/testdata/agmsg-unpinned-handwritten/get_team_messages.jsonl
+++ b/internal/board/testdata/agmsg-unpinned-handwritten/get_team_messages.jsonl
@@ -1,0 +1,4 @@
+{"type":"message_sent","id":"1","team":"panemux","from":"pane-a","to":"pane-b","body":"please review my latest commit","at":"2026-01-01T10:00:00Z"}
+{"type":"message_sent","id":"2","team":"panemux","from":"pane-a","to":"_system","body":"{\"kind\":\"board_status\",\"state\":\"working\",\"cwd\":\"/home/user/project\",\"branch\":\"feature/x\",\"repo\":\"owner/repo\",\"pr_url\":\"https://github.com/owner/repo/pull/123\",\"last_tool\":\"Edit internal/api/handler.go\",\"summary\":\"fixing failing tests\"}","at":"2026-01-01T10:01:00Z"}
+{"type":"message_sent","id":"3","team":"panemux","from":"pane-b","to":"_system","body":"{\"state\":\"looks like status but has no kind field\"}","at":"2026-01-01T10:02:00Z"}
+{"type":"message_sent","id":"4","team":"panemux","from":"pane-b","to":"pane-a","body":"lgtm, merging now","at":"2026-01-01T10:03:00Z"}

--- a/internal/board/testdata/agmsg-unpinned-handwritten/get_teams.jsonl
+++ b/internal/board/testdata/agmsg-unpinned-handwritten/get_teams.jsonl
@@ -1,0 +1,2 @@
+{"name": "panemux"}
+{"name": "other-team"}

--- a/internal/board/wrapper_script_integration_test.go
+++ b/internal/board/wrapper_script_integration_test.go
@@ -1,0 +1,76 @@
+package board
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// quoteArgsLikeSession mirrors internal/session's quoteArgs/shellQuotePath
+// exactly (single-quote each argument, escaping embedded single quotes,
+// join with spaces). It is duplicated here — rather than imported — because
+// internal/board deliberately does not depend on internal/session; this
+// test exists specifically to prove sendBase64WrapperScript survives that
+// real quoting discipline when actually interpreted by a POSIX shell, not
+// just against a fake executor.
+func quoteArgsLikeSession(args []string) string {
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
+	}
+	return strings.Join(quoted, " ")
+}
+
+// TestSendBase64WrapperScript_RealShell_DecodesMetacharacterBody proves the
+// full round trip end to end: RemoteAgmsgClient.Send's argument list, once
+// single-quote-escaped exactly as internal/session's RunBoardCommand would
+// escape it and handed to a real /bin/sh, decodes the base64-encoded body
+// back to its original bytes (including shell metacharacters) before the
+// stand-in send.sh script ever sees it — the property the whole
+// base64-wrapper design exists to guarantee.
+func TestSendBase64WrapperScript_RealShell_DecodesMetacharacterBody(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	if _, err := exec.LookPath("base64"); err != nil {
+		t.Skip("base64 not available")
+	}
+
+	dir := t.TempDir()
+	capturePath := filepath.Join(dir, "captured-argv")
+	sendStub := filepath.Join(dir, "send.sh")
+
+	// A stand-in for agmsg's real send.sh: dumps its argv, NUL-separated,
+	// to capturePath so the test can inspect exactly what it received.
+	stubScript := "#!/bin/sh\nprintf '%s\\0' \"$@\" > " + shellQuoteForTest(capturePath) + "\n"
+	//nolint:gosec // G306: test fixture needs the exec bit
+	require.NoError(t, os.WriteFile(sendStub, []byte(stubScript), 0700))
+
+	body := `it's; $(evil) && ` + "`echo hi`" + ` | rm -rf / ; "double" 'single'`
+	encoded := base64.StdEncoding.EncodeToString([]byte(body))
+
+	args := []string{
+		"sh", "-c", sendBase64WrapperScript, "board-send",
+		sendStub, "team-a", "from-a", "to-a", encoded,
+	}
+	cmd := quoteArgsLikeSession(args)
+
+	out, err := exec.CommandContext(context.Background(), "sh", "-c", cmd).CombinedOutput()
+	require.NoError(t, err, "shell command failed: %s", string(out))
+
+	captured, err := os.ReadFile(capturePath)
+	require.NoError(t, err)
+	fields := strings.Split(strings.TrimSuffix(string(captured), "\x00"), "\x00")
+
+	require.Equal(t, []string{"team-a", "from-a", "to-a", body, "--force"}, fields)
+}
+
+func shellQuoteForTest(path string) string {
+	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}

--- a/internal/board/wrapper_script_integration_test.go
+++ b/internal/board/wrapper_script_integration_test.go
@@ -56,7 +56,7 @@ func TestSendBase64WrapperScript_RealShell_DecodesMetacharacterBody(t *testing.T
 	encoded := base64.StdEncoding.EncodeToString([]byte(body))
 
 	args := []string{
-		"sh", "-c", sendBase64WrapperScript, "board-send",
+		"sh", "-c", sendBase64WrapperScript, sendBase64WrapperScriptName,
 		sendStub, "team-a", "from-a", "to-a", encoded,
 	}
 	cmd := quoteArgsLikeSession(args)

--- a/internal/config/agent_board.go
+++ b/internal/config/agent_board.go
@@ -1,0 +1,130 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultAgentBoardTeam = "panemux"
+	defaultAgmsgPath      = "~/.agents/skills/agmsg"
+
+	agentBoardModeMonitor = "monitor"
+	agentBoardModeTurn    = "turn"
+	agentBoardModeBoth    = "both"
+	agentBoardModeOff     = "off"
+
+	// reservedSystemID is the sentinel identity panemux's own relay and
+	// command center use as their agmsg from/to. It is deliberately not
+	// derived from the product name, since the application could be
+	// renamed without this reserved identity needing to change.
+	reservedSystemID = "_system"
+
+	authTokenByteLen = 32
+)
+
+const authTokenFileMode os.FileMode = 0600
+
+// AgentBoardConfig holds the top-level agent_board settings shared by every
+// board-enabled pane.
+type AgentBoardConfig struct {
+	Team      string `yaml:"team,omitempty"       json:"team,omitempty"`
+	AgmsgPath string `yaml:"agmsg_path,omitempty" json:"agmsg_path,omitempty"`
+}
+
+// CommandCenterConfig holds the top-level command_center settings.
+type CommandCenterConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+// PaneAgentBoardConfig holds per-pane agent_board overrides.
+type PaneAgentBoardConfig struct {
+	Enabled *bool  `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Mode    string `yaml:"mode,omitempty"    json:"mode,omitempty"`
+}
+
+func (c *Config) normalizeAgentBoard() {
+	if c.AgentBoard.Team == "" {
+		c.AgentBoard.Team = defaultAgentBoardTeam
+	}
+	if c.AgentBoard.AgmsgPath == "" {
+		c.AgentBoard.AgmsgPath = defaultAgmsgPath
+	}
+}
+
+func (c *Config) expandAgentBoardPaths() {
+	if strings.HasPrefix(c.AgentBoard.AgmsgPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			c.AgentBoard.AgmsgPath = filepath.Join(home, c.AgentBoard.AgmsgPath[2:])
+		}
+	}
+}
+
+// ensureAuthToken fills in Server.AuthToken when it is not already set,
+// either by reading a previously persisted token file or by generating and
+// persisting a new random token. Failure to resolve, read, or persist a
+// token is non-fatal: it is logged as a warning and AuthToken is left
+// empty, so Validate's non-loopback-requires-token rule remains the actual
+// enforcement point rather than Load/Default hard-failing for the common
+// loopback case.
+func (c *Config) ensureAuthToken() {
+	if c.Server.AuthToken != "" {
+		return
+	}
+
+	path, err := c.resolveAuthTokenPath()
+	if err != nil {
+		log.Printf("Warning: failed to resolve auth token path: %v", err)
+		return
+	}
+
+	if data, readErr := os.ReadFile(path); readErr == nil {
+		if token := strings.TrimSpace(string(data)); token != "" {
+			c.Server.AuthToken = token
+			c.authTokenFromFile = true
+			return
+		}
+	}
+
+	token, err := generateAuthToken()
+	if err != nil {
+		log.Printf("Warning: failed to generate auth token: %v", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		log.Printf("Warning: failed to create auth token directory: %v", err)
+		return
+	}
+	if err := os.WriteFile(path, []byte(token), authTokenFileMode); err != nil {
+		log.Printf("Warning: failed to persist auth token: %v", err)
+		return
+	}
+
+	c.Server.AuthToken = token
+	c.authTokenFromFile = true
+}
+
+func (c *Config) resolveAuthTokenPath() (string, error) {
+	if c.authTokenPath != "" {
+		return c.authTokenPath, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", "token"), nil
+}
+
+func generateAuthToken() (string, error) {
+	buf := make([]byte, authTokenByteLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generating auth token: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/internal/config/agent_board.go
+++ b/internal/config/agent_board.go
@@ -66,14 +66,19 @@ func (c *Config) expandAgentBoardPaths() {
 	}
 }
 
-// ensureAuthToken fills in Server.AuthToken when it is not already set,
+// EnsureAuthToken fills in Server.AuthToken when it is not already set,
 // either by reading a previously persisted token file or by generating and
 // persisting a new random token. Failure to resolve, read, or persist a
 // token is non-fatal: it is logged as a warning and AuthToken is left
 // empty, so Validate's non-loopback-requires-token rule remains the actual
-// enforcement point rather than Load/Default hard-failing for the common
+// enforcement point rather than this method hard-failing for the common
 // loopback case.
-func (c *Config) ensureAuthToken() {
+//
+// Deliberately not called by Load/Default/finishLoad — see finishLoad's own
+// doc comment for why. Callers that want the "auto-generate on first run"
+// behavior (currently only main.go's real startup path) must call this
+// explicitly after Load/LoadOrDefault has already succeeded.
+func (c *Config) EnsureAuthToken() {
 	if c.Server.AuthToken != "" {
 		return
 	}

--- a/internal/config/agent_board_test.go
+++ b/internal/config/agent_board_test.go
@@ -25,6 +25,12 @@ layout:
         type: local
 `
 
+// loadWithAuthTokenPath loads content the same way Load(path) would, but
+// lets the caller pre-set authTokenPath (impossible through the real Load
+// function, which always constructs a fresh, override-less Config
+// internally). It also calls EnsureAuthToken explicitly, mirroring what
+// main.go's real startup path does after Load succeeds — finishLoad itself
+// deliberately never calls EnsureAuthToken; see finishLoad's own comment.
 func loadWithAuthTokenPath(t *testing.T, content, tokenPath string) (*Config, error) {
 	t.Helper()
 	f := writeTempFile(t, content)
@@ -39,6 +45,7 @@ func loadWithAuthTokenPath(t *testing.T, content, tokenPath string) (*Config, er
 	if err := cfg.finishLoad(); err != nil {
 		return nil, err
 	}
+	cfg.EnsureAuthToken()
 	return &cfg, nil
 }
 
@@ -114,7 +121,31 @@ func TestEnsureAuthToken_WriteFailure_NonFatal_LoopbackHost(t *testing.T) {
 
 	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
 	require.NoError(t, err, "loopback host must load successfully even if token persistence fails")
-	assert.Empty(t, cfg.Server.AuthToken)
+	assert.Empty(t, cfg.Server.AuthToken,
+		"EnsureAuthToken must leave AuthToken empty, never panic or fatally error, on persistence failure")
+}
+
+func TestFinishLoad_NeverCallsEnsureAuthToken(t *testing.T) {
+	// Regression test: finishLoad (and therefore the real Load) must never
+	// touch the token file itself — only an explicit EnsureAuthToken call
+	// does. Point authTokenPath at a location finishLoad could plausibly
+	// have written to and confirm nothing appears there.
+	tokenPath := filepath.Join(t.TempDir(), "token")
+
+	f := writeTempFile(t, validConfigYAML)
+	data, err := os.ReadFile(f)
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	cfg.filePath = f
+	cfg.authTokenPath = tokenPath
+
+	require.NoError(t, cfg.finishLoad())
+	assert.Empty(t, cfg.Server.AuthToken, "finishLoad alone must never populate AuthToken")
+
+	_, statErr := os.Stat(tokenPath)
+	assert.True(t, os.IsNotExist(statErr), "finishLoad alone must never create the token file")
 }
 
 func TestValidate_NonLoopbackHost_EmptyToken_Error(t *testing.T) {
@@ -182,6 +213,53 @@ func TestValidate_AgentBoardMode_ValidValues_NoError(t *testing.T) {
 	}
 }
 
+func TestValidate_AgentBoardTeam_ReservedSystemID_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.Team = "_system"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent_board.team")
+	assert.Contains(t, err.Error(), "_system")
+}
+
+func TestValidate_AgentBoardTeam_Empty_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.Team = ""
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_AgentBoardTeam_NonReserved_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.Team = "my-team"
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_AgmsgPath_RelativePath_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.AgmsgPath = "relative/path"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent_board.agmsg_path")
+}
+
+func TestValidate_AgmsgPath_Empty_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.AgmsgPath = ""
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_AgmsgPath_AbsolutePath_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.AgmsgPath = "/opt/agmsg"
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_AgmsgPath_TildePrefixed_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.AgentBoard.AgmsgPath = "~/.agents/skills/agmsg"
+	assert.NoError(t, cfg.Validate())
+}
+
 func TestNormalizeAgentBoard_DefaultsTeamAndAgmsgPath(t *testing.T) {
 	home, err := os.UserHomeDir()
 	require.NoError(t, err)
@@ -218,14 +296,25 @@ layout:
 	assert.Equal(t, "/opt/agmsg", cfg.AgentBoard.AgmsgPath)
 }
 
-func TestDefault_SetsAgentBoardDefaultsAndToken(t *testing.T) {
+func TestDefault_SetsAgentBoardDefaultsAndLeavesTokenEmpty(t *testing.T) {
 	cfg := Default()
 	assert.Equal(t, "panemux", cfg.AgentBoard.Team)
 	assert.False(t, strings.HasPrefix(cfg.AgentBoard.AgmsgPath, "~/"))
-	// Default() uses the real token path; just assert it attempted
-	// resolution without erroring the whole call (AuthToken empty is
-	// also an acceptable outcome if the real home dir isn't writable).
-	_ = cfg.Server.AuthToken
+	// Default() must never touch the real filesystem for a token — see
+	// finishLoad's doc comment. AuthToken is only ever populated by an
+	// explicit EnsureAuthToken call, which the real startup path (main.go)
+	// makes but Default() itself never does.
+	assert.Empty(t, cfg.Server.AuthToken)
+}
+
+func TestDefault_EnsureAuthTokenExplicitly_Populates(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+
+	cfg := Default()
+	cfg.authTokenPath = tokenPath
+	cfg.EnsureAuthToken()
+
+	assert.NotEmpty(t, cfg.Server.AuthToken)
 }
 
 func TestSaveConfig_AutoGeneratedToken_NotWrittenBack(t *testing.T) {
@@ -237,7 +326,7 @@ func TestSaveConfig_AutoGeneratedToken_NotWrittenBack(t *testing.T) {
 	cfg.filePath = path
 	cfg.Server.AuthToken = ""
 	cfg.authTokenFromFile = false
-	cfg.ensureAuthToken()
+	cfg.EnsureAuthToken()
 	require.NotEmpty(t, cfg.Server.AuthToken)
 	require.True(t, cfg.authTokenFromFile)
 

--- a/internal/config/agent_board_test.go
+++ b/internal/config/agent_board_test.go
@@ -1,0 +1,297 @@
+package config
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const validConfigYAML = `
+server:
+  port: 8080
+  host: "127.0.0.1"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+
+func loadWithAuthTokenPath(t *testing.T, content, tokenPath string) (*Config, error) {
+	t.Helper()
+	f := writeTempFile(t, content)
+	data, err := os.ReadFile(f)
+	require.NoError(t, err)
+
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	cfg.filePath = f
+	cfg.authTokenPath = tokenPath
+
+	if err := cfg.finishLoad(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func TestEnsureAuthToken_GeneratesAndPersists_WhenAbsent(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "nested", "token")
+
+	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, cfg.Server.AuthToken)
+	_, decodeErr := hex.DecodeString(cfg.Server.AuthToken)
+	assert.NoError(t, decodeErr, "generated token should be hex-encoded")
+
+	info, statErr := os.Stat(tokenPath)
+	require.NoError(t, statErr, "token file should have been created")
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	persisted, readErr := os.ReadFile(tokenPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, cfg.Server.AuthToken, strings.TrimSpace(string(persisted)))
+}
+
+func TestEnsureAuthToken_ReadsExisting_WhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("existing-token-value\n"), 0600))
+
+	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-token-value", cfg.Server.AuthToken)
+
+	// Loading again must not regenerate/overwrite the existing token.
+	cfg2, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-token-value", cfg2.Server.AuthToken)
+}
+
+func TestEnsureAuthToken_DoesNotOverride_ExplicitYAMLToken(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("token-file-value"), 0600))
+
+	content := `
+server:
+  port: 8080
+  host: "127.0.0.1"
+  auth_token: "explicit-yaml-token"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+	cfg, err := loadWithAuthTokenPath(t, content, tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "explicit-yaml-token", cfg.Server.AuthToken)
+	assert.False(t, cfg.authTokenFromFile)
+
+	// The pre-existing token file must be left untouched.
+	data, readErr := os.ReadFile(tokenPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "token-file-value", string(data))
+}
+
+func TestEnsureAuthToken_WriteFailure_NonFatal_LoopbackHost(t *testing.T) {
+	// Point the token path's parent at a regular file, so MkdirAll fails.
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0600))
+	tokenPath := filepath.Join(blocker, "token")
+
+	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
+	require.NoError(t, err, "loopback host must load successfully even if token persistence fails")
+	assert.Empty(t, cfg.Server.AuthToken)
+}
+
+func TestValidate_NonLoopbackHost_EmptyToken_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Server.Host = "0.0.0.0"
+	cfg.Server.AuthToken = ""
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth_token")
+}
+
+func TestValidate_NonLoopbackHost_WithToken_NoError(t *testing.T) {
+	cfg := validConfig()
+	cfg.Server.Host = "0.0.0.0"
+	cfg.Server.AuthToken = "some-token"
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_LoopbackHost_EmptyToken_NoError(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "localhost", "::1", ""} {
+		t.Run(host, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Server.Host = host
+			cfg.Server.AuthToken = ""
+			assert.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestValidate_ReservedSystemPaneID_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.ID = "_system"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "_system")
+	assert.Contains(t, err.Error(), "reserved")
+}
+
+func TestValidate_ReservedSystemPaneID_AlongsideValidPanes_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children = []LayoutChild{
+		{Size: 50.0, Pane: &PaneConfig{ID: "_system", Type: "local"}},
+		{Size: 50.0, Pane: &PaneConfig{ID: "ok-pane", Type: "local"}},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "_system")
+}
+
+func TestValidate_AgentBoardMode_InvalidValue_Error(t *testing.T) {
+	cfg := validConfig()
+	cfg.Layout.Children[0].Pane.AgentBoard.Mode = "bogus"
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent_board.mode")
+}
+
+func TestValidate_AgentBoardMode_ValidValues_NoError(t *testing.T) {
+	for _, mode := range []string{"monitor", "turn", "both", "off", ""} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.Layout.Children[0].Pane.AgentBoard.Mode = mode
+			assert.NoError(t, cfg.Validate())
+		})
+	}
+}
+
+func TestNormalizeAgentBoard_DefaultsTeamAndAgmsgPath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
+	require.NoError(t, err)
+
+	assert.Equal(t, "panemux", cfg.AgentBoard.Team)
+	assert.Equal(t, filepath.Join(home, ".agents", "skills", "agmsg"), cfg.AgentBoard.AgmsgPath)
+	assert.False(t, strings.HasPrefix(cfg.AgentBoard.AgmsgPath, "~/"))
+}
+
+func TestNormalizeAgentBoard_PreservesExplicitTeam(t *testing.T) {
+	content := `
+server:
+  port: 8080
+  host: "127.0.0.1"
+agent_board:
+  team: "custom-team"
+  agmsg_path: "/opt/agmsg"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+`
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	cfg, err := loadWithAuthTokenPath(t, content, tokenPath)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-team", cfg.AgentBoard.Team)
+	assert.Equal(t, "/opt/agmsg", cfg.AgentBoard.AgmsgPath)
+}
+
+func TestDefault_SetsAgentBoardDefaultsAndToken(t *testing.T) {
+	cfg := Default()
+	assert.Equal(t, "panemux", cfg.AgentBoard.Team)
+	assert.False(t, strings.HasPrefix(cfg.AgentBoard.AgmsgPath, "~/"))
+	// Default() uses the real token path; just assert it attempted
+	// resolution without erroring the whole call (AuthToken empty is
+	// also an acceptable outcome if the real home dir isn't writable).
+	_ = cfg.Server.AuthToken
+}
+
+func TestSaveConfig_AutoGeneratedToken_NotWrittenBack(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	tokenPath := filepath.Join(t.TempDir(), "token")
+
+	cfg := Default()
+	cfg.authTokenPath = tokenPath
+	cfg.filePath = path
+	cfg.Server.AuthToken = ""
+	cfg.authTokenFromFile = false
+	cfg.ensureAuthToken()
+	require.NotEmpty(t, cfg.Server.AuthToken)
+	require.True(t, cfg.authTokenFromFile)
+
+	require.NoError(t, cfg.SaveLayout(cfg.Layout))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), cfg.Server.AuthToken)
+}
+
+func TestSaveConfig_ExplicitToken_WrittenBack(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+
+	cfg := Default()
+	cfg.filePath = path
+	cfg.Server.AuthToken = "explicit-token"
+	cfg.authTokenFromFile = false
+
+	require.NoError(t, cfg.SaveLayout(cfg.Layout))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "explicit-token")
+}
+
+func TestPaneAgentBoardConfig_YAMLRoundTrip(t *testing.T) {
+	content := `
+server:
+  port: 8080
+  host: "127.0.0.1"
+layout:
+  direction: horizontal
+  children:
+    - size: 100
+      pane:
+        id: main
+        type: local
+        agent_board:
+          enabled: true
+          mode: monitor
+`
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	cfg, err := loadWithAuthTokenPath(t, content, tokenPath)
+	require.NoError(t, err)
+
+	pane := cfg.Layout.Children[0].Pane
+	require.NotNil(t, pane.AgentBoard.Enabled)
+	assert.True(t, *pane.AgentBoard.Enabled)
+	assert.Equal(t, "monitor", pane.AgentBoard.Mode)
+}
+
+func TestPaneAgentBoardConfig_UnsetByDefault(t *testing.T) {
+	cfg := validConfig()
+	pane := cfg.Layout.Children[0].Pane
+	assert.Nil(t, pane.AgentBoard.Enabled)
+	assert.Empty(t, pane.AgentBoard.Mode)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,17 +126,32 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// finishLoad applies normalization, path expansion, auth-token resolution,
-// and validation to a Config whose raw fields (including any test-only
-// overrides such as authTokenPath) have already been set. Load uses this
-// directly; tests that need to set an override before validation runs call
-// it the same way, since Load itself has no way to inject an override into
-// the Config it constructs internally.
+// finishLoad applies normalization, path expansion, and validation to a
+// Config whose raw fields (including any test-only overrides such as
+// authTokenPath) have already been set. Load uses this directly; tests that
+// need to set an override before validation runs call it the same way,
+// since Load itself has no way to inject an override into the Config it
+// constructs internally.
+//
+// This deliberately does NOT call EnsureAuthToken: doing so here would mean
+// every caller of Load/Default — including the many pre-existing, otherwise
+// fully hermetic tests in this package that construct a config with no
+// authTokenPath override — would write a real token file to the invoking
+// process's actual $HOME as a side effect of loading a config, which is
+// exactly what DEVELOPMENT.md's testability rule exists to prevent. It also
+// changes what Validate's non-loopback-requires-token rule actually
+// enforces: if EnsureAuthToken ran first, a non-loopback host with no
+// explicit auth_token would always have a token silently filled in before
+// Validate ever saw it, and that check would only ever fire on a token-file
+// I/O failure. Running EnsureAuthToken only in the real startup path (see
+// main.go) after Load/LoadOrDefault has already succeeded makes that rule
+// mean what its own name says: an operator who points panemux at a
+// non-loopback host must have explicitly configured a token, not rely on
+// one having been silently generated for them.
 func (c *Config) finishLoad() error {
 	c.normalizeWorkspaces()
 	c.normalizeAgentBoard()
 	c.expandPaths()
-	c.ensureAuthToken()
 
 	if err := c.Validate(); err != nil {
 		return fmt.Errorf("invalid config: %w", err)
@@ -170,7 +185,6 @@ func Default() *Config {
 	}
 	cfg.normalizeAgentBoard()
 	cfg.expandAgentBoardPaths()
-	cfg.ensureAuthToken()
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,8 +27,9 @@ const (
 var chmodConfigFile = os.Chmod
 
 type ServerConfig struct {
-	Host string `yaml:"host"`
-	Port int    `yaml:"port"`
+	Host      string `yaml:"host"`
+	AuthToken string `yaml:"auth_token,omitempty"`
+	Port      int    `yaml:"port"`
 }
 
 type SSHConnection struct {
@@ -46,15 +47,16 @@ type DisplayConfig struct {
 }
 
 type PaneConfig struct {
-	ShowHeader    *bool  `yaml:"show_header,omitempty"    json:"show_header,omitempty"`
-	ShowStatusBar *bool  `yaml:"show_status_bar,omitempty" json:"show_status_bar,omitempty"`
-	ID            string `yaml:"id"           json:"id"`
-	Type          string `yaml:"type"         json:"type"` // local | ssh | tmux | ssh_tmux
-	Shell         string `yaml:"shell,omitempty"        json:"shell,omitempty"`
-	Cwd           string `yaml:"cwd,omitempty"          json:"cwd,omitempty"`
-	Title         string `yaml:"title,omitempty"        json:"title,omitempty"`
-	Connection    string `yaml:"connection,omitempty"   json:"connection,omitempty"` // ssh_connections key
-	TmuxSession   string `yaml:"tmux_session,omitempty" json:"tmux_session,omitempty"`
+	ShowHeader    *bool                `yaml:"show_header,omitempty"    json:"show_header,omitempty"`
+	ShowStatusBar *bool                `yaml:"show_status_bar,omitempty" json:"show_status_bar,omitempty"`
+	ID            string               `yaml:"id"           json:"id"`
+	Type          string               `yaml:"type"         json:"type"` // local | ssh | tmux | ssh_tmux
+	Shell         string               `yaml:"shell,omitempty"        json:"shell,omitempty"`
+	Cwd           string               `yaml:"cwd,omitempty"          json:"cwd,omitempty"`
+	Title         string               `yaml:"title,omitempty"        json:"title,omitempty"`
+	Connection    string               `yaml:"connection,omitempty"   json:"connection,omitempty"` // ssh_connections key
+	TmuxSession   string               `yaml:"tmux_session,omitempty" json:"tmux_session,omitempty"`
+	AgentBoard    PaneAgentBoardConfig `yaml:"agent_board,omitempty" json:"agent_board,omitempty"`
 }
 
 type LayoutNode struct {
@@ -92,9 +94,13 @@ type Config struct { //nolint:govet
 	Workspaces     WorkspacesConfig         `yaml:"workspaces,omitempty" json:"workspaces"`
 	Layout         LayoutNode               `yaml:"layout,omitempty"`
 	Display        DisplayConfig            `yaml:"display,omitempty" json:"display"`
+	AgentBoard     AgentBoardConfig         `yaml:"agent_board,omitempty" json:"agent_board"`
+	CommandCenter  CommandCenterConfig      `yaml:"command_center,omitempty" json:"command_center"`
 
-	filePath      string
-	sshConfigPath string // overridable for tests; empty = use sshconfig.DefaultPath()
+	filePath          string
+	sshConfigPath     string // overridable for tests; empty = use sshconfig.DefaultPath()
+	authTokenPath     string // overridable for tests; empty = use ~/.config/panemux/token
+	authTokenFromFile bool   // true when AuthToken came from the token file, not from config.yaml
 }
 
 func Load(path string) (*Config, error) {
@@ -109,11 +115,8 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg.filePath = path
-	cfg.normalizeWorkspaces()
-	cfg.expandPaths()
-
-	if err := cfg.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid config: %w", err)
+	if err := cfg.finishLoad(); err != nil {
+		return nil, err
 	}
 	if err := tightenConfigFilePermissions(path); err != nil {
 		//nolint:gosec // G706: local filesystem warning
@@ -123,8 +126,26 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+// finishLoad applies normalization, path expansion, auth-token resolution,
+// and validation to a Config whose raw fields (including any test-only
+// overrides such as authTokenPath) have already been set. Load uses this
+// directly; tests that need to set an override before validation runs call
+// it the same way, since Load itself has no way to inject an override into
+// the Config it constructs internally.
+func (c *Config) finishLoad() error {
+	c.normalizeWorkspaces()
+	c.normalizeAgentBoard()
+	c.expandPaths()
+	c.ensureAuthToken()
+
+	if err := c.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+	return nil
+}
+
 func Default() *Config {
-	return &Config{
+	cfg := &Config{
 		Server: ServerConfig{
 			Port: 8080,
 			Host: defaultServerHost,
@@ -147,6 +168,10 @@ func Default() *Config {
 			},
 		},
 	}
+	cfg.normalizeAgentBoard()
+	cfg.expandAgentBoardPaths()
+	cfg.ensureAuthToken()
+	return cfg
 }
 
 func defaultLayout() LayoutNode {
@@ -387,12 +412,25 @@ func (c *Config) write() error {
 		SSHConnections map[string]SSHConnection `yaml:"ssh_connections,omitempty"`
 		Workspaces     WorkspacesConfig         `yaml:"workspaces,omitempty"`
 		Display        DisplayConfig            `yaml:"display,omitempty"`
+		AgentBoard     AgentBoardConfig         `yaml:"agent_board,omitempty"`
+		CommandCenter  CommandCenterConfig      `yaml:"command_center,omitempty"`
 	}
+
+	server := c.Server
+	if c.authTokenFromFile {
+		// The token came from the token file (auto-generated or read from
+		// disk there), not from an operator-set config.yaml value — never
+		// echo it back into config.yaml.
+		server.AuthToken = ""
+	}
+
 	data, err := yaml.Marshal(configFile{
-		Server:         c.Server,
+		Server:         server,
 		SSHConnections: c.SSHConnections,
 		Workspaces:     c.Workspaces,
 		Display:        c.Display,
+		AgentBoard:     c.AgentBoard,
+		CommandCenter:  c.CommandCenter,
 	})
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
@@ -420,6 +458,7 @@ func (c *Config) expandPaths() {
 	if active, ok := c.ActiveWorkspace(); ok {
 		c.Layout = active.Layout
 	}
+	c.expandAgentBoardPaths()
 }
 
 func expandPanesCwd(children []LayoutChild) {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -33,6 +34,13 @@ func (c *Config) Validate() error {
 
 	if c.Server.Port < 1 || c.Server.Port > 65535 {
 		errs = append(errs, fmt.Sprintf("server.port %d is out of range (1-65535)", c.Server.Port))
+	}
+
+	if !isLoopbackHost(c.Server.Host) && c.Server.AuthToken == "" {
+		errs = append(errs, fmt.Sprintf(
+			"server.auth_token must be set when server.host %q is not loopback",
+			c.Server.Host,
+		))
 	}
 
 	sshConns := c.SSHConnections
@@ -201,6 +209,9 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 	if p.ID == "" {
 		errs = append(errs, "pane id must not be empty")
 	}
+	if p.ID == reservedSystemID {
+		errs = append(errs, fmt.Sprintf("pane id %q is reserved and cannot be used", reservedSystemID))
+	}
 
 	switch p.Type {
 	case paneTypeLocal, paneTypeSSH, paneTypeTmux, paneTypeSSHTmux:
@@ -230,6 +241,8 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 		errs = append(errs, fmt.Sprintf("pane %q: shell must be an absolute path, got %q", p.ID, p.Shell))
 	}
 
+	errs = append(errs, validatePaneAgentBoardMode(p)...)
+
 	if p.Type == paneTypeTmux || p.Type == paneTypeSSHTmux {
 		if p.TmuxSession == "" {
 			errs = append(errs, fmt.Sprintf("pane %q: tmux_session must not be empty", p.ID))
@@ -247,4 +260,36 @@ func validatePane(p *PaneConfig, sshConns map[string]SSHConnection) []string {
 	}
 
 	return errs
+}
+
+func validatePaneAgentBoardMode(p *PaneConfig) []string {
+	mode := p.AgentBoard.Mode
+	if mode == "" {
+		return nil
+	}
+	switch mode {
+	case agentBoardModeMonitor, agentBoardModeTurn, agentBoardModeBoth, agentBoardModeOff:
+		return nil
+	default:
+		return []string{fmt.Sprintf(
+			"pane %q: agent_board.mode %q must be monitor, turn, both, or off",
+			p.ID,
+			mode,
+		)}
+	}
+}
+
+// isLoopbackHost reports whether host is a loopback address panemux treats
+// as not requiring an auth token. An empty host is treated as loopback
+// since Default()/normalizeWorkspaces() fill in the loopback default before
+// Validate ever runs against a config that omitted server.host entirely.
+func isLoopbackHost(host string) bool {
+	if host == "" || host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -43,6 +43,8 @@ func (c *Config) Validate() error {
 		))
 	}
 
+	errs = append(errs, validateAgentBoard(c.AgentBoard)...)
+
 	sshConns := c.SSHConnections
 	if sshConns == nil {
 		sshConns = make(map[string]SSHConnection)
@@ -277,6 +279,22 @@ func validatePaneAgentBoardMode(p *PaneConfig) []string {
 			mode,
 		)}
 	}
+}
+
+// validateAgentBoard checks the top-level agent_board settings. Both fields
+// tolerate being empty here (Validate can run before normalizeAgentBoard has
+// filled in defaults — see finishLoad), matching the same "only validate a
+// path-like field when it's actually set" pattern validatePane already uses
+// for a pane's Shell.
+func validateAgentBoard(ab AgentBoardConfig) []string {
+	var errs []string
+	if ab.Team == reservedSystemID {
+		errs = append(errs, fmt.Sprintf("agent_board.team must not be the reserved id %q", reservedSystemID))
+	}
+	if path := ab.AgmsgPath; path != "" && !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "~/") {
+		errs = append(errs, fmt.Sprintf("agent_board.agmsg_path %q must be an absolute path or start with ~/", path))
+	}
+	return errs
 }
 
 // isLoopbackHost reports whether host is a loopback address panemux treats

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+const bearerPrefix = "Bearer "
+
+// bearerAuthMiddleware rejects any request whose Authorization header does
+// not carry exactly "Bearer <token>" for the given token, using a
+// constant-time comparison so response timing cannot be used to guess the
+// token byte-by-byte. It runs before next.ServeHTTP is ever called, so
+// wrapping a WebSocket upgrade handler with it rejects the handshake before
+// any upgrade attempt — no separate WS-specific logic is needed.
+//
+// This middleware is not yet wired into registerRoutes: doing so today
+// would require every existing, currently-unauthenticated frontend request
+// to start sending a token it doesn't have. It is built and tested standalone
+// so a later change can connect it once there is an auth-aware frontend and
+// board endpoints to protect — see docs/agent-board.md's API additions
+// section.
+func bearerAuthMiddleware(token string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !validBearerToken(r.Header.Get("Authorization"), token) {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// validBearerToken reports whether header is exactly "Bearer <token>" for a
+// non-empty token, so a config with no token configured always rejects
+// (fail closed) rather than accepting any request.
+func validBearerToken(header, token string) bool {
+	if token == "" || !strings.HasPrefix(header, bearerPrefix) {
+		return false
+	}
+	provided := strings.TrimPrefix(header, bearerPrefix)
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(token)) == 1
+}

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func okHandler() (http.Handler, *bool) {
+	called := false
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	return h, &called
+}
+
+func TestBearerAuthMiddleware_MissingHeader_Rejected(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called, "the wrapped handler must never run when auth fails")
+}
+
+func TestBearerAuthMiddleware_WrongToken_Rejected(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called)
+}
+
+func TestBearerAuthMiddleware_MissingBearerPrefix_Rejected(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "secret-token") // no "Bearer " prefix
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called)
+}
+
+func TestBearerAuthMiddleware_EmptyAuthorizationHeader_Rejected(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called)
+}
+
+func TestBearerAuthMiddleware_ConfiguredTokenEmpty_AlwaysRejects(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called, "an empty configured token must fail closed, never match any request")
+}
+
+func TestBearerAuthMiddleware_CorrectToken_PassesThrough(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, *called)
+}
+
+// TestBearerAuthMiddleware_WSHandshakeStyleRequest_RejectedBeforeUpgrade
+// proves the same middleware protects a WebSocket handshake: wrapping a
+// handler that simulates ws.Handler's own upgrade attempt, an
+// unauthenticated request carrying the standard WS upgrade headers is
+// rejected before that handler — and therefore before any upgrade — runs.
+func TestBearerAuthMiddleware_WSHandshakeStyleRequest_RejectedBeforeUpgrade(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws/board-command", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.False(t, *called, "the WS handler must never see the request, so no upgrade can happen")
+}
+
+func TestBearerAuthMiddleware_WSHandshakeStyleRequest_CorrectToken_PassesThrough(t *testing.T) {
+	inner, called := okHandler()
+	handler := bearerAuthMiddleware("secret-token")(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/ws/board-command", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Authorization", "Bearer secret-token")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.True(t, *called)
+}
+
+func TestValidBearerToken_TableDriven(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		token  string
+		want   bool
+	}{
+		{"exact match", "Bearer abc123", "abc123", true},
+		{"wrong token", "Bearer wrong", "abc123", false},
+		{"no prefix", "abc123", "abc123", false},
+		{"empty header", "", "abc123", false},
+		{"empty configured token", "Bearer ", "", false},
+		{"case-sensitive prefix", "bearer abc123", "abc123", false},
+		{"trailing whitespace differs", "Bearer abc123 ", "abc123", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, validBearerToken(tt.header, tt.token))
+		})
+	}
+}

--- a/internal/session/board_test.go
+++ b/internal/session/board_test.go
@@ -1,0 +1,114 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalSession_BoardHostID_ReturnsLocal(t *testing.T) {
+	s := &LocalSession{}
+	assert.Equal(t, "local", s.BoardHostID())
+}
+
+func TestTmuxLocalSession_BoardHostID_ReturnsLocal(t *testing.T) {
+	s := &TmuxLocalSession{}
+	assert.Equal(t, "local", s.BoardHostID())
+}
+
+func TestSSHSession_BoardHostID_ReturnsConnectionName(t *testing.T) {
+	s := &SSHSession{connectionName: "my-server"}
+	assert.Equal(t, "my-server", s.BoardHostID())
+}
+
+func TestTmuxSSHSession_BoardHostID_ReturnsConnectionName(t *testing.T) {
+	s := &TmuxSSHSession{connectionName: "remote-box"}
+	assert.Equal(t, "remote-box", s.BoardHostID())
+}
+
+func TestQuoteArgs_EscapesShellMetacharacters(t *testing.T) {
+	got := quoteArgs([]string{"send.sh", "team", "from", "to", `it's; $(evil) && ` + "`echo hi`"})
+	assert.Equal(
+		t,
+		`'send.sh' 'team' 'from' 'to' 'it'\''s; $(evil) && `+"`echo hi`"+`'`,
+		got,
+	)
+}
+
+func TestQuoteArgs_EmptyList(t *testing.T) {
+	assert.Equal(t, "", quoteArgs(nil))
+}
+
+func TestRunBoardCommand_BuildsQuotedCommandAndReturnsOutput(t *testing.T) {
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			`'send.sh' 'team' 'a' 'b' 'hello world'`: []byte("ok\n"),
+		},
+	}
+
+	out, err := runBoardCommand(context.Background(), func() (sshSessionRunner, error) {
+		return runner, nil
+	}, []string{"send.sh", "team", "a", "b", "hello world"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok\n", string(out))
+}
+
+func TestRunBoardCommand_MetacharacterBody_RoundTripsAsSingleArgument(t *testing.T) {
+	body := `it's; $(evil) && ` + "`echo hi`"
+	cmd := `'send.sh' 'team' 'a' 'b' ` + shellQuotePath(body)
+	runner := &fakeSSHRunner{
+		outputs: map[string][]byte{
+			cmd: []byte("ok\n"),
+		},
+	}
+
+	out, err := runBoardCommand(context.Background(), func() (sshSessionRunner, error) {
+		return runner, nil
+	}, []string{"send.sh", "team", "a", "b", body})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok\n", string(out))
+}
+
+func TestRunBoardCommand_NewSessionError_Propagates(t *testing.T) {
+	wantErr := errors.New("dial failed")
+	_, err := runBoardCommand(context.Background(), func() (sshSessionRunner, error) {
+		return nil, wantErr
+	}, []string{"api.sh"})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestRunBoardCommand_OutputError_Propagates(t *testing.T) {
+	runner := &fakeSSHRunner{
+		errs: map[string]error{
+			`'api.sh'`: errors.New("remote failure"),
+		},
+	}
+
+	_, err := runBoardCommand(context.Background(), func() (sshSessionRunner, error) {
+		return runner, nil
+	}, []string{"api.sh"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote failure")
+}
+
+func TestRunBoardCommand_ContextAlreadyCanceled_NeverOpensSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	_, err := runBoardCommand(ctx, func() (sshSessionRunner, error) {
+		called = true
+		return nil, nil
+	}, []string{"api.sh"})
+
+	require.Error(t, err)
+	assert.False(t, called, "newSession must not be invoked once ctx is already canceled")
+}

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -130,6 +130,9 @@ func (s *LocalSession) Close() error {
 	return nil
 }
 
+// BoardHostID identifies this session as running on panemux's own host.
+func (s *LocalSession) BoardHostID() string { return boardHostIDLocal }
+
 // GetCWD returns the current working directory of the shell process.
 // On Linux it reads /proc/<pid>/cwd; on macOS it runs lsof.
 func (s *LocalSession) GetCWD() (string, error) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,6 +1,9 @@
 package session
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // Type represents the type of terminal session.
 type Type string
@@ -83,6 +86,30 @@ type GitContextGetter interface {
 // SSHConnNamer is implemented by sessions that have an SSH connection name.
 type SSHConnNamer interface {
 	ConnectionName() string
+}
+
+// boardHostIDLocal is the BoardHostID value shared by every local/tmux-local
+// session, identifying the host panemux itself runs on.
+const boardHostIDLocal = "local"
+
+// BoardHostID is implemented by every session type. It returns the
+// identifier of the host whose agmsg installation this session's pane
+// participates in: "local" for local/tmux sessions, the SSH connection
+// name for ssh/ssh_tmux sessions.
+type BoardHostID interface {
+	BoardHostID() string
+}
+
+// BoardExecutor is implemented by SSH-backed sessions. It runs an agmsg
+// script on the remote host over the session's existing exec channel, as a
+// single shell command string built from args. RunBoardCommand itself
+// single-quote-escapes every element of args (the same discipline
+// internal/session/ssh.go already applies to cwd) before building that
+// string — the caller passes raw, unescaped values, exactly like
+// exec.Command's own argv contract, so there is exactly one place this can
+// be gotten wrong rather than one per call site.
+type BoardExecutor interface {
+	RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
 }
 
 // DirectoryEntry represents a browsable directory in a filesystem tree.

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/hmac"
 	"crypto/sha1" //nolint:gosec // G505: OpenSSH hashed known_hosts entries use HMAC-SHA1
 	"encoding/base64"
@@ -74,6 +75,59 @@ type SSHConfig struct {
 // within the path, making it safe to embed in a POSIX shell command.
 func shellQuotePath(path string) string {
 	return "'" + strings.ReplaceAll(path, "'", `'\''`) + "'"
+}
+
+// quoteArgs joins args into a single POSIX shell command string, with every
+// argument single-quote-escaped via shellQuotePath. This is the only place
+// that builds a board command string from a caller-supplied argument list,
+// matching the discipline validRemotePath/shellQuotePath already apply to
+// cwd — callers pass raw, unescaped values, exactly like exec.Command's own
+// argv contract.
+func quoteArgs(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = shellQuotePath(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+// runBoardCommand runs args as a single remote shell command over a new
+// session obtained from newSession, single-quote-escaping each argument
+// before joining them. It is shared by SSHSession and TmuxSSHSession, which
+// do not share a common embedded connection type to hang a method on.
+func runBoardCommand(
+	ctx context.Context,
+	newSession func() (sshSessionRunner, error),
+	args []string,
+) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	sess, err := newSession()
+	if err != nil {
+		return nil, fmt.Errorf("new ssh session for board command: %w", err)
+	}
+	defer sess.Close()
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			sess.Close()
+		case <-done:
+		}
+	}()
+
+	out, err := sess.Output(quoteArgs(args))
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("board command over ssh: %w", err)
+	}
+	return out, nil
 }
 
 // resolveKnownHostsFile returns the known_hosts file path, defaulting to ~/.ssh/known_hosts.
@@ -787,6 +841,18 @@ func (s *SSHSession) Close() error {
 
 // ConnectionName returns the panemux connection alias for this SSH session.
 func (s *SSHSession) ConnectionName() string { return s.connectionName }
+
+// BoardHostID identifies this session's Agent Board host as its SSH
+// connection name — the same identifier ConnectionName already returns.
+func (s *SSHSession) BoardHostID() string { return s.connectionName }
+
+// RunBoardCommand runs an agmsg script on the remote host over a new SSH
+// exec channel, matching the pattern GetCWD/InspectGitContext already use.
+func (s *SSHSession) RunBoardCommand(ctx context.Context, args []string) ([]byte, error) {
+	return runBoardCommand(ctx, func() (sshSessionRunner, error) {
+		return s.client.NewSession()
+	}, args)
+}
 
 // sshGetCWDCmd is the shell command used by SSHSession.GetCWD to detect the
 // current working directory of the interactive shell.

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -118,6 +118,9 @@ func (s *TmuxLocalSession) Resize(cols, rows uint16) error {
 	})
 }
 
+// BoardHostID identifies this session as running on panemux's own host.
+func (s *TmuxLocalSession) BoardHostID() string { return boardHostIDLocal }
+
 // GetCWD returns the current working directory of the active tmux pane.
 func (s *TmuxLocalSession) GetCWD() (string, error) {
 	out, err := tmuxLocalCWD(s.tmuxSession)

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -130,6 +131,18 @@ func (s *TmuxSSHSession) Resize(cols, rows uint16) error {
 
 // ConnectionName returns the panemux connection alias for this SSH session.
 func (s *TmuxSSHSession) ConnectionName() string { return s.connectionName }
+
+// BoardHostID identifies this session's Agent Board host as its SSH
+// connection name — the same identifier ConnectionName already returns.
+func (s *TmuxSSHSession) BoardHostID() string { return s.connectionName }
+
+// RunBoardCommand runs an agmsg script on the remote host over a new SSH
+// exec channel, matching the pattern GetCWD/InspectGitContext already use.
+func (s *TmuxSSHSession) RunBoardCommand(ctx context.Context, args []string) ([]byte, error) {
+	return runBoardCommand(ctx, func() (sshSessionRunner, error) {
+		return s.client.NewSession()
+	}, args)
+}
 
 // GetCWD runs `tmux display-message` over a new SSH exec channel to get the active pane's CWD.
 func (s *TmuxSSHSession) GetCWD() (string, error) {

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ func loadConfig(opts cliOptions) (*config.Config, error) {
 	if opts.port != 0 {
 		cfg.Server.Port = opts.port
 	}
+	cfg.EnsureAuthToken()
 	return cfg, nil
 }
 


### PR DESCRIPTION
Implements the base slice of Agent Board Phase 1: the internal/board package
(Row/Status/AgmsgClient, board_status discriminator, ownSendLedger, BoardCache,
LocalAgmsgClient, RemoteAgmsgClient), the BoardHostID/BoardExecutor session
capability interfaces on all four session types, agent_board/command_center/
server.auth_token config with validation and auto-generated token persistence,
a standalone (not yet route-wired) bearer auth middleware, and Tier 1 agmsg
compatibility fixtures.

The reserved sentinel identity is _system rather than _panemux so it isn't
coupled to the product name. RemoteAgmsgClient escapes message bodies via
base64-encode-then-allowlist (mirroring validRemotePath's accepted shape for
values that can't be regex-allowlisted directly) and decodes them back
through a fixed, non-tainted wrapper script using shell positional
parameters, proven end-to-end against a real /bin/sh.

Cross-host relay, PTY bootstrap injection, the /api/board/* and
/ws/board-command endpoints, and wiring the auth middleware into
registerRoutes are intentionally out of scope for this change — see
docs/agent-board.md's updated status note.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015bGorfVr8zjhtYxZxyEPra