### PR TITLE
feat: relay agent board messages and expose REST status/messages/broadcast

### DIFF
--- a/board.go
+++ b/board.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"panemux/internal/board"
@@ -16,6 +20,14 @@ const (
 	defaultBoardPollLimit     = 200
 	defaultBoardBackfillLimit = 1000
 	boardHostIDLocal          = "local"
+
+	// boardStartupProbeTimeout bounds the one-time remote $HOME probe
+	// newAgmsgClientForHost makes to resolve agmsg_path's leading ~/. This
+	// runs during setupBoard, before the HTTP listener is up — an
+	// unresponsive SSH host must not be able to hang process startup
+	// indefinitely just because one board-enabled pane happens to be
+	// unreachable (board features are additive, never load-bearing).
+	boardStartupProbeTimeout = 10 * time.Second
 )
 
 // setupBoard builds the shared BoardCache and Relay from cfg/manager. It
@@ -73,10 +85,19 @@ func persistBoardCursors(entries []board.CursorEntry) {
 	}
 }
 
+// boardHostForPane prefixes an SSH connection alias with "ssh:" before
+// using it as a board host key. Without the prefix, an operator naming an
+// SSH connection alias literally "local" would collide with
+// boardHostIDLocal, silently routing that remote host's board traffic
+// through the local agmsg installation and misclassifying its panes as
+// local for from-validation purposes — nothing in internal/config's
+// connection-name validation forbids that alias today. The prefix makes a
+// collision structurally impossible instead of relying on catching the
+// misconfiguration.
 func boardHostForPane(pane *config.PaneConfig) string {
 	switch session.Type(pane.Type) {
 	case session.TypeSSH, session.TypeSSHTmux:
-		return pane.Connection
+		return "ssh:" + pane.Connection
 	default:
 		return boardHostIDLocal
 	}
@@ -109,16 +130,24 @@ func newAgmsgClientForHost(
 	cfg *config.Config, manager *session.Manager, paneHosts map[string]string, host string,
 ) (board.AgmsgClient, bool) {
 	if host == boardHostIDLocal {
-		return board.NewLocalAgmsgClient(cfg.AgentBoard.AgmsgPath), true
+		// AgentBoard.AgmsgPath is intentionally left un-expanded by
+		// internal/config (see config.go's expandPaths), since a single
+		// config value is shared by every host, local and remote alike.
+		// The local host expands against its own home directory here; a
+		// remote host expands against its own $HOME below, via
+		// ResolveRemoteAgmsgPath's SSH probe.
+		return board.NewLocalAgmsgClient(expandLocalAgmsgPath(cfg.AgentBoard.AgmsgPath)), true
 	}
 
-	executor, ok := findBoardExecutor(manager, paneHosts, host)
-	if !ok {
+	executors := findBoardExecutors(manager, paneHosts, host)
+	if len(executors) == 0 {
 		log.Printf("Warning: agent board: no reachable session for host %q, skipping", host)
 		return nil, false
 	}
 
-	path, err := board.ResolveRemoteAgmsgPath(context.Background(), executor, cfg.AgentBoard.AgmsgPath)
+	probeCtx, cancel := context.WithTimeout(context.Background(), boardStartupProbeTimeout)
+	defer cancel()
+	path, err := board.ResolveRemoteAgmsgPath(probeCtx, executors[0], cfg.AgentBoard.AgmsgPath)
 	if err != nil {
 		log.Printf("Warning: agent board: resolving agmsg_path on host %q: %v", host, err)
 		return nil, false
@@ -128,17 +157,40 @@ func newAgmsgClientForHost(
 	return board.NewRemoteAgmsgClient(host, path, dynamicExecutor), true
 }
 
-// dynamicBoardExecutor re-resolves a live session on host via
-// findBoardExecutor on every call, rather than holding one session found at
+// expandLocalAgmsgPath expands a leading ~/ in path against panemux's own
+// local home directory. A failure to resolve the home directory leaves path
+// unchanged, matching internal/config's own expandPaths behavior for other
+// local-only paths (SSH key/known_hosts files).
+func expandLocalAgmsgPath(path string) string {
+	if !strings.HasPrefix(path, "~/") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[2:])
+}
+
+// dynamicBoardExecutor re-resolves the live sessions on host via
+// findBoardExecutors on every call, rather than holding one session found at
 // startup for the relay's entire lifetime. A fixed snapshot would bind a
 // whole remote host's board features to whichever single pane happened to
 // be picked first: an ordinary pane restart or delete (unrelated to Agent
 // Board) closes that pane's underlying SSH client, and nothing would ever
 // notice or fail over to another live pane on the same host, so board
 // traffic to/from that host would silently and permanently break until the
-// entire panemux process restarted. Re-resolving keeps working as long as
-// any board-enabled pane on host has a live session, regardless of which
-// one that is at any given moment.
+// entire panemux process restarted.
+//
+// RunBoardCommand doesn't stop at the first candidate returned, either: a
+// session can still be registered in the Manager after its underlying
+// connection has died (State() reporting can lag reality, e.g. between a
+// dropped SSH connection and the read loop noticing EOF), so trusting the
+// first match alone can silently and repeatedly pick a dead session even
+// though a different, genuinely live pane on the same host would have
+// worked. Trying every candidate in turn means any one working session on
+// host is enough, regardless of which pane it belongs to or in what order
+// the candidates happen to be found.
 type dynamicBoardExecutor struct {
 	manager   *session.Manager
 	paneHosts map[string]string
@@ -146,32 +198,46 @@ type dynamicBoardExecutor struct {
 }
 
 func (d *dynamicBoardExecutor) RunBoardCommand(ctx context.Context, args []string) ([]byte, error) {
-	executor, ok := findBoardExecutor(d.manager, d.paneHosts, d.host)
-	if !ok {
+	executors := findBoardExecutors(d.manager, d.paneHosts, d.host)
+	if len(executors) == 0 {
 		return nil, fmt.Errorf("agent board: no reachable session for host %q", d.host)
 	}
-	out, err := executor.RunBoardCommand(ctx, args)
-	if err != nil {
-		return nil, fmt.Errorf("agent board: %w", err)
+
+	var lastErr error
+	for _, executor := range executors {
+		out, err := executor.RunBoardCommand(ctx, args)
+		if err == nil {
+			return out, nil
+		}
+		lastErr = err
 	}
-	return out, nil
+	return nil, fmt.Errorf("agent board: no working session for host %q (tried %d): %w", d.host, len(executors), lastErr)
 }
 
-// findBoardExecutor returns a board.BoardExecutor for host by finding any
-// currently-started session, among the board-enabled panes known to live
-// on that host, whose session.Session also implements board.BoardExecutor.
-func findBoardExecutor(manager *session.Manager, paneHosts map[string]string, host string) (board.BoardExecutor, bool) {
+// findBoardExecutors returns every board.BoardExecutor currently available
+// for host: every currently-started session, among the board-enabled panes
+// known to live on that host, whose session.Session also implements
+// board.BoardExecutor. Sorted by pane ID for deterministic ordering — map
+// iteration order is randomized, and dynamicBoardExecutor's tests rely on a
+// stable candidate order to be able to assert which one actually answered.
+func findBoardExecutors(manager *session.Manager, paneHosts map[string]string, host string) []board.BoardExecutor {
+	var paneIDs []string
 	for paneID, paneHost := range paneHosts {
-		if paneHost != host {
-			continue
+		if paneHost == host {
+			paneIDs = append(paneIDs, paneID)
 		}
+	}
+	sort.Strings(paneIDs)
+
+	var executors []board.BoardExecutor
+	for _, paneID := range paneIDs {
 		sess, ok := manager.Get(paneID)
 		if !ok {
 			continue
 		}
 		if executor, ok := sess.(board.BoardExecutor); ok {
-			return executor, true
+			executors = append(executors, executor)
 		}
 	}
-	return nil, false
+	return executors
 }

--- a/board.go
+++ b/board.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -96,10 +97,14 @@ func distinctBoardHosts(paneHosts map[string]string) []string {
 
 // newAgmsgClientForHost builds the AgmsgClient for host. For the local host
 // this never fails. For a remote host it needs a live session on that host
-// implementing board.BoardExecutor to resolve agent_board.agmsg_path's
-// leading ~/ against the remote $HOME — if no board-enabled pane on that
-// host currently has a started session, the host is skipped with a
-// warning rather than failing startup.
+// implementing board.BoardExecutor, at least once, to resolve
+// agent_board.agmsg_path's leading ~/ against the remote $HOME — if no
+// board-enabled pane on that host currently has a started session, the host
+// is skipped with a warning rather than failing startup. The RemoteAgmsgClient
+// itself is handed a dynamicBoardExecutor, not that one-time snapshot,
+// so it keeps working across the relay's lifetime even if the particular
+// pane used to resolve agmsg_path is later restarted or deleted — see
+// dynamicBoardExecutor's own comment for why a fixed snapshot is wrong here.
 func newAgmsgClientForHost(
 	cfg *config.Config, manager *session.Manager, paneHosts map[string]string, host string,
 ) (board.AgmsgClient, bool) {
@@ -119,7 +124,37 @@ func newAgmsgClientForHost(
 		return nil, false
 	}
 
-	return board.NewRemoteAgmsgClient(host, path, executor), true
+	dynamicExecutor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: host}
+	return board.NewRemoteAgmsgClient(host, path, dynamicExecutor), true
+}
+
+// dynamicBoardExecutor re-resolves a live session on host via
+// findBoardExecutor on every call, rather than holding one session found at
+// startup for the relay's entire lifetime. A fixed snapshot would bind a
+// whole remote host's board features to whichever single pane happened to
+// be picked first: an ordinary pane restart or delete (unrelated to Agent
+// Board) closes that pane's underlying SSH client, and nothing would ever
+// notice or fail over to another live pane on the same host, so board
+// traffic to/from that host would silently and permanently break until the
+// entire panemux process restarted. Re-resolving keeps working as long as
+// any board-enabled pane on host has a live session, regardless of which
+// one that is at any given moment.
+type dynamicBoardExecutor struct {
+	manager   *session.Manager
+	paneHosts map[string]string
+	host      string
+}
+
+func (d *dynamicBoardExecutor) RunBoardCommand(ctx context.Context, args []string) ([]byte, error) {
+	executor, ok := findBoardExecutor(d.manager, d.paneHosts, d.host)
+	if !ok {
+		return nil, fmt.Errorf("agent board: no reachable session for host %q", d.host)
+	}
+	out, err := executor.RunBoardCommand(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("agent board: %w", err)
+	}
+	return out, nil
 }
 
 // findBoardExecutor returns a board.BoardExecutor for host by finding any

--- a/board.go
+++ b/board.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"panemux/internal/board"
+	"panemux/internal/config"
+	"panemux/internal/session"
+)
+
+const (
+	defaultBoardPollInterval  = 5 * time.Second
+	defaultBoardPollLimit     = 200
+	defaultBoardBackfillLimit = 1000
+	boardHostIDLocal          = "local"
+)
+
+// setupBoard builds the shared BoardCache and Relay from cfg/manager. It
+// never fails startup — agent board is additive, never load-bearing (see
+// docs/agent-board.md's Design principles) — a host whose connection isn't
+// usable simply gets no AgmsgClient and is logged, not fatal.
+func setupBoard(cfg *config.Config, manager *session.Manager) (*board.BoardCache, *board.Relay) {
+	cache := board.NewBoardCache()
+
+	paneHosts := map[string]string{}
+	for _, pane := range cfg.AllPanes() {
+		if pane.AgentBoard.Enabled == nil || !*pane.AgentBoard.Enabled {
+			continue
+		}
+		paneHosts[pane.ID] = boardHostForPane(pane)
+	}
+
+	clients := map[string]board.AgmsgClient{}
+	for _, host := range distinctBoardHosts(paneHosts) {
+		client, ok := newAgmsgClientForHost(cfg, manager, paneHosts, host)
+		if !ok {
+			continue
+		}
+		clients[host] = client
+	}
+
+	relay := board.NewRelay(cache, board.RelayConfig{
+		Team:           cfg.AgentBoard.Team,
+		Clients:        clients,
+		PaneHosts:      paneHosts,
+		Limit:          defaultBoardPollLimit,
+		BackfillLimit:  defaultBoardBackfillLimit,
+		PersistCursors: persistBoardCursors,
+	})
+
+	if path, err := board.DefaultCursorFilePath(); err == nil {
+		if entries, err := board.LoadCursorFile(path); err == nil {
+			relay.LoadCursors(entries)
+		} else {
+			log.Printf("Warning: agent board: loading relay cursor file: %v", err)
+		}
+	}
+
+	return cache, relay
+}
+
+func persistBoardCursors(entries []board.CursorEntry) {
+	path, err := board.DefaultCursorFilePath()
+	if err != nil {
+		log.Printf("Warning: agent board: resolving relay cursor file path: %v", err)
+		return
+	}
+	if err := board.SaveCursorFile(path, entries); err != nil {
+		log.Printf("Warning: agent board: persisting relay cursor: %v", err)
+	}
+}
+
+func boardHostForPane(pane *config.PaneConfig) string {
+	switch session.Type(pane.Type) {
+	case session.TypeSSH, session.TypeSSHTmux:
+		return pane.Connection
+	default:
+		return boardHostIDLocal
+	}
+}
+
+func distinctBoardHosts(paneHosts map[string]string) []string {
+	seen := make(map[string]bool, len(paneHosts))
+	var hosts []string
+	for _, host := range paneHosts {
+		if seen[host] {
+			continue
+		}
+		seen[host] = true
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+// newAgmsgClientForHost builds the AgmsgClient for host. For the local host
+// this never fails. For a remote host it needs a live session on that host
+// implementing board.BoardExecutor to resolve agent_board.agmsg_path's
+// leading ~/ against the remote $HOME — if no board-enabled pane on that
+// host currently has a started session, the host is skipped with a
+// warning rather than failing startup.
+func newAgmsgClientForHost(
+	cfg *config.Config, manager *session.Manager, paneHosts map[string]string, host string,
+) (board.AgmsgClient, bool) {
+	if host == boardHostIDLocal {
+		return board.NewLocalAgmsgClient(cfg.AgentBoard.AgmsgPath), true
+	}
+
+	executor, ok := findBoardExecutor(manager, paneHosts, host)
+	if !ok {
+		log.Printf("Warning: agent board: no reachable session for host %q, skipping", host)
+		return nil, false
+	}
+
+	path, err := board.ResolveRemoteAgmsgPath(context.Background(), executor, cfg.AgentBoard.AgmsgPath)
+	if err != nil {
+		log.Printf("Warning: agent board: resolving agmsg_path on host %q: %v", host, err)
+		return nil, false
+	}
+
+	return board.NewRemoteAgmsgClient(host, path, executor), true
+}
+
+// findBoardExecutor returns a board.BoardExecutor for host by finding any
+// currently-started session, among the board-enabled panes known to live
+// on that host, whose session.Session also implements board.BoardExecutor.
+func findBoardExecutor(manager *session.Manager, paneHosts map[string]string, host string) (board.BoardExecutor, bool) {
+	for paneID, paneHost := range paneHosts {
+		if paneHost != host {
+			continue
+		}
+		sess, ok := manager.Get(paneID)
+		if !ok {
+			continue
+		}
+		if executor, ok := sess.(board.BoardExecutor); ok {
+			return executor, true
+		}
+	}
+	return nil, false
+}

--- a/board_test.go
+++ b/board_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"panemux/internal/session"
@@ -99,5 +101,89 @@ func TestDynamicBoardExecutor_FallsBackToAnotherPaneOnSameHost(t *testing.T) {
 	}
 	if string(out) != "pane-b-session" {
 		t.Fatalf("expected fallback to pane-b's session, got %q", out)
+	}
+}
+
+// failingBoardSession is a session.Session that is still registered in the
+// Manager and reports a normal State(), but whose underlying command always
+// fails — standing in for a dead SSH connection whose read loop hasn't yet
+// noticed the drop and removed the session from the Manager.
+type failingBoardSession struct {
+	id string
+}
+
+func (f *failingBoardSession) ID() string                     { return f.id }
+func (f *failingBoardSession) Type() session.Type             { return session.TypeSSH }
+func (f *failingBoardSession) Title() string                  { return f.id }
+func (f *failingBoardSession) State() session.State           { return session.StateConnected }
+func (f *failingBoardSession) Read(p []byte) (int, error)     { return 0, nil }
+func (f *failingBoardSession) Write(p []byte) (int, error)    { return len(p), nil }
+func (f *failingBoardSession) Resize(cols, rows uint16) error { return nil }
+func (f *failingBoardSession) Close() error                   { return nil }
+
+func (f *failingBoardSession) RunBoardCommand(_ context.Context, _ []string) ([]byte, error) {
+	return nil, errors.New("failingBoardSession: connection dead")
+}
+
+func TestDynamicBoardExecutor_DeadButRegisteredSession_TriesAnotherCandidate(t *testing.T) {
+	// Regression test (adversarial review round 2, finding R1): a session
+	// can still be registered in the Manager, and still report a normal
+	// State(), after its underlying connection has actually died — State()
+	// reporting can lag reality. The previous fix (re-resolving on every
+	// call) only helped once the dead pane was removed/replaced; it did
+	// nothing for "registered but dead". dynamicBoardExecutor must not give
+	// up after the first candidate it happens to try — it must keep trying
+	// every other board-enabled pane on the same host until one actually
+	// works.
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "build-host", "pane-b": "build-host"}
+	manager.Add(&failingBoardSession{id: "pane-a"})
+	manager.Add(&fakeBoardSession{id: "pane-b", tag: "pane-b-session"})
+
+	executor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: "build-host"}
+
+	// Run several times: findBoardExecutors is sorted by pane ID, so this
+	// must succeed deterministically every time, not just probabilistically
+	// depending on Go's randomized map iteration order.
+	for i := 0; i < 20; i++ {
+		out, err := executor.RunBoardCommand(context.Background(), []string{"noop"})
+		if err != nil {
+			t.Fatalf("RunBoardCommand (attempt %d): %v", i, err)
+		}
+		if string(out) != "pane-b-session" {
+			t.Fatalf("attempt %d: expected fallback past the dead session to pane-b, got %q", i, out)
+		}
+	}
+}
+
+func TestDynamicBoardExecutor_AllCandidatesFail_ReturnsError(t *testing.T) {
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "build-host", "pane-b": "build-host"}
+	manager.Add(&failingBoardSession{id: "pane-a"})
+	manager.Add(&failingBoardSession{id: "pane-b"})
+
+	executor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: "build-host"}
+	_, err := executor.RunBoardCommand(context.Background(), []string{"noop"})
+	if err == nil {
+		t.Fatal("expected an error when every candidate session fails")
+	}
+}
+
+func TestExpandLocalAgmsgPath_TildePrefixed_ExpandsToHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir: %v", err)
+	}
+	got := expandLocalAgmsgPath("~/.agents/skills/agmsg")
+	want := filepath.Join(home, ".agents", "skills", "agmsg")
+	if got != want {
+		t.Fatalf("expandLocalAgmsgPath(~/...) = %q, want %q", got, want)
+	}
+}
+
+func TestExpandLocalAgmsgPath_AbsolutePath_Unchanged(t *testing.T) {
+	got := expandLocalAgmsgPath("/opt/agmsg")
+	if got != "/opt/agmsg" {
+		t.Fatalf("expandLocalAgmsgPath(/opt/agmsg) = %q, want unchanged", got)
 	}
 }

--- a/board_test.go
+++ b/board_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"panemux/internal/session"
+)
+
+// fakeBoardSession is a minimal session.Session that also implements
+// board.BoardExecutor, standing in for SSHSession/TmuxSSHSession in tests
+// that don't need a real SSH connection.
+type fakeBoardSession struct {
+	id     string
+	tag    string // distinguishes which fakeBoardSession instance answered a call
+	closed bool
+}
+
+func (f *fakeBoardSession) ID() string                     { return f.id }
+func (f *fakeBoardSession) Type() session.Type             { return session.TypeSSH }
+func (f *fakeBoardSession) Title() string                  { return f.id }
+func (f *fakeBoardSession) State() session.State           { return session.StateConnected }
+func (f *fakeBoardSession) Read(p []byte) (int, error)     { return 0, nil }
+func (f *fakeBoardSession) Write(p []byte) (int, error)    { return len(p), nil }
+func (f *fakeBoardSession) Resize(cols, rows uint16) error { return nil }
+func (f *fakeBoardSession) Close() error                   { f.closed = true; return nil }
+
+func (f *fakeBoardSession) RunBoardCommand(_ context.Context, _ []string) ([]byte, error) {
+	if f.closed {
+		return nil, errors.New("fakeBoardSession: use of closed session")
+	}
+	return []byte(f.tag), nil
+}
+
+func TestDynamicBoardExecutor_ReResolvesAfterPaneRestart(t *testing.T) {
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "build-host"}
+
+	original := &fakeBoardSession{id: "pane-a", tag: "original"}
+	manager.Add(original)
+
+	executor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: "build-host"}
+
+	out, err := executor.RunBoardCommand(context.Background(), []string{"noop"})
+	if err != nil {
+		t.Fatalf("RunBoardCommand before restart: %v", err)
+	}
+	if string(out) != "original" {
+		t.Fatalf("expected output from original session, got %q", out)
+	}
+
+	// Simulate an ordinary, Agent-Board-unrelated pane restart: the old
+	// session is closed and removed, a brand-new one takes its place under
+	// the same pane ID.
+	if removeErr := manager.Remove("pane-a"); removeErr != nil {
+		t.Fatalf("Remove: %v", removeErr)
+	}
+	replacement := &fakeBoardSession{id: "pane-a", tag: "replacement"}
+	manager.Add(replacement)
+
+	out, err = executor.RunBoardCommand(context.Background(), []string{"noop"})
+	if err != nil {
+		t.Fatalf("RunBoardCommand after restart: %v", err)
+	}
+	if string(out) != "replacement" {
+		t.Fatalf("expected dynamicBoardExecutor to re-resolve to the replacement session, got %q", out)
+	}
+	if !original.closed {
+		t.Fatalf("expected original session to have been closed by Remove")
+	}
+}
+
+func TestDynamicBoardExecutor_NoLiveSessionOnHost_ReturnsError(t *testing.T) {
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "build-host"}
+
+	executor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: "build-host"}
+
+	_, err := executor.RunBoardCommand(context.Background(), []string{"noop"})
+	if err == nil {
+		t.Fatal("expected an error when no session is registered for the host")
+	}
+}
+
+func TestDynamicBoardExecutor_FallsBackToAnotherPaneOnSameHost(t *testing.T) {
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "build-host", "pane-b": "build-host"}
+
+	// pane-a is the one that would have been snapshotted at startup, but it
+	// gets removed without replacement; pane-b, on the same host, is still
+	// live and must be found instead.
+	manager.Add(&fakeBoardSession{id: "pane-b", tag: "pane-b-session"})
+
+	executor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: "build-host"}
+	out, err := executor.RunBoardCommand(context.Background(), []string{"noop"})
+	if err != nil {
+		t.Fatalf("RunBoardCommand: %v", err)
+	}
+	if string(out) != "pane-b-session" {
+		t.Fatalf("expected fallback to pane-b's session, got %q", out)
+	}
+}

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -12,7 +12,11 @@
 > `/ws/{sessionID}` — see [Security model](#security-model) and
 > [security.md](security.md#auth-token-and-transport-encryption) for why those stay unauthenticated
 > for now. `setupBoard` in `board.go` (`package main`) builds the `AgmsgClient`s and pane→host map
-> from config at startup and wires the relay goroutine into `main.go`'s lifecycle. Still design-only:
+> from config at startup and wires the relay goroutine into `main.go`'s lifecycle. A remote host's
+> `RemoteAgmsgClient` is handed a `dynamicBoardExecutor` (`board.go`), which re-resolves a live
+> `BoardExecutor` session on that host on every call rather than holding the one pane's session found
+> at startup — an ordinary pane restart/delete of whichever pane was picked first must not
+> permanently break board traffic for the rest of that host. Still design-only:
 > the PTY bootstrap flow (process detection, the one-time onboarding instruction), `/ws/board-command`,
 > `GET /api/board/command/history`, and the command center itself — none of that exists yet, so this
 > document's bootstrap/command-center sections below are not reachable through any current config or
@@ -1064,7 +1068,11 @@ that shaped the design.
   short-lived **own-send ledger** of `Send` calls it issued itself (see [Cross-host
   relay](#cross-host-relay) and [Package layout](#package-layout)) — is what closes this: a
   `_system`-attributed row is only accepted if it corresponds to a send panemux's own broadcast
-  handler or command center actually made, never on the strength of the string alone.
+  handler or command center actually made, never on the strength of the string alone. The ledger
+  entry is recorded immediately before the `Send` call (needed so a fast poll racing a *successful*
+  `Send` still matches it) and is explicitly forgotten again if that `Send` then fails — otherwise a
+  failed send would leave a live, matchable entry for the rest of its TTL with nothing ever actually
+  delivered behind it, which any pane on the destination host could exploit within that window.
 - **The command center's `/ws/board-command` and `/api/board/command/history` are gated by the same
   bearer token as everything else, and that gate is the entire authorization model for messaging
   any pane from the command center** — see [Command center](#command-center). There is deliberately

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -538,10 +538,14 @@ type AgmsgClient interface {
 // relay later observes with From == "_system" actually corresponds to one of panemux's own sends,
 // since send.sh --force never checks From against a roster and an ordinary board pane could
 // otherwise forge that identity. Entries expire after a few poll intervals; a body is stored only
-// as a hash, since the ledger's job is matching, not re-displaying content.
+// as a hash, since the ledger's job is matching, not re-displaying content. entries is a multiset —
+// one expiry per occurrence, not one per distinct key — because two broadcasts with the identical
+// (destHost, team, to, body) are two real, independent sends that each produce their own row; a
+// plain single-entry map would let the second Record silently overwrite the first and drop one of
+// two genuinely delivered messages from history the next time the destination host is polled.
 type ownSendLedger struct {
     mu      sync.Mutex
-    entries map[ownSendKey]time.Time // value is expiry
+    entries map[ownSendKey][]time.Time // one expiry per occurrence of this key
 }
 
 type ownSendKey struct {
@@ -551,7 +555,7 @@ type ownSendKey struct {
     BodyHash string // e.g. sha256, truncated; not a security boundary by itself, only a dedup key
 }
 
-func (l *ownSendLedger) Record(destHost, team, to, body string)      { /* inserts with a short TTL */ }
+func (l *ownSendLedger) Record(destHost, team, to, body string)      { /* appends one occurrence with a short TTL */ }
 func (l *ownSendLedger) Consume(destHost, team, to, body string) bool { /* true+deletes if matched, false if expired/absent */ }
 
 // BoardCache is the in-memory, panemux-owned view of recent board activity shown in Architecture.
@@ -1082,6 +1086,21 @@ that shaped the design.
 
 ## Known limitations
 
+- **A remote host with no reachable session at panemux startup gets no `AgmsgClient` for the rest of
+  that process's lifetime, even if a board-enabled pane on it becomes reachable later.**
+  `newAgmsgClientForHost` (`board.go`) runs exactly once per host, at `setupBoard` time; a host it
+  skips (no live session to resolve `agmsg_path`'s `~/` against, or the probe itself failing) is
+  simply absent from `Relay`'s `Clients` map from then on — nothing retries client construction on a
+  schedule the way `dynamicBoardExecutor` re-resolves a *session* on every call once a client already
+  exists for that host. This is a real, distinct gap from the session-level fix `dynamicBoardExecutor`
+  provides: that fix keeps a host's board features working across a pane restart/delete *after* the
+  host has a client; it does nothing for a host that had no reachable pane at all when panemux itself
+  started. In practice this mostly matters for a host whose only board-enabled pane's SSH connection
+  hadn't finished dialing yet when `setupBoard` ran, or one that was genuinely unreachable at boot but
+  recovers later — in both cases, that host's board features stay silently unavailable (logged once,
+  at startup, as a warning) until the whole panemux process restarts. A future fix would need
+  `newAgmsgClientForHost` to be retried on a schedule, similar in shape to how `dynamicBoardExecutor`
+  already re-resolves sessions, rather than being a one-shot startup step.
 - **Account-wide token/cost totals are explicitly out of scope for Agent Board.** Unlike
   branch/PR/cwd, token usage isn't external world-state an agent can query with an ordinary command
   (`git`, `gh`), and there's no verified way for an agent to introspect its own cumulative usage and

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -1,16 +1,22 @@
 # Agent Board: Cross-Pane Claude Messaging and Status Aggregation
 
-> **Status: foundation implemented, feature not yet usable.** The `internal/board` package's core
-> types (`Row`, `Status`, `AgmsgClient`, `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`,
-> `RemoteAgmsgClient`), the `BoardHostID`/`BoardExecutor` session capability interfaces, and the
-> `agent_board`/`command_center`/`server.auth_token` config surface described below are implemented
-> and tested — see [architecture.md](architecture.md)'s `internal/board` section and
-> [security.md](security.md#agent-board-remote-writes) for what actually ships today. The relay
-> goroutine, the PTY bootstrap flow, the `/api/board/*` and `/ws/board-command` endpoints, the
-> command center, and wiring the bearer auth middleware into any route are still design-only — none
-> of them exist yet, so this document's API/UI surface below is not reachable through any current
-> config or endpoint. Update this note (and its cross-links) again once a later phase closes that
-> gap; until then, no other doc should describe `board` REST/WS endpoints as current behavior.
+> **Status: relay and REST status/messages/broadcast implemented; bootstrap and command center not
+> yet usable.** The `internal/board` package's core types (`Row`, `Status`, `AgmsgClient`,
+> `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`, `RemoteAgmsgClient`), the `BoardHostID`/
+> `BoardExecutor` session capability interfaces, the `agent_board`/`command_center`/
+> `server.auth_token` config surface, the relay goroutine (`internal/board/relay.go`, cursor
+> persistence in `internal/board/cursor_store.go`), and the three REST endpoints in [API
+> additions](#api-additions) — `GET /api/board/status`, `GET /api/board/messages`, `POST
+> /api/board/broadcast` — are implemented and tested. `bearerAuthMiddleware` is wired, but **only**
+> onto the new `/api/board/*` sub-route, not onto any pre-existing `/api/*` route or
+> `/ws/{sessionID}` — see [Security model](#security-model) and
+> [security.md](security.md#auth-token-and-transport-encryption) for why those stay unauthenticated
+> for now. `setupBoard` in `board.go` (`package main`) builds the `AgmsgClient`s and pane→host map
+> from config at startup and wires the relay goroutine into `main.go`'s lifecycle. Still design-only:
+> the PTY bootstrap flow (process detection, the one-time onboarding instruction), `/ws/board-command`,
+> `GET /api/board/command/history`, and the command center itself — none of that exists yet, so this
+> document's bootstrap/command-center sections below are not reachable through any current config or
+> endpoint. Update this note (and its cross-links) again once a later phase closes that gap.
 
 ## Purpose
 
@@ -556,18 +562,21 @@ type BoardCache struct {
     mu       sync.RWMutex
     status   map[string]Status // paneID -> latest self-reported status (pane IDs are globally unique)
     nextSeq  int64
-    history  []cachedRow       // bounded ring buffer, most recent last
+    history  []CachedRow       // bounded ring buffer, most recent last
 }
 
-type cachedRow struct {
-    Seq int64
+// CachedRow pairs a Row with the BoardCache-local Seq it was assigned when appended. Exported
+// because GET /api/board/messages?since=<seq> needs the Seq back from every returned row to use as
+// its next since cursor — a bare []Row would discard exactly the value the caller needs.
+type CachedRow struct {
     Row Row
+    Seq int64
 }
 
-func (c *BoardCache) RecordStatus(paneID string, s Status) { /* mutex-guarded write; sets s.UpdatedAt */ }
-func (c *BoardCache) AppendMessage(r Row)                  { /* mutex-guarded write; assigns next Seq */ }
-func (c *BoardCache) StatusSnapshot() map[string]Status    { /* mutex-guarded copy */ }
-func (c *BoardCache) MessagesSince(afterSeq int64) []Row   { /* mutex-guarded copy, filtered by Seq */ }
+func (c *BoardCache) RecordStatus(paneID string, s Status)     { /* mutex-guarded write; sets s.UpdatedAt */ }
+func (c *BoardCache) AppendMessage(r Row)                       { /* mutex-guarded write; assigns next Seq */ }
+func (c *BoardCache) StatusSnapshot() map[string]Status         { /* mutex-guarded copy */ }
+func (c *BoardCache) MessagesSince(afterSeq int64) []CachedRow  { /* mutex-guarded copy, filtered by Seq */ }
 ```
 
 The relay inspects every `Row` it reads: if `To == "_system"` and `Body` parses as JSON with
@@ -599,6 +608,21 @@ was already doing.
   own SQL escaping internally, so panemux never needs a second, SQL-literal escaping layer of its
   own on top of the shell layer — there is no local schema of panemux's own to escape SQL text for.
   See [Security model](#security-model) and [security.md](security.md).
+
+`internal/board/relay.go`'s `Relay` type (constructed once in `board.go`'s `setupBoard` and shared
+between the polling goroutine and the broadcast REST handler, per [Cross-host relay](#cross-host-relay))
+implements the row-processing order and cold-start backfill described there: `Poll(ctx)` runs one
+polling pass and is what `Run(ctx, interval)` calls on a real `time.Ticker` in production; tests drive
+`runLoop` directly against an injected `<-chan time.Time` instead, since this is the first
+time-driven goroutine loop in this codebase and keeping `Poll` synchronous and directly testable
+avoids relying on wall-clock timing in any test. `Broadcast(ctx, from, to, body)` is what
+`POST /api/board/broadcast` calls; it records into the same `ownSendLedger` instance the poll loop
+consumes from, resolves each `to` pane ID to its host via the same config-derived pane→host map the
+relay already holds, and returns an `*UnknownPaneError` (naming every unresolvable pane ID at once,
+not just the first) rather than partially delivering to some panes and silently dropping others.
+Relay cursors (`internal/board/cursor_store.go`'s `CursorEntry{Host, Team, Cursor}`) persist to
+`~/.config/panemux/board-relay-cursor.json` (`0600`) after each poll and are loaded once at startup;
+a missing or unreadable cursor file is logged and treated as a cold start, never a fatal error.
 
 Because panemux owns no schema, it needs no embedded database driver of its own at all — every
 board operation is either a local `exec.Command` or a remote exec-channel command running agmsg's
@@ -893,18 +917,23 @@ hypothetical future requirements.
 
 ## API additions
 
-All of the following require the global bearer-token auth described in
-[Security model](#security-model) — board auth is not scoped narrower than the rest of the API,
-because an unauthenticated board endpoint would be a smaller problem than the pre-existing
-unauthenticated `/ws/{sessionID}` full-shell endpoint, and once auth exists it should cover both.
+The first three rows are implemented; see [docs/behavior.md](behavior.md#agent-board-rest-api) for
+exact request/response shapes and status codes. All three require the bearer token described in
+[Security model](#security-model), but — a deliberate, narrower choice than an earlier revision of
+this document specified — that gate today covers **only** `/api/board/*`, not the pre-existing
+`/api/*` routes or `/ws/{sessionID}`: nothing yet relies on the board endpoints (no frontend calls
+them), so gating them from day one costs nothing, while retrofitting auth onto the already-relied-
+upon unauthenticated routes is a separate, larger change with its own frontend work — see
+[security.md](security.md#auth-token-and-transport-encryption). The last two rows (command center)
+remain design-only.
 
 | Endpoint | Purpose |
 |---|---|
 | `GET /api/board/status` | A snapshot of panemux's in-memory status cache — no `AgmsgClient` call happens on this request (see [Architecture](#architecture)) |
 | `GET /api/board/messages?since=<seq>` | History feed for the dashboard UI. `<seq>` is `BoardCache`'s own panemux-local sequence number (see [Package layout](#package-layout)), not an agmsg-native `id` — those aren't comparable across hosts |
 | `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn); delivery to the pane is immediate, but the message appears in `GET /api/board/messages`' history only after the relay's next poll cycle reads it back — see [Known limitations](#known-limitations) |
-| `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
-| `GET /api/board/command/history` | Command center's own captured conversation history — see [Command center](#command-center) |
+| `WS /ws/board-command` (design-only) | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
+| `GET /api/board/command/history` (design-only) | Command center's own captured conversation history — see [Command center](#command-center) |
 
 ## Config additions
 
@@ -1222,8 +1251,19 @@ documented behavior changed.
 - `internal/config`: `host != loopback && auth_token == ""` is a validation error; all other
   combinations are valid. `agent_board.team` defaults to `"panemux"` when unset. A pane config with
   `id: "_system"` is a validation error, both alone and alongside otherwise-valid other panes.
-- `internal/api`: missing/incorrect bearer token is rejected (401) on both REST and the WebSocket
-  handshake; correct token succeeds.
+- `internal/server`: missing/incorrect bearer token on `/api/board/*` is rejected (401); the correct
+  token succeeds; pre-existing `/api/*` routes and `/ws/{sessionID}` remain reachable with no
+  `Authorization` header at all — a required regression test, since scoping the middleware to
+  `/api/board` only (rather than gating the whole API) is exactly the choice that could silently
+  widen later. Once `/ws/board-command` exists, its handshake rejection is covered here too,
+  following the same pattern.
+- `internal/api`: `GetBoardStatus`/`GetBoardMessages`/`PostBoardBroadcast` handler-level behavior —
+  empty cache returns a well-formed empty response (`{"statuses":{}}` / `{"messages":[]}`, never
+  `null`), `since` omitted defaults to `0`, a non-numeric `since` is `400`, `to`/`body` validation
+  failures and `*board.UnknownPaneError` are `422`, malformed request JSON is `400`, any other
+  downstream `AgmsgClient`/relay error is `502`, success is `200`. Auth itself is not this package's
+  concern — that is `internal/server`'s bullet above, since `bearerAuthMiddleware` sits in front of
+  these handlers, not inside them.
 - `internal/ws`: `/ws/board-command` is new surface under the same package as the existing terminal
   WebSocket handler, so it is covered by `coverage-go`'s existing `internal/ws` gate (see
   `DEVELOPMENT.md`) — no separate coverage carve-out is introduced for it. Its handshake rejection

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ Optional capability interfaces extend the base `Session` contract without breaki
 - `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
 
-### `internal/board` (foundation implemented; relay, bootstrap, and API surface still planned)
+### `internal/board` (relay + REST status/messages/broadcast implemented; bootstrap and command center still planned)
 
 A package that replaces transcript-based Claude activity inference with a self-reported channel:
 panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh` calls rather
@@ -85,12 +85,22 @@ interfaces, `BoardHostID` and `BoardExecutor`, extend the same pattern as
 `CWDGetter`/`ActiveWorkdirGetter` above and are implemented on all four session types
 (`BoardHostID`) and on `SSHSession`/`TmuxSSHSession` (`BoardExecutor`'s `RunBoardCommand`).
 
-Not yet implemented: the relay goroutine that polls every host's agmsg on a schedule and populates
-`BoardCache` as a side effect, the bootstrap flow that writes a one-time onboarding instruction into
-a pane's PTY, the `/api/board/*` and `/ws/board-command` REST/WS surface, and the command center.
-The `server.auth_token` config field, its non-loopback validation rule, and a constant-time bearer
-auth middleware are implemented (see [security.md](security.md#auth-token-and-transport-encryption)),
-but that middleware is not yet connected to any route.
+Also implemented and tested: the relay goroutine (`internal/board/relay.go`'s `Relay`, run from
+`main.go` via `board.go`'s `setupBoard`) that polls every configured host's agmsg on a schedule,
+populates `BoardCache` as a side effect, persists its per-(host,team) cursor to
+`~/.config/panemux/board-relay-cursor.json` (`internal/board/cursor_store.go`), and resolves a
+remote `agmsg_path`'s leading `~/` against that host's own `$HOME`
+(`internal/board/agmsg_path.go`'s `ResolveRemoteAgmsgPath`); and the three REST endpoints `GET
+/api/board/status`, `GET /api/board/messages`, `POST /api/board/broadcast` (`internal/api/board.go`),
+gated by the `server.auth_token` config field's constant-time bearer auth middleware
+(`internal/server/auth.go`) — see [security.md](security.md#auth-token-and-transport-encryption).
+That middleware is wired **only** onto the new `/api/board/*` sub-route; every pre-existing `/api/*`
+route and `/ws/{sessionID}` remain unauthenticated, since retrofitting auth onto routes the current
+frontend already relies on is a separate, larger change.
+
+Not yet implemented: the bootstrap flow that writes a one-time onboarding instruction into a pane's
+PTY, the `/ws/board-command` WS endpoint, `GET /api/board/command/history`, and the command center
+itself.
 
 The same design also specifies a **command center**: a single headless `claude -p --resume`
 subprocess, invoked per query, that reads and writes the board exclusively through panemux's own
@@ -340,7 +350,7 @@ Architecture-level security summary:
 - remote shell entrypoints validate SSH working directories before interpolating them into shell commands
 - host-key handling intentionally preserves compatibility with OpenSSH hashed `known_hosts` entries
 - shipped code should structurally avoid `gosec` findings rather than suppress them
-- panemux does not terminate TLS; non-loopback exposure is expected to sit behind operator-managed infrastructure (reverse proxy, tunnel, VPN), and the `server.auth_token` config field (implemented, but not yet enforced by any route — see this document's `internal/board` section above) is only meaningful once that transport is encrypted — see [agent-board.md](agent-board.md#security-model)
+- panemux does not terminate TLS; non-loopback exposure is expected to sit behind operator-managed infrastructure (reverse proxy, tunnel, VPN), and the `server.auth_token` config field (enforced only on `/api/board/*` today, not on pre-existing `/api/*` routes or `/ws/{sessionID}` — see this document's `internal/board` section above) is only meaningful once that transport is encrypted — see [agent-board.md](agent-board.md#security-model)
 
 ## Tradeoffs and Intentional Limits
 
@@ -348,5 +358,5 @@ Architecture-level security summary:
 - Open CORS and permissive WebSocket origin checks reduce friction for local use, but are not suitable as-is for an untrusted deployment.
 - All workspace panes are started at backend startup, including panes in inactive workspaces. This keeps tab switching fast and preserves terminal state, at the cost of using resources for hidden workspaces.
 - Dynamic session creation exists, but current UI behavior mainly creates new local panes; this is not yet a full remote session orchestration product.
-- The planned `internal/board` cross-host relay (see [agent-board.md](agent-board.md)) makes panemux a persistent relay for agent-to-agent messages between hosts it cannot make talk to each other directly, closer to a TURN server than a STUN server: panemux stays in the data path for the life of the exchange rather than helping two hosts connect directly and stepping aside, and it sees each relayed message as plaintext in process memory between the two encrypted SSH hops.
-- The same planned design's command center spawns a `claude -p` subprocess per query rather than keeping one warm — simpler process lifecycle and no persistent extra process, at the cost of response latency that includes subprocess startup on every query (see [agent-board.md's Process lifecycle](agent-board.md#process-lifecycle)).
+- The implemented `internal/board` cross-host relay (see [agent-board.md](agent-board.md)) makes panemux a persistent relay for agent-to-agent messages between hosts it cannot make talk to each other directly, closer to a TURN server than a STUN server: panemux stays in the data path for the life of the exchange rather than helping two hosts connect directly and stepping aside, and it sees each relayed message as plaintext in process memory between the two encrypted SSH hops.
+- The still-planned command center design spawns a `claude -p` subprocess per query rather than keeping one warm — simpler process lifecycle and no persistent extra process, at the cost of response latency that includes subprocess startup on every query (see [agent-board.md's Process lifecycle](agent-board.md#process-lifecycle)).

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -410,7 +410,11 @@ Request body:
 - `400`: invalid JSON
 - `422`: `to` is empty, `body` is empty, or `to` names one or more pane IDs the relay doesn't know
   about (`board.UnknownPaneError`, which names every unresolvable pane ID at once)
-- `502`: a downstream `AgmsgClient`/SSH error while relaying to a resolved pane's host
+- `502`: a downstream `AgmsgClient`/SSH error while relaying to a resolved pane's host. Broadcasting
+  is fail-fast, not all-or-nothing, once every `to` ID has resolved: it stops at the first `Send`
+  failure, so an earlier pane in `to` may already have received the message. The response body is
+  `{ "error": "...", "delivered": ["pane-a"] }` — the pane IDs successfully delivered to before the
+  failure — so the caller can tell which panes to avoid re-sending to on retry.
 - `200`: `{ "delivered": ["pane-a", "pane-b"] }`, the pane IDs the broadcast actually reached
 
 ## WebSocket Protocol

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -329,6 +329,90 @@ Request body:
 
 Returns display preferences such as header/status-bar visibility.
 
+## Agent Board REST API
+
+Full design and rationale live in [agent-board.md](agent-board.md); this section documents only the
+request/response shapes and status codes of what is actually implemented today. Unlike every route
+above, every endpoint in this section requires `Authorization: Bearer <server.auth_token>` — see
+[security.md](security.md#auth-token-and-transport-encryption). A missing or incorrect token returns
+`401` before the handler runs. The bootstrap flow, `/ws/board-command`, and `GET
+/api/board/command/history` are not implemented yet and are not documented here — see
+[agent-board.md](agent-board.md)'s status note.
+
+### `GET /api/board/status`
+
+Returns a snapshot of panemux's in-memory status cache. No `AgmsgClient` call happens on this
+request — the relay goroutine is what keeps the cache current by polling agmsg on a schedule.
+
+Response:
+
+```json
+{
+  "statuses": {
+    "pane-a": {
+      "updated_at": "2026-08-10T12:00:00Z",
+      "state": "working",
+      "cwd": "/home/user/project",
+      "branch": "feature/x",
+      "repo": "owner/repo",
+      "pr_url": "https://github.com/owner/repo/pull/123",
+      "last_tool": "Edit internal/api/handler.go",
+      "summary": "fixing failing tests"
+    }
+  }
+}
+```
+
+An empty cache returns `200` with `{"statuses":{}}`, never `null`. All fields besides `updated_at`
+are omitted (not emitted as empty strings) when the reporting pane didn't include them.
+
+- `200`: snapshot returned (including when empty)
+
+### `GET /api/board/messages?since=<seq>`
+
+Returns board message history newer than `since`, `BoardCache`'s own panemux-local sequence number —
+not an agmsg-native `id`, which isn't comparable across hosts. `since` defaults to `0` when omitted.
+
+Response:
+
+```json
+{
+  "messages": [
+    {
+      "seq": 42,
+      "host": "local",
+      "team": "panemux",
+      "from": "pane-a",
+      "to": "pane-b",
+      "body": "please review",
+      "at": "2026-08-10T12:00:00Z"
+    }
+  ]
+}
+```
+
+- `400`: `since` is present but not a valid integer
+- `200`: messages returned (`"messages":[]` when there are none, never `null`)
+
+### `POST /api/board/broadcast`
+
+Sends `body` to every pane ID in `to`, via the shared relay's `Broadcast`, directly to each target's
+own host — never via PTY injection, so it is safe to send to a pane mid-turn. Delivery is immediate,
+but the message appears in `GET /api/board/messages`'s history only after the relay's next poll
+cycle reads it back.
+
+Request body:
+
+```json
+{ "to": ["pane-a", "pane-b"], "body": "please review" }
+```
+
+- `400`: invalid JSON
+- `422`: `to` is empty, `body` is empty, or `to` names one or more pane IDs the relay doesn't know
+  about (`board.UnknownPaneError`, which names every unresolvable pane ID at once)
+- `502`: a downstream `AgmsgClient`/SSH error while relaying to a resolved pane's host
+- `200`: `{ "delivered": ["pane-a", "pane-b"] }`, the pane IDs the broadcast actually reached
+
 ## WebSocket Protocol
 
 Endpoint: `GET /ws/{sessionID}`

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,12 +79,18 @@ internally, so `RunBoardCommand` remains responsible only for the POSIX shell es
 (`shellQuotePath`-style, matching the existing `cwd` discipline) that wraps every argument,
 including the wrapper script text itself, before the remote command string is built.
 
-`send.sh` and `api.sh` are the only board-related commands panemux itself ever executes remotely;
-each runs against agmsg's own local store on that host. panemux only ever detects an existing agmsg
+`send.sh` and `api.sh` are the two agmsg scripts this design's message read/write path runs
+remotely; each runs against agmsg's own local store on that host. The only other remote command
+panemux itself ever executes is a fixed, non-tainted `sh -c 'printf '%s' "$HOME"'` probe
+(`internal/board/agmsg_path.go`'s `remoteHomeProbeCmd`), run once per remote host to resolve
+`agent_board.agmsg_path`'s leading `~/` against that host's own home directory before it is ever
+placed in a `RunBoardCommand` argument list — see [agent-board.md](agent-board.md)'s "`~` in
+`agmsg_path` is expanded by panemux" section. panemux only ever detects an existing agmsg
 installation — it never installs, updates, or otherwise manages agmsg on the operator's behalf,
-locally or remotely. The relay goroutine that actually drives this on a schedule, the bootstrap flow
-that writes an onboarding instruction into a pane's PTY, and the `/api/board/*` REST surface are not
-yet implemented — see [agent-board.md](agent-board.md)'s status note.
+locally or remotely. The relay goroutine that drives this on a schedule (`internal/board/relay.go`)
+and the `/api/board/*` REST surface (`GET /status`, `GET /messages`, `POST /broadcast`) are
+implemented — see [agent-board.md](agent-board.md)'s status note. The bootstrap flow that writes an
+onboarding instruction into a pane's PTY, and the command center, are not yet implemented.
 
 ### Auth token and transport encryption
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,11 +100,15 @@ so the token only provides real protection once the operator has placed a TLS-te
 proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
 [agent-board.md](agent-board.md#security-model) for the full rationale.
 
-`internal/server`'s constant-time bearer-token middleware (`bearerAuthMiddleware`) is also
-implemented and unit-tested, but it is **not yet wired into `registerRoutes`** — connecting it to
-today's `/api/*` and `/ws/{sessionID}` routes without a matching frontend change would break every
-existing, currently-unauthenticated request. It is connected once board endpoints exist to protect
-and the frontend sends the token; see [agent-board.md](agent-board.md)'s status note.
+`internal/server`'s constant-time bearer-token middleware (`bearerAuthMiddleware`, `internal/server/auth.go`)
+is implemented, unit-tested, and wired into `registerRoutes` — but **only** onto the new
+`r.Route("/api/board", ...)` sub-route (`GET /status`, `GET /messages`, `POST /broadcast`), not onto
+any pre-existing `/api/*` route or `/ws/{sessionID}`. Widening it to those routes without a matching
+frontend change would break every existing, currently-unauthenticated request, so that remains a
+separate, larger change. `internal/server/board_routes_test.go` covers this scoping as a regression:
+missing/incorrect token on `/api/board/*` is rejected with `401`, the correct token reaches `200`,
+and pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no `Authorization` header
+at all. See [agent-board.md](agent-board.md)'s status note.
 
 ## General Rules
 

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"panemux/internal/board"
+)
+
+type boardStatusEntry struct {
+	UpdatedAt time.Time `json:"updated_at"`
+	State     string    `json:"state,omitempty"`
+	CWD       string    `json:"cwd,omitempty"`
+	Branch    string    `json:"branch,omitempty"`
+	Repo      string    `json:"repo,omitempty"`
+	PRURL     string    `json:"pr_url,omitempty"`
+	LastTool  string    `json:"last_tool,omitempty"`
+	Summary   string    `json:"summary,omitempty"`
+}
+
+type boardStatusResponse struct {
+	Statuses map[string]boardStatusEntry `json:"statuses"`
+}
+
+// GetBoardStatus returns a snapshot of the board's in-memory status cache.
+// No AgmsgClient call happens on this request — the relay is what keeps
+// the cache current (see docs/agent-board.md's Architecture section).
+func (h *Handler) GetBoardStatus(w http.ResponseWriter, r *http.Request) {
+	snapshot := h.boardCache.StatusSnapshot()
+	resp := boardStatusResponse{Statuses: make(map[string]boardStatusEntry, len(snapshot))}
+	for paneID, s := range snapshot {
+		resp.Statuses[paneID] = boardStatusEntry{
+			State:     s.State,
+			CWD:       s.CWD,
+			Branch:    s.Branch,
+			Repo:      s.Repo,
+			PRURL:     s.PRURL,
+			LastTool:  s.LastTool,
+			Summary:   s.Summary,
+			UpdatedAt: s.UpdatedAt,
+		}
+	}
+	writeJSON(w, resp)
+}
+
+type boardMessageResponse struct {
+	At   time.Time `json:"at"`
+	Host string    `json:"host"`
+	Team string    `json:"team"`
+	From string    `json:"from"`
+	To   string    `json:"to"`
+	Body string    `json:"body"`
+	Seq  int64     `json:"seq"`
+}
+
+type boardMessagesResponse struct {
+	Messages []boardMessageResponse `json:"messages"`
+}
+
+// GetBoardMessages returns board history newer than the since query
+// parameter (BoardCache's own local Seq, not an agmsg-native id — those
+// aren't comparable across hosts). Missing since defaults to 0.
+func (h *Handler) GetBoardMessages(w http.ResponseWriter, r *http.Request) {
+	since := int64(0)
+	if raw := r.URL.Query().Get("since"); raw != "" {
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			http.Error(w, "invalid since parameter", http.StatusBadRequest)
+			return
+		}
+		since = v
+	}
+
+	rows := h.boardCache.MessagesSince(since)
+	resp := boardMessagesResponse{Messages: make([]boardMessageResponse, 0, len(rows))}
+	for _, cr := range rows {
+		resp.Messages = append(resp.Messages, boardMessageResponse{
+			Seq:  cr.Seq,
+			Host: cr.Row.Host,
+			Team: cr.Row.Team,
+			From: cr.Row.From,
+			To:   cr.Row.To,
+			Body: cr.Row.Body,
+			At:   cr.Row.At,
+		})
+	}
+	writeJSON(w, resp)
+}
+
+type boardBroadcastRequest struct {
+	Body string   `json:"body"`
+	To   []string `json:"to"`
+}
+
+type boardBroadcastResponse struct {
+	Delivered []string `json:"delivered"`
+}
+
+// PostBoardBroadcast sends body to every pane ID in to, via the shared
+// Relay's own-send-ledger-recording Broadcast — never via PTY injection, so
+// it is safe to send to a pane mid-turn.
+func (h *Handler) PostBoardBroadcast(w http.ResponseWriter, r *http.Request) {
+	var req boardBroadcastRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.To) == 0 {
+		writeValidationError(w, "to must contain at least one pane id")
+		return
+	}
+	if req.Body == "" {
+		writeValidationError(w, "body must not be empty")
+		return
+	}
+
+	delivered, err := h.boardBroadcastFn(r.Context(), req.To, req.Body)
+	if err != nil {
+		var unknownErr *board.UnknownPaneError
+		if errors.As(err, &unknownErr) {
+			writeValidationError(w, err.Error())
+			return
+		}
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, boardBroadcastResponse{Delivered: delivered})
+}

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -99,6 +99,17 @@ type boardBroadcastResponse struct {
 	Delivered []string `json:"delivered"`
 }
 
+// boardBroadcastErrorResponse is the 502 body for a Broadcast call that
+// failed partway through. Relay.Broadcast is fail-fast, not all-or-nothing,
+// on a Send failure: it stops at the first error but still reports which
+// pane IDs were successfully delivered before that point. Dropping that
+// list (as a plain http.Error would) leaves the caller unable to tell which
+// panes already got the message, risking a double-send on naive retry.
+type boardBroadcastErrorResponse struct {
+	Error     string   `json:"error"`
+	Delivered []string `json:"delivered"`
+}
+
 // PostBoardBroadcast sends body to every pane ID in to, via the shared
 // Relay's own-send-ledger-recording Broadcast — never via PTY injection, so
 // it is safe to send to a pane mid-turn.
@@ -124,7 +135,9 @@ func (h *Handler) PostBoardBroadcast(w http.ResponseWriter, r *http.Request) {
 			writeValidationError(w, err.Error())
 			return
 		}
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(boardBroadcastErrorResponse{Error: err.Error(), Delivered: delivered})
 		return
 	}
 	writeJSON(w, boardBroadcastResponse{Delivered: delivered})

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/board"
+	"panemux/internal/session"
+)
+
+type broadcastFunc func(ctx context.Context, to []string, body string) ([]string, error)
+
+func setupBoardRouter(cache *board.BoardCache, broadcastFn broadcastFunc) *Handler {
+	h := NewHandler(defaultTestConfig(), session.NewManager(), cache, nil)
+	if broadcastFn != nil {
+		h.boardBroadcastFn = broadcastFn
+	}
+	return h
+}
+
+func TestGetBoardStatus_EmptyCache_ReturnsEmptyObject(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardStatusResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Statuses)
+}
+
+func TestGetBoardStatus_PopulatedCache_ReturnsEntries(t *testing.T) {
+	cache := board.NewBoardCache()
+	cache.RecordStatus("pane-a", board.Status{State: "working", Branch: "feature/x"})
+	h := setupBoardRouter(cache, nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardStatusResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Contains(t, resp.Statuses, "pane-a")
+	assert.Equal(t, "working", resp.Statuses["pane-a"].State)
+	assert.Equal(t, "feature/x", resp.Statuses["pane-a"].Branch)
+}
+
+func TestGetBoardMessages_EmptyCache_ReturnsEmptyArray(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/messages", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardMessagesResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotNil(t, resp.Messages)
+	assert.Empty(t, resp.Messages)
+}
+
+func TestGetBoardMessages_MissingSince_DefaultsToZero(t *testing.T) {
+	cache := board.NewBoardCache()
+	cache.AppendMessage(board.Row{From: "a", To: "b", Body: "hi", At: time.Now()})
+	h := setupBoardRouter(cache, nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/messages", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardMessagesResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Messages, 1)
+	assert.Equal(t, int64(1), resp.Messages[0].Seq)
+	assert.Equal(t, "hi", resp.Messages[0].Body)
+}
+
+func TestGetBoardMessages_NonNumericSince_400(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/messages?since=not-a-number", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGetBoardMessages_SinceExcludesEverything_EmptyResult(t *testing.T) {
+	cache := board.NewBoardCache()
+	cache.AppendMessage(board.Row{Body: "one"})
+	h := setupBoardRouter(cache, nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/messages?since=1", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardMessagesResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Messages)
+}
+
+func postBoardBroadcast(t *testing.T, r http.Handler, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	switch v := body.(type) {
+	case string:
+		reader = bytes.NewReader([]byte(v))
+	default:
+		data, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(data)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/board/broadcast", reader)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestPostBoardBroadcast_MissingTo_422(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), func(context.Context, []string, string) ([]string, error) {
+		t.Fatal("broadcast fn must not be called for a validation failure")
+		return nil, nil
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{Body: "hello"})
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostBoardBroadcast_EmptyBody_422(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), func(context.Context, []string, string) ([]string, error) {
+		t.Fatal("broadcast fn must not be called for a validation failure")
+		return nil, nil
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"pane-a"}})
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+}
+
+func TestPostBoardBroadcast_MalformedJSON_400(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, "not json")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestPostBoardBroadcast_UnknownPaneError_422(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), func(context.Context, []string, string) ([]string, error) {
+		return nil, &board.UnknownPaneError{IDs: []string{"no-such-pane"}}
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"no-such-pane"}, Body: "hello"})
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&body))
+	assert.Contains(t, body["error"], "no-such-pane")
+}
+
+func TestPostBoardBroadcast_GenericError_502(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), func(context.Context, []string, string) ([]string, error) {
+		return nil, errors.New("ssh: connection lost")
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"pane-a"}, Body: "hello"})
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+}
+
+func TestPostBoardBroadcast_Success_200WithDelivered(t *testing.T) {
+	h := setupBoardRouter(board.NewBoardCache(), func(_ context.Context, to []string, body string) ([]string, error) {
+		assert.Equal(t, []string{"pane-a", "pane-b"}, to)
+		assert.Equal(t, "hello", body)
+		return to, nil
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"pane-a", "pane-b"}, Body: "hello"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardBroadcastResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, []string{"pane-a", "pane-b"}, resp.Delivered)
+}

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -188,6 +188,29 @@ func TestPostBoardBroadcast_GenericError_502(t *testing.T) {
 
 	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"pane-a"}, Body: "hello"})
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	var resp boardBroadcastErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Contains(t, resp.Error, "ssh: connection lost")
+	assert.Empty(t, resp.Delivered)
+}
+
+func TestPostBoardBroadcast_PartialFailure_502ReportsDelivered(t *testing.T) {
+	// Relay.Broadcast is fail-fast, not all-or-nothing, on a Send failure: it
+	// stops at the first error but reports every pane ID it successfully
+	// delivered to before that point. The handler must forward that partial
+	// list rather than discarding it, so a caller can tell which panes
+	// already got the message instead of risking a double-send on retry.
+	h := setupBoardRouter(board.NewBoardCache(), func(_ context.Context, to []string, body string) ([]string, error) {
+		return []string{"pane-a"}, errors.New("agent board: broadcast to \"pane-b\" failed: ssh timeout")
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := postBoardBroadcast(t, r, boardBroadcastRequest{To: []string{"pane-a", "pane-b"}, Body: "hello"})
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	var resp boardBroadcastErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, []string{"pane-a"}, resp.Delivered)
+	assert.Contains(t, resp.Error, "pane-b")
 }
 
 func TestPostBoardBroadcast_Success_200WithDelivered(t *testing.T) {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"panemux/internal/board"
 	"panemux/internal/config"
 	"panemux/internal/session"
 	"panemux/internal/sshconfig"
@@ -33,24 +34,26 @@ import (
 //
 //nolint:govet // keeps test injection hooks and binary-path overrides on one handler value
 type Handler struct {
-	cfg                     *config.Config
+	readDirFn               func(name string) ([]os.DirEntry, error)
 	manager                 *session.Manager
-	sshConfigPath           string
-	codeBinaryPath          string // empty = auto-detect; overridden in tests
-	ghBinaryPath            string // empty = auto-detect; overridden in tests
+	boardBroadcastFn        func(ctx context.Context, to []string, body string) ([]string, error)
+	boardCache              *board.BoardCache
+	gitInfoCacheBySession   map[string]gitInfoCacheEntry
 	createSession           func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
 	detectLocalShellFn      func() (string, error)
 	detectRemoteShellFn     func(cfg session.SSHConfig) (string, error)
-	listLocalDirectoriesFn  func(path string, showHidden bool) (directoryBrowserResponse, error)
 	listRemoteDirectoriesFn func(cfg session.SSHConfig, path string, showHidden bool) (directoryBrowserResponse, error)
-	readDirFn               func(name string) ([]os.DirEntry, error)
-	preferredCWDMu          sync.Mutex
+	listLocalDirectoriesFn  func(path string, showHidden bool) (directoryBrowserResponse, error)
 	preferredCWDBySession   map[string][]preferredCWDState
-	restartMu               sync.Mutex
-	restartInFlight         map[string]struct{}
 	nowFn                   func() time.Time
+	cfg                     *config.Config
+	restartInFlight         map[string]struct{}
+	ghBinaryPath            string
+	codeBinaryPath          string
+	sshConfigPath           string
+	restartMu               sync.Mutex
+	preferredCWDMu          sync.Mutex
 	gitInfoCacheMu          sync.Mutex
-	gitInfoCacheBySession   map[string]gitInfoCacheEntry
 }
 
 type preferredCWDState struct {
@@ -149,7 +152,9 @@ type directoryBrowserResponse struct {
 var validHostName = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 
 // NewHandler creates a new API handler.
-func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
+func NewHandler(
+	cfg *config.Config, manager *session.Manager, boardCache *board.BoardCache, boardRelay *board.Relay,
+) *Handler {
 	h := &Handler{
 		cfg:                   cfg,
 		manager:               manager,
@@ -158,6 +163,7 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 		restartInFlight:       make(map[string]struct{}),
 		nowFn:                 time.Now,
 		gitInfoCacheBySession: make(map[string]gitInfoCacheEntry),
+		boardCache:            boardCache,
 	}
 	h.createSession = session.CreateFromConfig
 	h.detectLocalShellFn = session.DetectLocalShell
@@ -165,6 +171,9 @@ func NewHandler(cfg *config.Config, manager *session.Manager) *Handler {
 	h.readDirFn = os.ReadDir
 	h.listLocalDirectoriesFn = h.listLocalDirectories
 	h.listRemoteDirectoriesFn = listRemoteDirectories
+	h.boardBroadcastFn = func(ctx context.Context, to []string, body string) ([]string, error) {
+		return boardRelay.Broadcast(ctx, board.SystemID, to, body)
+	}
 	return h
 }
 

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -81,7 +81,7 @@ func (m *mockSession) Close() error {
 }
 
 func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	// Use a temp empty SSH config to avoid real ~/.ssh/config leaking into tests
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	return setupRouterWithHandler(h)
@@ -110,6 +110,9 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Post("/api/ssh-config/hosts", h.PostSSHConfigHost)
 	r.Get("/api/detect-shell", h.GetDetectShell)
 	r.Get("/api/directories", h.GetDirectories)
+	r.Get("/api/board/status", h.GetBoardStatus)
+	r.Get("/api/board/messages", h.GetBoardMessages)
+	r.Post("/api/board/broadcast", h.PostBoardBroadcast)
 	return r
 }
 
@@ -310,7 +313,7 @@ func TestPutWorkspaceTabPosition_UpdatesEveryValidPositionAndPersists(t *testing
 	for _, position := range []string{"top", "bottom", "left", "right"} {
 		t.Run(position, func(t *testing.T) {
 			cfg, path := loadWorkspaceTestConfigFromFile(t)
-			h := NewHandler(cfg, session.NewManager())
+			h := NewHandler(cfg, session.NewManager(), nil, nil)
 			h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 			r := setupRouterWithHandler(h)
 
@@ -336,7 +339,7 @@ func TestPutWorkspaceTabPosition_UpdatesEveryValidPositionAndPersists(t *testing
 }
 
 func TestPutWorkspaceTabPosition_InvalidBody_Returns400(t *testing.T) {
-	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h := NewHandler(workspaceTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/tab-position", bytes.NewBufferString("not json"))
@@ -347,7 +350,7 @@ func TestPutWorkspaceTabPosition_InvalidBody_Returns400(t *testing.T) {
 
 func TestPutWorkspaceTabPosition_InvalidPosition_Returns422AndKeepsExistingValue(t *testing.T) {
 	cfg := workspaceTestConfig()
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 	assertWorkspaceSettingRejected(
 		t,
@@ -363,7 +366,7 @@ func TestPutWorkspaceTabPosition_InvalidPosition_Returns422AndKeepsExistingValue
 
 func TestPutWorkspaceVerticalBarWidth_UpdatesAndPersists(t *testing.T) {
 	cfg, path := loadWorkspaceTestConfigFromFile(t)
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -387,7 +390,7 @@ func TestPutWorkspaceVerticalBarWidth_UpdatesAndPersists(t *testing.T) {
 }
 
 func TestPutWorkspaceVerticalBarWidth_InvalidBody_Returns400(t *testing.T) {
-	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h := NewHandler(workspaceTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/workspaces/vertical-bar-width", bytes.NewBufferString("not json"))
@@ -398,7 +401,7 @@ func TestPutWorkspaceVerticalBarWidth_InvalidBody_Returns400(t *testing.T) {
 
 func TestPutWorkspaceVerticalBarWidth_InvalidWidth_Returns422AndKeepsExistingValue(t *testing.T) {
 	cfg := workspaceTestConfig()
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 	assertWorkspaceSettingRejected(
 		t,
@@ -415,7 +418,7 @@ func TestPutWorkspaceVerticalBarWidth_InvalidWidth_Returns422AndKeepsExistingVal
 func TestPostWorkspace_AddsDefaultLocalWorkspaceAndPersists(t *testing.T) {
 	cfg, path := loadWorkspaceTestConfigFromFile(t)
 	mgr := session.NewManager()
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
 		return newMockSession(pane.ID), nil
@@ -451,7 +454,7 @@ func TestPostWorkspace_AddsDefaultLocalWorkspaceAndPersists(t *testing.T) {
 
 func TestDeleteWorkspace_NotFound_Returns404(t *testing.T) {
 	cfg := workspaceTestConfig()
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -464,7 +467,7 @@ func TestDeleteWorkspace_NotFound_Returns404(t *testing.T) {
 
 func TestDeleteWorkspace_LastWorkspace_Returns409(t *testing.T) {
 	cfg := defaultTestConfig()
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -481,7 +484,7 @@ func TestDeleteWorkspace_RemovesWorkspaceSessionsAndPersists(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("one-main"))
 	mgr.Add(newMockSession("two-main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -512,7 +515,7 @@ func TestDeleteWorkspace_ClearsPreferredCWDForRemovedPanes(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("one-main"))
 	mgr.Add(newMockSession("two-main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.preferredCWDBySession["two-main"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
@@ -536,7 +539,7 @@ func TestDeleteWorkspace_ClearsGitInfoCacheForRemovedPanes(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("one-main"))
 	mgr.Add(newMockSession("two-main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.gitInfoCacheBySession["two-main"] = gitInfoCacheEntry{
 		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
@@ -555,7 +558,7 @@ func TestDeleteWorkspace_ClearsGitInfoCacheForRemovedPanes(t *testing.T) {
 
 func TestPutWorkspace_RenamesWorkspaceAndPersists(t *testing.T) {
 	cfg, path := loadWorkspaceTestConfigFromFile(t)
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -579,7 +582,7 @@ func TestPutWorkspace_RenamesWorkspaceAndPersists(t *testing.T) {
 }
 
 func TestPutWorkspace_InvalidBody_Returns400(t *testing.T) {
-	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h := NewHandler(workspaceTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -591,7 +594,7 @@ func TestPutWorkspace_InvalidBody_Returns400(t *testing.T) {
 }
 
 func TestPutWorkspace_BlankTitle_Returns422(t *testing.T) {
-	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h := NewHandler(workspaceTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -605,7 +608,7 @@ func TestPutWorkspace_BlankTitle_Returns422(t *testing.T) {
 }
 
 func TestPutWorkspace_NotFound_Returns404(t *testing.T) {
-	h := NewHandler(workspaceTestConfig(), session.NewManager())
+	h := NewHandler(workspaceTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	r := setupRouterWithHandler(h)
 
@@ -817,7 +820,7 @@ func TestDeleteSession_NotFound_404(t *testing.T) {
 }
 
 func TestPostSession_ValidLocal_201(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
 		return newMockSession(pane.ID), nil
@@ -869,7 +872,7 @@ func TestRestartSession_Found_200(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main")) // pre-existing (exited) session
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
 		return newMockSession(pane.ID), nil
@@ -898,7 +901,7 @@ func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.preferredCWDBySession["main"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
@@ -931,7 +934,7 @@ func TestRestartSession_ClearsGitInfoCache(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.gitInfoCacheBySession["main"] = gitInfoCacheEntry{
 		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
@@ -972,7 +975,7 @@ func TestRestartSession_CreateFails_OldSessionStaysRegistered(t *testing.T) {
 	mgr := session.NewManager()
 	original := newMockSession("main")
 	mgr.Add(original)
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
 		return nil, errors.New("dial failed")
@@ -1003,7 +1006,7 @@ func TestRestartSession_CreateFails_PreservesPreferredCWD(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.preferredCWDBySession["main"] = []preferredCWDState{{
 		CWD:       "/remote/home/demo",
@@ -1036,7 +1039,7 @@ func TestRestartSession_CreateFails_500Body(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
 		return nil, errors.New("dial tcp: lookup host.example: no such host")
@@ -1062,7 +1065,7 @@ func TestRestartSession_CreateFails_NoPanicWhenNoPriorSession(t *testing.T) {
 		},
 	}
 	mgr := session.NewManager()
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error) {
 		return nil, errors.New("dial failed")
@@ -1099,7 +1102,7 @@ func TestRestartSession_ConcurrentRequests_SecondReturns409(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 
 	started := make(chan struct{})
@@ -1158,7 +1161,7 @@ func TestRestartSession_GuardReleasedAfterCompletion(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("main"))
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-ssh-config-nonexistent")
 	h.createSession = func(pane *config.PaneConfig, _ map[string]config.SSHConnection) (session.Session, error) {
 		return nil, errors.New("dial failed")
@@ -1200,7 +1203,7 @@ func TestDeleteSession_ClearsPreferredCWD(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
 	cfg := defaultTestConfig()
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.preferredCWDBySession["s1"] = []preferredCWDState{{
 		CWD:       "/tmp/worktree",
 		CommonDir: "/repo/.git",
@@ -1221,7 +1224,7 @@ func TestDeleteSession_ClearsGitInfoCache(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
 	cfg := defaultTestConfig()
-	h := NewHandler(cfg, mgr)
+	h := NewHandler(cfg, mgr, nil, nil)
 	h.gitInfoCacheBySession["s1"] = gitInfoCacheEntry{
 		expiresAt: h.nowFn().Add(gitInfoCacheTTL),
 		response:  gitInfoResponse{IsGit: true, Branch: "stale-branch"},
@@ -1373,7 +1376,7 @@ func TestGetSSHConnections_MergesSSHConfigHosts(t *testing.T) {
 		"yaml-conn": {Host: "yaml.example.com", Port: 22, User: "bob"},
 	}
 
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1398,7 +1401,7 @@ func TestGetSSHConnections_SSHConfigTakesPrecedenceOnConflict(t *testing.T) {
 		"shared": {Host: "yaml.example.com", Port: 22, User: "bob"},
 	}
 
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1419,7 +1422,7 @@ func TestGetSSHConfigHosts_ReturnsHosts(t *testing.T) {
 		"Host myhost\n    HostName myhost.example.com\n    User ubuntu\n    Port 2222\n",
 	)
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1440,7 +1443,7 @@ func TestGetSSHConfigHosts_ReturnsHosts(t *testing.T) {
 func TestGetSSHConfigHosts_Empty(t *testing.T) {
 	sshConfigPath := writeTempSSHConfigForAPI(t, "")
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1458,7 +1461,7 @@ func TestPostSSHConfigHost_ValidHost_201(t *testing.T) {
 	dir := t.TempDir()
 	sshConfigPath := filepath.Join(dir, "config")
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1490,7 +1493,7 @@ func TestPostSSHConfigHost_MissingName_422(t *testing.T) {
 func postSSHConfigHost(t *testing.T, body sshConfigHostRequest) *httptest.ResponseRecorder {
 	t.Helper()
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
@@ -1503,7 +1506,7 @@ func postSSHConfigHost(t *testing.T, body sshConfigHostRequest) *httptest.Respon
 }
 
 func TestPostSSHConfigHost_InvalidNameChars_422(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
@@ -1529,7 +1532,7 @@ func TestPostSSHConfigHost_MissingUser_422(t *testing.T) {
 }
 
 func TestPostSSHConfigHost_PortOutOfRange_422(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
@@ -1550,7 +1553,7 @@ func TestPostSSHConfigHost_PortOutOfRange_422(t *testing.T) {
 func TestPostSSHConfigHost_DuplicateName_409(t *testing.T) {
 	sshConfigPath := writeTempSSHConfigForAPI(t, "Host existing\n    HostName existing.example.com\n    User ubuntu\n")
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = sshConfigPath
 	r := setupRouterWithHandler(h)
 
@@ -1564,7 +1567,7 @@ func TestPostSSHConfigHost_DuplicateName_409(t *testing.T) {
 }
 
 func TestPostSSHConfigHost_InvalidBody_400(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(t.TempDir(), "config")
 	r := setupRouterWithHandler(h)
 
@@ -1579,12 +1582,12 @@ func TestPostSSHConfigHost_InvalidBody_400(t *testing.T) {
 //
 //nolint:govet // test helper layout is not performance-sensitive
 type mockCWDSession struct {
-	activeErr error
-	cwdErr    error
-	cwd       string
-	mockSession
+	activeErr      error
+	cwdErr         error
+	cwd            string
 	activeWorkdirs []string
-	getCWDCalls    int
+	mockSession
+	getCWDCalls int
 }
 
 func (m *mockCWDSession) GetCWD() (string, error) {
@@ -1612,13 +1615,13 @@ func (m *mockSSHCWDSession) ConnectionName() string  { return m.connName }
 //
 //nolint:govet // test helper layout is not performance-sensitive
 type mockRemoteGitSession struct {
-	activeErr   error
-	cwdErr      error
-	gitContexts map[string]session.GitContext
-	gitErrs     map[string]error
-	cwd         string
-	mockSession
+	activeErr      error
+	cwdErr         error
+	gitContexts    map[string]session.GitContext
+	gitErrs        map[string]error
+	cwd            string
 	activeWorkdirs []string
+	mockSession
 }
 
 func (m *mockRemoteGitSession) GetCWD() (string, error) { return m.cwd, m.cwdErr }
@@ -1650,7 +1653,7 @@ func setupRouterWithVSCode(h *Handler) *chi.Mux {
 }
 
 func TestPostOpenVSCode_NotFound_404(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithVSCode(h)
 
 	rec := httptest.NewRecorder()
@@ -1663,7 +1666,7 @@ func TestPostOpenVSCode_NotFound_404(t *testing.T) {
 func TestPostOpenVSCode_NoCWDGetter_422(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithVSCode(h)
 
 	rec := httptest.NewRecorder()
@@ -1721,7 +1724,7 @@ func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
 
 	mgr := session.NewManager()
 	mgr.Add(sess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
@@ -1746,7 +1749,7 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 
 	mgr := session.NewManager()
 	mgr.Add(sess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
@@ -1792,7 +1795,7 @@ func TestResolveActiveGitContexts_ReusesInspectedContext(t *testing.T) {
 		},
 	}
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	contexts, err := h.resolveActiveGitContexts(sess, sess.cwd)
 	require.NoError(t, err)
 	require.Len(t, contexts, 1)
@@ -1805,7 +1808,7 @@ func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeR
 
 	mgr := session.NewManager()
 	mgr.Add(sess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
@@ -1833,7 +1836,7 @@ func TestPostOpenVSCode_Local_DeletedDir_422(t *testing.T) {
 		mockSession: mockSession{id: "local-del", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
@@ -1861,7 +1864,7 @@ func TestPostOpenVSCode_SSH_InvalidConnName_422(t *testing.T) {
 		cwd:         "/home/user",
 		connName:    "bad name; rm -rf /",
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
 	r := setupRouterWithVSCode(h)
 
@@ -1893,7 +1896,7 @@ func TestPostOpenVSCode_SSHTmux_200(t *testing.T) {
 }
 
 func TestGetDetectShell_Local_Success(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "nonexistent")
 	h.detectLocalShellFn = func() (string, error) { return "/usr/bin/zsh", nil }
 	h.detectRemoteShellFn = func(cfg session.SSHConfig) (string, error) {
@@ -1918,7 +1921,7 @@ func TestGetDetectShell_SSH_Success(t *testing.T) {
 	cfg.SSHConnections = map[string]config.SSHConnection{
 		"myhost": {Host: "myhost.example.com", User: "admin"},
 	}
-	h := NewHandler(cfg, session.NewManager())
+	h := NewHandler(cfg, session.NewManager(), nil, nil)
 	h.detectRemoteShellFn = func(sshCfg session.SSHConfig) (string, error) {
 		return "/bin/bash", nil
 	}
@@ -1937,7 +1940,7 @@ func TestGetDetectShell_SSH_Success(t *testing.T) {
 }
 
 func TestGetDetectShell_SSH_ConnectionNotFound(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = filepath.Join(os.TempDir(), "panemux-test-empty-ssh-cfg")
 	r := setupRouterWithHandler(h)
 
@@ -1949,7 +1952,7 @@ func TestGetDetectShell_SSH_ConnectionNotFound(t *testing.T) {
 }
 
 func TestGetDetectShell_DetectFails(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.detectLocalShellFn = func() (string, error) { return "", errors.New("cannot detect") }
 	r := setupRouterWithHandler(h)
 
@@ -2013,7 +2016,7 @@ func setupRouterWithGitInfo(h *Handler) *chi.Mux {
 }
 
 func TestGetGitInfo_NotFound_404(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2026,7 +2029,7 @@ func TestGetGitInfo_NotFound_404(t *testing.T) {
 func TestGetGitInfo_NoCWDGetter_IsGitFalse(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2046,7 +2049,7 @@ func TestGetGitInfo_NotAGitRepo_IsGitFalse(t *testing.T) {
 		mockSession: mockSession{id: "local1", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2077,7 +2080,7 @@ func TestGetGitInfo_NotAGitRepo_LogsCauseAndRemediation(t *testing.T) {
 		log.SetFlags(originalFlags)
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2103,7 +2106,7 @@ func TestGetGitInfo_IsGitRepo_ReturnsBranchAndRepo(t *testing.T) {
 		mockSession: mockSession{id: "local2", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2136,7 +2139,7 @@ func TestGetGitInfo_IsGitRepo_WithLinkedPR_ReturnsPRInfo(t *testing.T) {
 		mockSession: mockSession{id: "local-pr", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/123\",\"number\":123}'\n",
@@ -2167,7 +2170,7 @@ func TestGetGitInfo_SubdirOfGitRepo_ReturnsBranchAndRepo(t *testing.T) {
 		mockSession: mockSession{id: "sub1", typ: session.TypeLocal},
 		cwd:         subdir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2188,7 +2191,7 @@ func TestGetGitInfo_PRLookupFails_StillReturnsGitInfo(t *testing.T) {
 		mockSession: mockSession{id: "local-pr-miss", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nexit 1\n")
 	r := setupRouterWithGitInfo(h)
 
@@ -2215,7 +2218,7 @@ func TestGetGitInfo_DetachedHead_StillReturnsGitInfo(t *testing.T) {
 		mockSession: mockSession{id: "detached", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2231,7 +2234,7 @@ func TestGetGitInfo_DetachedHead_StillReturnsGitInfo(t *testing.T) {
 }
 
 func TestLookupPRInfo_TimesOutAndFallsBack(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nsleep 1\n")
 	prev := prLookupTimeout
 	prLookupTimeout = 10 * time.Millisecond
@@ -2253,7 +2256,7 @@ func TestGetGitInfo_ActiveAgentWorkdir_PrefersWorktreeBranch(t *testing.T) {
 		cwd:            repoDir,
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/456\",\"number\":456}'\n",
@@ -2285,7 +2288,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_ReturnsAllWorktreesWithPRs(t *testin
 		cwd:            repoDir,
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, ""+
 		"#!/bin/sh\n"+
 		"case \"$3\" in\n"+
@@ -2334,7 +2337,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_DuplicateRootDeduped(t *testing.T) {
 		cwd:            repoDir,
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/111\",\"number\":111}'\n",
@@ -2364,7 +2367,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_OnePRLookupFails_OthersStillReturned
 		cwd:            repoDir,
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, ""+
 		"#!/bin/sh\n"+
 		"case \"$3\" in\n"+
@@ -2403,7 +2406,7 @@ func TestGetGitInfo_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 		cwd:            repoDir,
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/789\",\"number\":789}'\n",
@@ -2433,7 +2436,7 @@ func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(sess)
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/999\",\"number\":999}'\n",
@@ -2473,7 +2476,7 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(sess)
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
 	r := setupRouterWithGitInfo(h)
@@ -2543,7 +2546,7 @@ func TestResolveSinglePreferredCWD_StickyWorktreeIgnoredAfterRepoChange(t *testi
 		},
 	}
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	assert.Equal(t, worktreeDir, h.resolveSinglePreferredCWD(sess, sess.cwd))
 
 	sess.activeWorkdirs = nil
@@ -2583,7 +2586,7 @@ func TestResolveSinglePreferredCWD_LogsPaneIdentity(t *testing.T) {
 		log.SetFlags(originalFlags)
 	})
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	assert.Equal(t, "/repo/base-worktree", h.resolveSinglePreferredCWD(sess, sess.cwd))
 	assert.Contains(t, buf.String(), `git info pane="pane-123" type="ssh_tmux" selected active workdir`)
 }
@@ -2618,7 +2621,7 @@ func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(sess)
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/654\",\"number\":654}'\n",
@@ -2652,7 +2655,7 @@ func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
 		mockSession: mockSession{id: "local3", typ: session.TypeLocal},
 		cwd:         dir,
 	})
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	prev := gitExistsFn
 	gitExistsFn = func() error { return errors.New("git not found") }
 	t.Cleanup(func() { gitExistsFn = prev })
@@ -2676,7 +2679,7 @@ func TestGetGitInfo_SecondRequestWithinTTL_ServesCachedResponseWithoutRecomputin
 	}
 	mgr := session.NewManager()
 	mgr.Add(sess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
 	r := setupRouterWithGitInfo(h)
@@ -2712,7 +2715,7 @@ func TestGetGitInfo_RequestAfterTTLExpires_Recomputes(t *testing.T) {
 	}
 	mgr := session.NewManager()
 	mgr.Add(sess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
 	r := setupRouterWithGitInfo(h)
@@ -2742,7 +2745,7 @@ func TestGetGitInfo_AfterSessionRecreatedWithSameID_DoesNotServeOldSessionsCache
 	oldSess.ensureBuf()
 	mgr := session.NewManager()
 	mgr.Add(oldSess)
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2800,7 +2803,7 @@ func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 		},
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2845,7 +2848,7 @@ func TestGetGitInfo_RemoteGitContextFailure_LogsCauseAndRemediation(t *testing.T
 		log.SetFlags(originalFlags)
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2887,7 +2890,7 @@ func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T
 		},
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2921,7 +2924,7 @@ func TestGetGitInfo_RemoteGitContext_WithOrigin_ReturnsRepoURL(t *testing.T) {
 		},
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	r := setupRouterWithGitInfo(h)
 
 	rec := httptest.NewRecorder()
@@ -2953,7 +2956,7 @@ func TestGetGitInfo_RemoteGitContext_WithSSHConfigAliasOrigin_ReturnsResolvedRep
 		},
 	})
 
-	h := NewHandler(defaultTestConfig(), mgr)
+	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
 	r := setupRouterWithGitInfo(h)
 
@@ -2969,7 +2972,7 @@ func TestGetGitInfo_RemoteGitContext_WithSSHConfigAliasOrigin_ReturnsResolvedRep
 }
 
 func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nexit 99\n")
 
 	url, number := h.lookupPRInfo(&mockRemoteGitSession{}, "/home/demo/panemux", session.GitContext{
@@ -2980,7 +2983,7 @@ func TestLookupPRInfo_RemoteSessionWithoutOriginSkipsLookup(t *testing.T) {
 }
 
 func TestLookupPRInfo_RemoteSessionWithSSHConfigAliasOrigin_UsesResolvedRepoSpec(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
 	h.ghBinaryPath = writeFakeGHBinary(
 		t,
@@ -3108,7 +3111,7 @@ func TestRepoPageURLFromOriginURL(t *testing.T) {
 }
 
 func TestHandlerRepoPageURLFromOriginURL_ResolvesSSHConfigAlias(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
 
 	got := h.repoPageURLFromOriginURL("git@github-work:example/panemux.git")
@@ -3117,7 +3120,7 @@ func TestHandlerRepoPageURLFromOriginURL_ResolvesSSHConfigAlias(t *testing.T) {
 }
 
 func TestHandlerRepoPageURLFromOriginURL_LeavesUnknownSCPHostUntouched(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
 
 	got := h.repoPageURLFromOriginURL("git@source:example/panemux.git")
@@ -3126,7 +3129,7 @@ func TestHandlerRepoPageURLFromOriginURL_LeavesUnknownSCPHostUntouched(t *testin
 }
 
 func TestHandlerRepoSpecFromOriginURL_ResolvesSSHConfigAlias(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
 
 	got := h.repoSpecFromOriginURL("git@github-work:example/panemux.git")
@@ -3146,7 +3149,7 @@ func TestGetDirectories_LocalPathReturnsDirectories(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0600))
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -3165,7 +3168,7 @@ func TestGetDirectories_ShowHiddenIncludesHiddenDirectories(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -3184,7 +3187,7 @@ func TestGetDirectories_NoVisibleChildDirectoriesReturnsEmptyArray(t *testing.T)
 	require.NoError(t, os.Mkdir(filepath.Join(dir, ".hidden"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("x"), 0600))
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -3196,7 +3199,7 @@ func TestGetDirectories_NoVisibleChildDirectoriesReturnsEmptyArray(t *testing.T)
 }
 
 func TestGetDirectories_UsesRemoteConnectionWhenProvided(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	h.listRemoteDirectoriesFn = func(
 		cfg session.SSHConfig,
 		path string,
@@ -3229,7 +3232,7 @@ func TestGetDirectories_UsesRemoteConnectionWhenProvided(t *testing.T) {
 }
 
 func TestGetDirectories_InvalidLocalPathReturns422(t *testing.T) {
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
@@ -3247,7 +3250,7 @@ func TestGetDirectories_SkipsUnreadableChildDirectories(t *testing.T) {
 	require.NoError(t, os.Mkdir(filepath.Join(readableDir, "nested"), 0755))
 	require.NoError(t, os.Mkdir(unreadableDir, 0755))
 
-	h := NewHandler(defaultTestConfig(), session.NewManager())
+	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
 	originalReadDir := h.readDirFn
 	h.readDirFn = func(name string) ([]os.DirEntry, error) {
 		if name == unreadableDir {

--- a/internal/board/agmsg_fixture_test.go
+++ b/internal/board/agmsg_fixture_test.go
@@ -113,7 +113,7 @@ func TestAgmsgFixture_TeamMessages_BoardCacheIntegration(t *testing.T) {
 	// ordinary message and IS appended.
 	history := cache.MessagesSince(0)
 	require.Len(t, history, 3)
-	bodies := []string{history[0].Body, history[1].Body, history[2].Body}
+	bodies := []string{history[0].Row.Body, history[1].Row.Body, history[2].Row.Body}
 	assert.Equal(t, []string{
 		"please review my latest commit",
 		`{"state":"looks like status but has no kind field"}`,

--- a/internal/board/agmsg_path.go
+++ b/internal/board/agmsg_path.go
@@ -1,0 +1,38 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// remoteHomeProbeCmd is a fixed, non-tainted command run once per remote
+// host to resolve $HOME for expanding a leading ~/ in agent_board.agmsg_path
+// before it ever reaches a RunBoardCommand argument list — a literal ~
+// inside quoteArgs's single-quoting never expands on the remote shell (see
+// docs/agent-board.md's "~ in agmsg_path is expanded by panemux" note).
+const remoteHomeProbeCmd = `echo -n "$HOME"`
+
+// ResolveRemoteAgmsgPath expands a leading ~/ in path against the remote
+// host's own $HOME, reached through executor. A path that doesn't start
+// with ~/ (e.g. already absolute) is returned unchanged, with no
+// RunBoardCommand call at all. Callers are expected to cache the result for
+// the life of a connection — this function itself makes no attempt to
+// cache, matching internal/board's existing per-call, stateless convention
+// (see AgmsgClient's own doc comments).
+func ResolveRemoteAgmsgPath(ctx context.Context, executor BoardExecutor, path string) (string, error) {
+	if !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+
+	out, err := executor.RunBoardCommand(ctx, []string{"sh", "-c", remoteHomeProbeCmd})
+	if err != nil {
+		return "", fmt.Errorf("agmsg: resolving remote $HOME: %w", err)
+	}
+	home := strings.TrimSpace(string(out))
+	if home == "" {
+		return "", errors.New("agmsg: remote $HOME is empty")
+	}
+	return home + "/" + path[2:], nil
+}

--- a/internal/board/agmsg_path.go
+++ b/internal/board/agmsg_path.go
@@ -12,7 +12,11 @@ import (
 // before it ever reaches a RunBoardCommand argument list — a literal ~
 // inside quoteArgs's single-quoting never expands on the remote shell (see
 // docs/agent-board.md's "~ in agmsg_path is expanded by panemux" note).
-const remoteHomeProbeCmd = `echo -n "$HOME"`
+// printf, not "echo -n", because -n is not part of POSIX echo — some /bin/sh
+// implementations print it literally instead of suppressing the trailing
+// newline, which would otherwise corrupt the probed path in a way that's
+// confusing to diagnose (a path literally starting with "-n ").
+const remoteHomeProbeCmd = `printf '%s' "$HOME"`
 
 // ResolveRemoteAgmsgPath expands a leading ~/ in path against the remote
 // host's own $HOME, reached through executor. A path that doesn't start
@@ -33,6 +37,9 @@ func ResolveRemoteAgmsgPath(ctx context.Context, executor BoardExecutor, path st
 	home := strings.TrimSpace(string(out))
 	if home == "" {
 		return "", errors.New("agmsg: remote $HOME is empty")
+	}
+	if !strings.HasPrefix(home, "/") {
+		return "", fmt.Errorf("agmsg: remote $HOME is not an absolute path: %q", home)
 	}
 	return home + "/" + path[2:], nil
 }

--- a/internal/board/agmsg_path_test.go
+++ b/internal/board/agmsg_path_test.go
@@ -1,0 +1,58 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRemoteAgmsgPath_TildePrefixed_ExpandsAgainstRemoteHome(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		strings.Join([]string{"sh", "-c", remoteHomeProbeCmd}, "\x00"): []byte("/home/remote-user"),
+	}}
+
+	got, err := ResolveRemoteAgmsgPath(context.Background(), exec, "~/.agents/skills/agmsg")
+	require.NoError(t, err)
+	assert.Equal(t, "/home/remote-user/.agents/skills/agmsg", got)
+}
+
+func TestResolveRemoteAgmsgPath_AbsolutePath_ReturnedUnchanged_NoExecutorCall(t *testing.T) {
+	exec := &fakeBoardExecutor{}
+
+	got, err := ResolveRemoteAgmsgPath(context.Background(), exec, "/opt/agmsg")
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/agmsg", got)
+	assert.Empty(t, exec.calls, "an already-absolute path must never trigger a RunBoardCommand call")
+}
+
+func TestResolveRemoteAgmsgPath_ExecutorError_Wrapped(t *testing.T) {
+	wantErr := errors.New("ssh: connection lost")
+	exec := &fakeBoardExecutor{err: wantErr}
+
+	_, err := ResolveRemoteAgmsgPath(context.Background(), exec, "~/agmsg")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestResolveRemoteAgmsgPath_EmptyHomeResponse_Error(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		strings.Join([]string{"sh", "-c", remoteHomeProbeCmd}, "\x00"): []byte(""),
+	}}
+
+	_, err := ResolveRemoteAgmsgPath(context.Background(), exec, "~/agmsg")
+	assert.Error(t, err)
+}
+
+func TestResolveRemoteAgmsgPath_TrimsWhitespaceFromProbeResponse(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		strings.Join([]string{"sh", "-c", remoteHomeProbeCmd}, "\x00"): []byte("/home/remote-user\n"),
+	}}
+
+	got, err := ResolveRemoteAgmsgPath(context.Background(), exec, "~/agmsg")
+	require.NoError(t, err)
+	assert.Equal(t, "/home/remote-user/agmsg", got)
+}

--- a/internal/board/agmsg_path_test.go
+++ b/internal/board/agmsg_path_test.go
@@ -56,3 +56,17 @@ func TestResolveRemoteAgmsgPath_TrimsWhitespaceFromProbeResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "/home/remote-user/agmsg", got)
 }
+
+func TestResolveRemoteAgmsgPath_NonAbsoluteProbeResponse_Error(t *testing.T) {
+	// Regression test: a non-POSIX echo -n printing "-n" literally (fixed by
+	// switching to printf), or any other shell quirk that corrupts the
+	// probe response, must fail loudly rather than silently building a
+	// broken, relative agmsg path.
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		strings.Join([]string{"sh", "-c", remoteHomeProbeCmd}, "\x00"): []byte("-n /home/remote-user"),
+	}}
+
+	_, err := ResolveRemoteAgmsgPath(context.Background(), exec, "~/agmsg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an absolute path")
+}

--- a/internal/board/cache.go
+++ b/internal/board/cache.go
@@ -11,7 +11,11 @@ import (
 // cache isn't immediately trimmed back down.
 const defaultBoardCacheHistoryLimit = 2000
 
-type cachedRow struct {
+// CachedRow pairs a Row with the BoardCache-local Seq it was assigned when
+// appended. Exported because GET /api/board/messages?since=<seq> needs the
+// Seq back from every returned row to use as its next since cursor — a bare
+// []Row would discard exactly the value the caller needs.
+type CachedRow struct {
 	Row Row
 	Seq int64
 }
@@ -26,7 +30,7 @@ type cachedRow struct {
 type BoardCache struct {
 	status     map[string]Status
 	now        func() time.Time
-	history    []cachedRow
+	history    []CachedRow
 	nextSeq    int64
 	maxHistory int
 	mu         sync.RWMutex
@@ -60,7 +64,7 @@ func (c *BoardCache) AppendMessage(r Row) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.nextSeq++
-	c.history = append(c.history, cachedRow{Seq: c.nextSeq, Row: r})
+	c.history = append(c.history, CachedRow{Seq: c.nextSeq, Row: r})
 	if overflow := len(c.history) - c.maxHistory; overflow > 0 {
 		c.history = c.history[overflow:]
 	}
@@ -77,16 +81,16 @@ func (c *BoardCache) StatusSnapshot() map[string]Status {
 	return out
 }
 
-// MessagesSince returns every history row whose Seq is greater than
-// afterSeq, oldest first. An empty or fully-consumed history returns nil,
-// never an error.
-func (c *BoardCache) MessagesSince(afterSeq int64) []Row {
+// MessagesSince returns every history row (with its Seq) whose Seq is
+// greater than afterSeq, oldest first. An empty or fully-consumed history
+// returns nil, never an error.
+func (c *BoardCache) MessagesSince(afterSeq int64) []CachedRow {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	var out []Row
+	var out []CachedRow
 	for _, cr := range c.history {
 		if cr.Seq > afterSeq {
-			out = append(out, cr.Row)
+			out = append(out, cr)
 		}
 	}
 	return out

--- a/internal/board/cache_test.go
+++ b/internal/board/cache_test.go
@@ -59,8 +59,10 @@ func TestBoardCache_AppendMessage_AssignsIncreasingSeq(t *testing.T) {
 
 	rows := c.MessagesSince(0)
 	require.Len(t, rows, 2)
-	assert.Equal(t, "first", rows[0].Body)
-	assert.Equal(t, "second", rows[1].Body)
+	assert.Equal(t, "first", rows[0].Row.Body)
+	assert.Equal(t, "second", rows[1].Row.Body)
+	assert.Equal(t, int64(1), rows[0].Seq)
+	assert.Equal(t, int64(2), rows[1].Seq)
 }
 
 func TestBoardCache_MessagesSince_FiltersByAfterSeq(t *testing.T) {
@@ -71,8 +73,8 @@ func TestBoardCache_MessagesSince_FiltersByAfterSeq(t *testing.T) {
 
 	rows := c.MessagesSince(1)
 	require.Len(t, rows, 2)
-	assert.Equal(t, "two", rows[0].Body)
-	assert.Equal(t, "three", rows[1].Body)
+	assert.Equal(t, "two", rows[0].Row.Body)
+	assert.Equal(t, "three", rows[1].Row.Body)
 }
 
 func TestBoardCache_MessagesSince_EmptyHistory_ReturnsNilNotError(t *testing.T) {
@@ -96,9 +98,9 @@ func TestBoardCache_AppendMessage_BoundedHistory_DropsOldest(t *testing.T) {
 
 	rows := c.MessagesSince(0)
 	require.Len(t, rows, 3)
-	assert.Equal(t, "c", rows[0].Body)
-	assert.Equal(t, "d", rows[1].Body)
-	assert.Equal(t, "e", rows[2].Body)
+	assert.Equal(t, "c", rows[0].Row.Body)
+	assert.Equal(t, "d", rows[1].Row.Body)
+	assert.Equal(t, "e", rows[2].Row.Body)
 }
 
 func TestBoardCache_AppendMessage_BoundedHistory_SeqKeepsIncreasingPastBound(t *testing.T) {
@@ -113,8 +115,10 @@ func TestBoardCache_AppendMessage_BoundedHistory_SeqKeepsIncreasingPastBound(t *
 	// only what survived (b, c), not error or resurrect the dropped row.
 	rows := c.MessagesSince(0)
 	require.Len(t, rows, 2)
-	assert.Equal(t, "b", rows[0].Body)
-	assert.Equal(t, "c", rows[1].Body)
+	assert.Equal(t, "b", rows[0].Row.Body)
+	assert.Equal(t, "c", rows[1].Row.Body)
+	assert.Equal(t, int64(2), rows[0].Seq, "Seq must reflect the original assignment, not be renumbered after truncation")
+	assert.Equal(t, int64(3), rows[1].Seq)
 }
 
 func TestBoardCache_ConcurrentReadWrite_NoRace(t *testing.T) {

--- a/internal/board/cursor_store.go
+++ b/internal/board/cursor_store.go
@@ -1,0 +1,64 @@
+package board
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const cursorFileName = "board-relay-cursor.json"
+const cursorFileMode os.FileMode = 0600
+
+// CursorEntry is one (host, team) relay poll cursor. Persisted as a JSON
+// array rather than a map keyed by an encoded "host|team" string, since
+// host names (SSH connection aliases in particular) and team names aren't
+// constrained enough to guarantee any chosen delimiter is collision-free.
+type CursorEntry struct {
+	Host   string
+	Team   string
+	Cursor string
+}
+
+// LoadCursorFile reads previously persisted cursor entries. A missing file
+// is the normal state before the relay's first successful save, not an
+// error, and returns a nil slice.
+func LoadCursorFile(path string) ([]CursorEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading relay cursor file: %w", err)
+	}
+	var entries []CursorEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parsing relay cursor file: %w", err)
+	}
+	return entries, nil
+}
+
+// SaveCursorFile persists entries, creating the parent directory if needed.
+func SaveCursorFile(path string, entries []CursorEntry) error {
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return fmt.Errorf("encoding relay cursor file: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return fmt.Errorf("creating relay cursor directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, cursorFileMode); err != nil {
+		return fmt.Errorf("writing relay cursor file: %w", err)
+	}
+	return nil
+}
+
+// DefaultCursorFilePath returns ~/.config/panemux/board-relay-cursor.json.
+func DefaultCursorFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", cursorFileName), nil
+}

--- a/internal/board/cursor_store.go
+++ b/internal/board/cursor_store.go
@@ -40,16 +40,38 @@ func LoadCursorFile(path string) ([]CursorEntry, error) {
 }
 
 // SaveCursorFile persists entries, creating the parent directory if needed.
+// The write goes through a temp file plus rename, not a direct WriteFile,
+// so a crash or power loss mid-write can never leave a truncated or
+// half-written cursor file on disk — a rename onto an existing path is
+// atomic on the platforms panemux targets, unlike a direct write.
 func SaveCursorFile(path string, entries []CursorEntry) error {
 	data, err := json.Marshal(entries)
 	if err != nil {
 		return fmt.Errorf("encoding relay cursor file: %w", err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
-		return fmt.Errorf("creating relay cursor directory: %w", err)
+	dir := filepath.Dir(path)
+	if mkdirErr := os.MkdirAll(dir, 0750); mkdirErr != nil {
+		return fmt.Errorf("creating relay cursor directory: %w", mkdirErr)
 	}
-	if err := os.WriteFile(path, data, cursorFileMode); err != nil {
-		return fmt.Errorf("writing relay cursor file: %w", err)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp relay cursor file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp relay cursor file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp relay cursor file: %w", err)
+	}
+	if err := os.Chmod(tmpPath, cursorFileMode); err != nil {
+		return fmt.Errorf("setting relay cursor file mode: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replacing relay cursor file: %w", err)
 	}
 	return nil
 }

--- a/internal/board/cursor_store_test.go
+++ b/internal/board/cursor_store_test.go
@@ -1,0 +1,73 @@
+package board
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveCursorFile_ThenLoad_RoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cursor.json")
+	entries := []CursorEntry{
+		{Host: "local", Team: "panemux", Cursor: "5"},
+		{Host: "build-host", Team: "panemux", Cursor: "12"},
+	}
+
+	require.NoError(t, SaveCursorFile(path, entries))
+
+	loaded, err := LoadCursorFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, entries, loaded)
+}
+
+func TestSaveCursorFile_SetsFileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cursor.json")
+	require.NoError(t, SaveCursorFile(path, []CursorEntry{{Host: "local", Team: "t", Cursor: "1"}}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestSaveCursorFile_CreatesParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "dir", "cursor.json")
+	require.NoError(t, SaveCursorFile(path, []CursorEntry{{Host: "local", Team: "t", Cursor: "1"}}))
+
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+}
+
+func TestLoadCursorFile_MissingFile_ReturnsNilNotError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+
+	entries, err := LoadCursorFile(path)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+}
+
+func TestLoadCursorFile_MalformedJSON_Error(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cursor.json")
+	require.NoError(t, os.WriteFile(path, []byte("not valid json"), 0600))
+
+	_, err := LoadCursorFile(path)
+	assert.Error(t, err)
+}
+
+func TestLoadCursorFile_EmptyArray_ReturnsEmptySlice(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cursor.json")
+	require.NoError(t, os.WriteFile(path, []byte("[]"), 0600))
+
+	entries, err := LoadCursorFile(path)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestDefaultCursorFilePath_ContainsExpectedSuffix(t *testing.T) {
+	path, err := DefaultCursorFilePath()
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(path, filepath.Join(".config", "panemux", "board-relay-cursor.json")))
+}

--- a/internal/board/ledger.go
+++ b/internal/board/ledger.go
@@ -74,3 +74,19 @@ func (l *ownSendLedger) Consume(destHost, team, to, body string) bool {
 	delete(l.entries, key)
 	return !l.now().After(expiry)
 }
+
+// Forget removes an entry that was Recorded for a Send that then failed, so
+// it never actually reached the destination host. Record happens before the
+// Send call, not after it succeeds, because a fast poll racing the Send
+// itself must already see the entry once delivery genuinely happens — but
+// that means a failed Send would otherwise leave a live, matchable entry
+// for up to the full TTL with nothing behind it, which any pane on
+// destHost could exploit by producing a row with From == SystemID and a
+// body whose hash it happens to match. Forget closes that window
+// immediately instead of waiting out the TTL.
+func (l *ownSendLedger) Forget(destHost, team, to, body string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
+	delete(l.entries, key)
+}

--- a/internal/board/ledger.go
+++ b/internal/board/ledger.go
@@ -31,8 +31,22 @@ type ownSendKey struct {
 // never checks From against a roster, so an ordinary board pane could
 // otherwise forge that identity. See docs/agent-board.md's Cross-host
 // relay and Security model sections.
+//
+// entries is a multiset, not a set: it holds one expiry per occurrence of a
+// key, not one expiry per distinct key. Two broadcasts with the identical
+// (destHost, team, to, body) — a duplicate message, which is ordinary
+// input, not an attack — are two real, independent sends that will each
+// produce their own row on the destination host. A plain map keyed by
+// ownSendKey can only remember one of them: the second Record would
+// overwrite the first, so only one of the two real rows would ever
+// Consume successfully and the other would be dropped as "invalid from"
+// and silently vanish from history, even though panemux really did send
+// both. Storing a slice of expiries per key — one appended per Record, one
+// removed per Consume/Forget — lets the ledger represent "N sends with this
+// shape are currently in flight or awaiting poll-back" instead of just
+// "a send with this shape happened once."
 type ownSendLedger struct {
-	entries map[ownSendKey]time.Time // value is expiry
+	entries map[ownSendKey][]time.Time // value is one expiry per occurrence
 	now     func() time.Time
 	mu      sync.Mutex
 	ttl     time.Duration
@@ -40,7 +54,7 @@ type ownSendLedger struct {
 
 func newOwnSendLedger() *ownSendLedger {
 	return &ownSendLedger{
-		entries: make(map[ownSendKey]time.Time),
+		entries: make(map[ownSendKey][]time.Time),
 		ttl:     defaultOwnSendLedgerTTL,
 		now:     time.Now,
 	}
@@ -51,42 +65,80 @@ func bodyHash(body string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// Record inserts an entry for a Send panemux itself just issued, matchable
-// until it expires after l.ttl.
+// Record inserts one occurrence for a Send panemux itself just issued,
+// matchable until it expires after l.ttl. A second Record for the same
+// destHost/team/to/body adds a second, independent occurrence rather than
+// overwriting the first — see ownSendLedger's own doc comment for why.
 func (l *ownSendLedger) Record(destHost, team, to, body string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
-	l.entries[key] = l.now().Add(l.ttl)
+	l.entries[key] = append(l.entries[key], l.now().Add(l.ttl))
 }
 
-// Consume reports whether a matching, unexpired entry exists for the given
-// send parameters, deleting it either way (a consumed entry cannot be
-// matched twice, and an expired one is stale bookkeeping either way).
+// Consume reports whether at least one unexpired occurrence exists for the
+// given send parameters. If so, it removes exactly one such occurrence (so
+// two real, distinct sends with the same shape each get their own match)
+// and returns true. Every already-expired occurrence encountered along the
+// way is dropped too, as ordinary garbage collection, regardless of
+// whether an unexpired one is also found.
 func (l *ownSendLedger) Consume(destHost, team, to, body string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
-	expiry, ok := l.entries[key]
-	if !ok {
-		return false
+
+	now := l.now()
+	matched := false
+	live := make([]time.Time, 0, len(l.entries[key]))
+	for _, expiry := range l.entries[key] {
+		if now.After(expiry) {
+			continue // expired occurrence; drop it
+		}
+		if !matched {
+			matched = true // consume exactly this one occurrence
+			continue
+		}
+		live = append(live, expiry)
 	}
-	delete(l.entries, key)
-	return !l.now().After(expiry)
+	if len(live) == 0 {
+		delete(l.entries, key)
+	} else {
+		l.entries[key] = live
+	}
+	return matched
 }
 
-// Forget removes an entry that was Recorded for a Send that then failed, so
-// it never actually reached the destination host. Record happens before the
-// Send call, not after it succeeds, because a fast poll racing the Send
-// itself must already see the entry once delivery genuinely happens — but
-// that means a failed Send would otherwise leave a live, matchable entry
-// for up to the full TTL with nothing behind it, which any pane on
-// destHost could exploit by producing a row with From == SystemID and a
-// body whose hash it happens to match. Forget closes that window
-// immediately instead of waiting out the TTL.
+// Forget removes exactly one occurrence that was Recorded for a Send that
+// then failed, so it never actually reached the destination host. Record
+// happens before the Send call, not after it succeeds, because a fast poll
+// racing the Send itself must already see the occurrence once delivery
+// genuinely happens — but that means a failed Send would otherwise leave a
+// live, matchable occurrence for up to the full TTL with nothing behind
+// it, which any pane on destHost could exploit by producing a row with
+// From == SystemID and a body whose hash it happens to match. Forget
+// closes that window immediately instead of waiting out the TTL.
+//
+// It is safe to remove any one occurrence rather than specifically the one
+// this caller's own Record just added, even under concurrent Broadcast
+// calls racing on the identical key: every occurrence for a key is
+// interchangeable (same destHost/team/to/bodyHash, only the expiry
+// timestamp differs, and those are all within one Record-to-Forget span of
+// each other). What matters is that the live count stays equal to the
+// number of sends actually still in flight or delivered-but-not-yet-
+// polled-back — which occurrence gets removed to reach that count doesn't
+// matter. Removing the most recently added one (LIFO) is simplest to
+// implement as a slice truncation.
 func (l *ownSendLedger) Forget(destHost, team, to, body string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	key := ownSendKey{DestHost: destHost, Team: team, To: to, BodyHash: bodyHash(body)}
-	delete(l.entries, key)
+	entries := l.entries[key]
+	if len(entries) == 0 {
+		return
+	}
+	if len(entries) == 1 {
+		delete(l.entries, key)
+		return
+	}
+	l.entries[key] = entries[:len(entries)-1]
 }

--- a/internal/board/ledger_test.go
+++ b/internal/board/ledger_test.go
@@ -92,3 +92,34 @@ func TestOwnSendLedger_UnexpiredEntry_StillMatchable(t *testing.T) {
 	l.now = fixedClock(start.Add(2 * time.Second))
 	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"))
 }
+
+func TestOwnSendLedger_Forget_RemovesEntryBeforeItExpires(t *testing.T) {
+	// Regression test: a Send that fails after Record must not leave a
+	// live, matchable entry for the rest of the TTL window — that would let
+	// any pane on destHost forge a From == SystemID row until the entry
+	// naturally expired, even though panemux never actually delivered
+	// anything with that body to that host.
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	l.Forget("host-b", "team", "pane-x", "hello")
+
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"), "forgotten entry must not match")
+}
+
+func TestOwnSendLedger_Forget_NoMatchingEntry_NoPanicNoOp(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Forget("host-b", "team", "pane-x", "hello")
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"))
+}
+
+func TestOwnSendLedger_Forget_OnlyRemovesMatchingKey(t *testing.T) {
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+	l.Record("host-b", "team", "pane-y", "hello")
+
+	l.Forget("host-b", "team", "pane-x", "hello")
+
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"), "forgotten entry must not match")
+	assert.True(t, l.Consume("host-b", "team", "pane-y", "hello"), "unrelated entry must be unaffected")
+}

--- a/internal/board/ledger_test.go
+++ b/internal/board/ledger_test.go
@@ -70,7 +70,7 @@ func TestOwnSendLedger_EmptyTeam_StillMatches(t *testing.T) {
 func TestOwnSendLedger_ExpiredEntry_NoLongerMatchable(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	l := &ownSendLedger{
-		entries: make(map[ownSendKey]time.Time),
+		entries: make(map[ownSendKey][]time.Time),
 		ttl:     time.Second,
 		now:     fixedClock(start),
 	}
@@ -83,7 +83,7 @@ func TestOwnSendLedger_ExpiredEntry_NoLongerMatchable(t *testing.T) {
 func TestOwnSendLedger_UnexpiredEntry_StillMatchable(t *testing.T) {
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	l := &ownSendLedger{
-		entries: make(map[ownSendKey]time.Time),
+		entries: make(map[ownSendKey][]time.Time),
 		ttl:     10 * time.Second,
 		now:     fixedClock(start),
 	}
@@ -122,4 +122,59 @@ func TestOwnSendLedger_Forget_OnlyRemovesMatchingKey(t *testing.T) {
 
 	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"), "forgotten entry must not match")
 	assert.True(t, l.Consume("host-b", "team", "pane-y", "hello"), "unrelated entry must be unaffected")
+}
+
+func TestOwnSendLedger_DuplicateRecord_BothOccurrencesIndependentlyConsumable(t *testing.T) {
+	// Regression test (adversarial review round 2, finding B4a): two
+	// broadcasts with the identical destHost/team/to/body are two real,
+	// independent sends — each will produce its own row when the relay
+	// polls the destination host back. A plain single-entry map would let
+	// the second Record silently overwrite the first, so only one of the
+	// two real rows could ever Consume successfully and the other would be
+	// dropped as "invalid from" — an ordinary duplicate message, not an
+	// attack, would vanish from history. Both occurrences must be
+	// independently matchable.
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello")
+	l.Record("host-b", "team", "pane-x", "hello")
+
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"), "first occurrence must match")
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"), "second, independent occurrence must also match")
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"), "a third, non-existent occurrence must not match")
+}
+
+func TestOwnSendLedger_ForgetOneOfTwoDuplicates_OtherStillMatchable(t *testing.T) {
+	// Regression test (adversarial review round 2, finding B4b): the
+	// Forget-on-Send-failure fix must remove only the occurrence
+	// corresponding to the failed send, never a different, still-live
+	// occurrence that happens to share the same key because an earlier,
+	// successful send used the identical destHost/team/to/body.
+	l := newOwnSendLedger()
+	l.Record("host-b", "team", "pane-x", "hello") // first send: succeeds, stays live
+	l.Record("host-b", "team", "pane-x", "hello") // second, duplicate send: about to fail
+
+	l.Forget("host-b", "team", "pane-x", "hello") // undo only the failed one
+
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"),
+		"the first, successful send's occurrence must survive a Forget for an unrelated failed duplicate")
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"),
+		"only one occurrence should have remained after Forget removed one of the two")
+}
+
+func TestOwnSendLedger_Consume_SkipsExpiredOccurrenceFindsUnexpiredOne(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := &ownSendLedger{
+		entries: make(map[ownSendKey][]time.Time),
+		ttl:     time.Second,
+		now:     fixedClock(start),
+	}
+	l.Record("host-b", "team", "pane-x", "hello") // will have expired by the time we Consume
+
+	l.now = fixedClock(start.Add(2 * time.Second))
+	l.Record("host-b", "team", "pane-x", "hello") // recorded "now", still unexpired
+
+	assert.True(t, l.Consume("host-b", "team", "pane-x", "hello"),
+		"an unexpired occurrence must still match even alongside an expired one for the same key")
+	assert.False(t, l.Consume("host-b", "team", "pane-x", "hello"),
+		"no occurrence should remain: the expired one was garbage-collected, the live one was just consumed")
 }

--- a/internal/board/relay.go
+++ b/internal/board/relay.go
@@ -11,6 +11,15 @@ import (
 	"time"
 )
 
+// hostOperationTimeout bounds every individual Since/Send call the relay
+// makes against one host. Poll's own ctx is process-lifetime (canceled only
+// on shutdown), so without a per-operation bound one unresponsive host
+// (dead SSH connection, wedged agmsg process) would stall pollHost — and
+// therefore every other host queued behind it in the same Poll pass, since
+// hosts are polled sequentially — indefinitely instead of just for this one
+// poll cycle.
+const hostOperationTimeout = 10 * time.Second
+
 // RelayConfig is the static, precomputed input the relay needs. Building it
 // (which hosts exist, which AgmsgClient reaches each, which board-enabled
 // pane IDs live on which host) is the caller's job — internal/board does
@@ -23,6 +32,11 @@ type RelayConfig struct {
 	Team           string
 	Limit          int // steady-state --limit
 	BackfillLimit  int // cold-start --limit
+	// OperationTimeout bounds every individual Since/Send call against one
+	// host. Zero (the default for every real caller) falls back to
+	// hostOperationTimeout; tests that need to exercise the timeout itself
+	// without an actual multi-second wait can set a small value here.
+	OperationTimeout time.Duration
 }
 
 // Relay is panemux's own agmsg poller: it reads every known host's agmsg
@@ -40,6 +54,7 @@ type Relay struct {
 	team          string
 	limit         int
 	backfillLimit int
+	opTimeout     time.Duration
 	mu            sync.Mutex
 	backfilled    bool
 }
@@ -53,6 +68,10 @@ func NewRelay(cache *BoardCache, cfg RelayConfig) *Relay {
 		}
 		hostPanes[host][pane] = true
 	}
+	opTimeout := cfg.OperationTimeout
+	if opTimeout <= 0 {
+		opTimeout = hostOperationTimeout
+	}
 	return &Relay{
 		cache:         cache,
 		ledger:        newOwnSendLedger(),
@@ -64,6 +83,7 @@ func NewRelay(cache *BoardCache, cfg RelayConfig) *Relay {
 		team:          cfg.Team,
 		limit:         cfg.Limit,
 		backfillLimit: cfg.BackfillLimit,
+		opTimeout:     opTimeout,
 	}
 }
 
@@ -94,13 +114,24 @@ func (r *Relay) Cursors() []CursorEntry {
 	return entries
 }
 
+// HasClients reports whether the relay knows of at least one agmsg-reachable
+// host. Callers can use this to skip starting the poll loop altogether when
+// there is nothing to poll — see main.go's use of this before starting Run.
+func (r *Relay) HasClients() bool {
+	return len(r.clients) > 0
+}
+
 // Poll runs exactly one pass: on the very first call it performs the
 // cold-start backfill (one BackfillLimit-sized Since call per known host),
 // then every call performs the steady-state Limit-sized poll, processes
-// returned rows, advances cursors, and — if PersistCursors is set —
-// persists the resulting snapshot. Poll never panics on a per-host error;
-// it logs and continues with the remaining hosts, returning a joined error
-// only for callers that want to observe failures.
+// returned rows, and advances cursors. If PersistCursors is set, it is
+// called only when at least one host's cursor actually advanced this pass
+// — a poll that finds nothing new (the common steady-state case, and the
+// permanent case for an operator with no board-enabled panes at all) must
+// not turn into a disk write every single interval forever. Poll never
+// panics on a per-host error; it logs and continues with the remaining
+// hosts, returning a joined error only for callers that want to observe
+// failures.
 func (r *Relay) Poll(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("agent board relay: %w", err)
@@ -117,13 +148,17 @@ func (r *Relay) Poll(ctx context.Context) error {
 	}
 
 	var errs []error
+	changed := false
 	for _, host := range sortedHostKeys(r.clients) {
-		if err := r.pollHost(ctx, host, limit); err != nil {
+		hostChanged, err := r.pollHost(ctx, host, limit)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("host %q: %w", host, err))
+			continue
 		}
+		changed = changed || hostChanged
 	}
 
-	if r.persist != nil {
+	if changed && r.persist != nil {
 		r.persist(r.Cursors())
 	}
 
@@ -133,16 +168,19 @@ func (r *Relay) Poll(ctx context.Context) error {
 	return nil
 }
 
-func (r *Relay) pollHost(ctx context.Context, host string, limit int) error {
+// pollHost polls one host and reports whether its cursor advanced.
+func (r *Relay) pollHost(ctx context.Context, host string, limit int) (bool, error) {
 	client := r.clients[host]
 
 	r.mu.Lock()
 	cursor := r.cursors[host]
 	r.mu.Unlock()
 
-	rows, err := client.Since(ctx, r.team, cursor, limit)
+	sinceCtx, cancel := context.WithTimeout(ctx, r.opTimeout)
+	rows, err := client.Since(sinceCtx, r.team, cursor, limit)
+	cancel()
 	if err != nil {
-		return fmt.Errorf("since: %w", err)
+		return false, fmt.Errorf("since: %w", err)
 	}
 
 	for _, row := range rows {
@@ -150,12 +188,13 @@ func (r *Relay) pollHost(ctx context.Context, host string, limit int) error {
 	}
 
 	newCursor := maxRowID(rows, cursor)
-	if newCursor != cursor {
-		r.mu.Lock()
-		r.cursors[host] = newCursor
-		r.mu.Unlock()
+	if newCursor == cursor {
+		return false, nil
 	}
-	return nil
+	r.mu.Lock()
+	r.cursors[host] = newCursor
+	r.mu.Unlock()
+	return true, nil
 }
 
 // maxRowID returns the largest numerically-parseable row ID among rows,
@@ -227,7 +266,9 @@ func (r *Relay) processRow(ctx context.Context, sourceHost string, row Row) {
 		log.Printf("agent board relay: no client for host %q while relaying to pane %q", destHost, row.To)
 		return
 	}
-	if err := client.Send(ctx, row.Team, row.From, row.To, row.Body); err != nil {
+	sendCtx, cancel := context.WithTimeout(ctx, r.opTimeout)
+	defer cancel()
+	if err := client.Send(sendCtx, row.Team, row.From, row.To, row.Body); err != nil {
 		log.Printf("agent board relay: relaying to host %q failed: %v", destHost, err)
 	}
 }

--- a/internal/board/relay.go
+++ b/internal/board/relay.go
@@ -283,10 +283,14 @@ func (e *UnknownPaneError) Error() string {
 // an own-send-ledger entry is recorded for each target immediately before
 // its Send — matching exactly what the relay's own from-validation later
 // checks for such a row, closing the from-forgery gap docs/security.md and
-// docs/agent-board.md describe. On a resolved-but-unreachable-host or a
-// Send failure, Broadcast stops at the first failure and returns the pane
-// IDs successfully delivered so far, plus the error (fail-fast — a
-// deliberate PR2 simplification, not an oversight).
+// docs/agent-board.md describe. If that Send then fails, the just-recorded
+// entry is immediately forgotten again: leaving it live would let any pane
+// on that destination host impersonate SystemID for up to the ledger's TTL
+// with nothing ever actually delivered behind it. On a
+// resolved-but-unreachable-host or a Send failure, Broadcast stops at the
+// first failure and returns the pane IDs successfully delivered so far,
+// plus the error (fail-fast — a deliberate PR2 simplification, not an
+// oversight).
 func (r *Relay) Broadcast(ctx context.Context, from string, to []string, body string) ([]string, error) {
 	hosts := make(map[string]string, len(to))
 	var unknown []string
@@ -313,6 +317,9 @@ func (r *Relay) Broadcast(ctx context.Context, from string, to []string, body st
 			r.ledger.Record(host, r.team, pane, body)
 		}
 		if err := client.Send(ctx, r.team, from, pane, body); err != nil {
+			if from == SystemID {
+				r.ledger.Forget(host, r.team, pane, body)
+			}
 			return delivered, fmt.Errorf("agent board: broadcast to %q failed: %w", pane, err)
 		}
 		delivered = append(delivered, pane)

--- a/internal/board/relay.go
+++ b/internal/board/relay.go
@@ -1,0 +1,330 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RelayConfig is the static, precomputed input the relay needs. Building it
+// (which hosts exist, which AgmsgClient reaches each, which board-enabled
+// pane IDs live on which host) is the caller's job — internal/board does
+// not import internal/config or internal/session, mirroring
+// AgmsgClient/BoardExecutor's own existing dependency direction.
+type RelayConfig struct {
+	Clients        map[string]AgmsgClient // keyed by AgmsgClient.HostID()
+	PaneHosts      map[string]string      // board-enabled pane ID -> host (a key into Clients)
+	PersistCursors func(entries []CursorEntry)
+	Team           string
+	Limit          int // steady-state --limit
+	BackfillLimit  int // cold-start --limit
+}
+
+// Relay is panemux's own agmsg poller: it reads every known host's agmsg
+// team, updates BoardCache, and relays cross-host messages. See
+// docs/agent-board.md's Cross-host relay section for the full design this
+// implements.
+type Relay struct {
+	cache         *BoardCache
+	ledger        *ownSendLedger
+	clients       map[string]AgmsgClient
+	paneHosts     map[string]string
+	hostPanes     map[string]map[string]bool // host -> set of board-enabled pane IDs on that host
+	persist       func([]CursorEntry)
+	cursors       map[string]string // host -> agmsg-native cursor id
+	team          string
+	limit         int
+	backfillLimit int
+	mu            sync.Mutex
+	backfilled    bool
+}
+
+// NewRelay returns a Relay that writes into cache as it polls.
+func NewRelay(cache *BoardCache, cfg RelayConfig) *Relay {
+	hostPanes := make(map[string]map[string]bool, len(cfg.Clients))
+	for pane, host := range cfg.PaneHosts {
+		if hostPanes[host] == nil {
+			hostPanes[host] = make(map[string]bool)
+		}
+		hostPanes[host][pane] = true
+	}
+	return &Relay{
+		cache:         cache,
+		ledger:        newOwnSendLedger(),
+		clients:       cfg.Clients,
+		paneHosts:     cfg.PaneHosts,
+		hostPanes:     hostPanes,
+		persist:       cfg.PersistCursors,
+		cursors:       make(map[string]string),
+		team:          cfg.Team,
+		limit:         cfg.Limit,
+		backfillLimit: cfg.BackfillLimit,
+	}
+}
+
+// LoadCursors seeds cursor state from a previously persisted snapshot. Call
+// before the first Poll/Run. Entries for a different team than this Relay's
+// own are ignored.
+func (r *Relay) LoadCursors(entries []CursorEntry) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, e := range entries {
+		if e.Team != r.team {
+			continue
+		}
+		r.cursors[e.Host] = e.Cursor
+	}
+}
+
+// Cursors returns a snapshot of current cursor state in the same shape
+// LoadCursors accepts, sorted by host for deterministic output.
+func (r *Relay) Cursors() []CursorEntry {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entries := make([]CursorEntry, 0, len(r.cursors))
+	for host, cursor := range r.cursors {
+		entries = append(entries, CursorEntry{Host: host, Team: r.team, Cursor: cursor})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Host < entries[j].Host })
+	return entries
+}
+
+// Poll runs exactly one pass: on the very first call it performs the
+// cold-start backfill (one BackfillLimit-sized Since call per known host),
+// then every call performs the steady-state Limit-sized poll, processes
+// returned rows, advances cursors, and — if PersistCursors is set —
+// persists the resulting snapshot. Poll never panics on a per-host error;
+// it logs and continues with the remaining hosts, returning a joined error
+// only for callers that want to observe failures.
+func (r *Relay) Poll(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("agent board relay: %w", err)
+	}
+
+	r.mu.Lock()
+	backfill := !r.backfilled
+	r.backfilled = true
+	r.mu.Unlock()
+
+	limit := r.limit
+	if backfill {
+		limit = r.backfillLimit
+	}
+
+	var errs []error
+	for _, host := range sortedHostKeys(r.clients) {
+		if err := r.pollHost(ctx, host, limit); err != nil {
+			errs = append(errs, fmt.Errorf("host %q: %w", host, err))
+		}
+	}
+
+	if r.persist != nil {
+		r.persist(r.Cursors())
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("agent board relay: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+func (r *Relay) pollHost(ctx context.Context, host string, limit int) error {
+	client := r.clients[host]
+
+	r.mu.Lock()
+	cursor := r.cursors[host]
+	r.mu.Unlock()
+
+	rows, err := client.Since(ctx, r.team, cursor, limit)
+	if err != nil {
+		return fmt.Errorf("since: %w", err)
+	}
+
+	for _, row := range rows {
+		r.processRow(ctx, host, row)
+	}
+
+	newCursor := maxRowID(rows, cursor)
+	if newCursor != cursor {
+		r.mu.Lock()
+		r.cursors[host] = newCursor
+		r.mu.Unlock()
+	}
+	return nil
+}
+
+// maxRowID returns the largest numerically-parseable row ID among rows,
+// falling back to prev if no row's ID parses (or rows is empty) — a row
+// whose ID doesn't parse never regresses the cursor.
+func maxRowID(rows []Row, prev string) string {
+	best := prev
+	bestN, bestOK := parseAgmsgID(prev)
+	for _, row := range rows {
+		n, ok := parseAgmsgID(row.ID)
+		if !ok {
+			continue
+		}
+		if !bestOK || n > bestN {
+			best = row.ID
+			bestN = n
+			bestOK = true
+		}
+	}
+	return best
+}
+
+// processRow applies the row-processing algorithm documented in
+// docs/agent-board.md's Cross-host relay section:
+//  1. from-validation fails -> drop+log, never cached.
+//  2. to == SystemID -> always appended to history; a board_status body also
+//     updates the status cache; never relayed further (status stays local).
+//  3. to doesn't resolve to a known pane -> drop+log, never cached (same as
+//     an invalid from).
+//  4. to resolves to a known pane -> appended to history; relayed via
+//     AgmsgClient.Send (always --force) only when the destination host
+//     differs from sourceHost.
+//
+// A row this method relays to another host keeps its original From (the
+// real pane ID, not SystemID). When that host is polled next, from-
+// validation for that row is evaluated against *that host's* own known
+// panes — the original pane is not local there, so the row is correctly
+// dropped rather than re-appended to history a second time. This is
+// intentional, not a bug: see the relay design notes in the project's
+// implementation plan.
+func (r *Relay) processRow(ctx context.Context, sourceHost string, row Row) {
+	if !r.validFrom(sourceHost, row) {
+		log.Printf("agent board relay: dropping row from host %q: invalid from %q", sourceHost, row.From)
+		return
+	}
+
+	if row.To == SystemID {
+		r.cache.AppendMessage(row)
+		if status, ok := IsStatusRow(row); ok {
+			r.cache.RecordStatus(row.From, status)
+		}
+		return
+	}
+
+	destHost, ok := r.paneHosts[row.To]
+	if !ok {
+		log.Printf("agent board relay: dropping row from host %q: unknown to %q", sourceHost, row.To)
+		return
+	}
+
+	r.cache.AppendMessage(row)
+
+	if destHost == sourceHost {
+		return
+	}
+
+	client, ok := r.clients[destHost]
+	if !ok {
+		log.Printf("agent board relay: no client for host %q while relaying to pane %q", destHost, row.To)
+		return
+	}
+	if err := client.Send(ctx, row.Team, row.From, row.To, row.Body); err != nil {
+		log.Printf("agent board relay: relaying to host %q failed: %v", destHost, err)
+	}
+}
+
+func (r *Relay) validFrom(sourceHost string, row Row) bool {
+	if row.From == SystemID {
+		return r.ledger.Consume(sourceHost, row.Team, row.To, row.Body)
+	}
+	return r.hostPanes[sourceHost][row.From]
+}
+
+// Run polls every interval until ctx is canceled, running one immediate
+// Poll first so the cold-start backfill happens as soon as possible rather
+// than waiting a full interval.
+func (r *Relay) Run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	r.runLoop(ctx, ticker.C)
+}
+
+// runLoop is Run's actual loop, factored out so tests can drive it with an
+// injected tick channel instead of real time.
+func (r *Relay) runLoop(ctx context.Context, tick <-chan time.Time) {
+	r.pollLogged(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick:
+			r.pollLogged(ctx)
+		}
+	}
+}
+
+func (r *Relay) pollLogged(ctx context.Context) {
+	if err := r.Poll(ctx); err != nil {
+		log.Printf("agent board relay: poll error: %v", err)
+	}
+}
+
+// UnknownPaneError is returned by Broadcast when one or more `to` pane IDs
+// don't resolve to a known board-enabled pane.
+type UnknownPaneError struct{ IDs []string }
+
+func (e *UnknownPaneError) Error() string {
+	return "agent board: unknown pane id(s): " + strings.Join(e.IDs, ", ")
+}
+
+// Broadcast sends body from `from` to every pane ID in `to`. All `to` IDs
+// are validated against known board-enabled panes before any Send is
+// issued (all-or-nothing): an unknown pane returns *UnknownPaneError naming
+// every unresolved ID, and no Send happens at all. When from == SystemID,
+// an own-send-ledger entry is recorded for each target immediately before
+// its Send — matching exactly what the relay's own from-validation later
+// checks for such a row, closing the from-forgery gap docs/security.md and
+// docs/agent-board.md describe. On a resolved-but-unreachable-host or a
+// Send failure, Broadcast stops at the first failure and returns the pane
+// IDs successfully delivered so far, plus the error (fail-fast — a
+// deliberate PR2 simplification, not an oversight).
+func (r *Relay) Broadcast(ctx context.Context, from string, to []string, body string) ([]string, error) {
+	hosts := make(map[string]string, len(to))
+	var unknown []string
+	for _, pane := range to {
+		host, ok := r.paneHosts[pane]
+		if !ok {
+			unknown = append(unknown, pane)
+			continue
+		}
+		hosts[pane] = host
+	}
+	if len(unknown) > 0 {
+		return nil, &UnknownPaneError{IDs: unknown}
+	}
+
+	delivered := make([]string, 0, len(to))
+	for _, pane := range to {
+		host := hosts[pane]
+		client, ok := r.clients[host]
+		if !ok {
+			return delivered, fmt.Errorf("agent board: no client for host %q (pane %q)", host, pane)
+		}
+		if from == SystemID {
+			r.ledger.Record(host, r.team, pane, body)
+		}
+		if err := client.Send(ctx, r.team, from, pane, body); err != nil {
+			return delivered, fmt.Errorf("agent board: broadcast to %q failed: %w", pane, err)
+		}
+		delivered = append(delivered, pane)
+	}
+	return delivered, nil
+}
+
+func sortedHostKeys(m map[string]AgmsgClient) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/board/relay_test.go
+++ b/internal/board/relay_test.go
@@ -406,6 +406,44 @@ func TestRelay_Broadcast_SendFailurePartway_ReportsPartialDelivery(t *testing.T)
 	assert.Equal(t, []string{"pane-a"}, delivered)
 }
 
+func TestRelay_Broadcast_SendFailure_OwnSendLedgerEntryForgotten(t *testing.T) {
+	// Regression test: Broadcast records a ledger entry before Send so a
+	// fast poll racing a *successful* Send can still match it — but if Send
+	// then fails, that entry must not stay live for the rest of its TTL.
+	// Otherwise any pane on the destination host could forge a
+	// From == SystemID row with the same to/body within that window and
+	// have it accepted as legitimate, even though nothing was ever
+	// actually delivered.
+	hostB := &fakeAgmsgClient{hostID: "host-b", sendErr: errors.New("ssh: connection lost")}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-b": hostB}, map[string]string{
+		"pane-b": "host-b",
+	})
+
+	_, err := r.Broadcast(context.Background(), SystemID, []string{"pane-b"}, "hello")
+	require.Error(t, err)
+
+	forged := Row{Host: "host-b", Team: "panemux", From: SystemID, To: "pane-b", Body: "hello"}
+	assert.False(t, r.validFrom("host-b", forged),
+		"a Send failure must not leave a matchable own-send-ledger entry behind")
+}
+
+func TestRelay_Broadcast_SendSucceeds_OwnSendLedgerEntryStillMatchable(t *testing.T) {
+	// Contrast case for the regression above: a *successful* Send's ledger
+	// entry must remain matchable, since that's the normal path a real
+	// relayed-back row is validated against.
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-b": hostB}, map[string]string{
+		"pane-b": "host-b",
+	})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-b"}, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pane-b"}, delivered)
+
+	row := Row{Host: "host-b", Team: "panemux", From: SystemID, To: "pane-b", Body: "hello"}
+	assert.True(t, r.validFrom("host-b", row), "a successful Send's ledger entry must remain matchable")
+}
+
 func TestRelay_Broadcast_UnreachableHost_Error(t *testing.T) {
 	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{}, map[string]string{"pane-a": "host-a"})
 

--- a/internal/board/relay_test.go
+++ b/internal/board/relay_test.go
@@ -3,6 +3,7 @@ package board
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -353,6 +354,100 @@ func TestRelay_Poll_PersistCursorsCalledWithSnapshot(t *testing.T) {
 	assert.Equal(t, "5", captured[0].Cursor)
 }
 
+func TestRelay_Poll_NoNewRows_PersistCursorsNotCalled(t *testing.T) {
+	// Regression test: a poll that finds nothing new must not write the
+	// cursor file — otherwise every panemux process writes to disk on every
+	// tick forever, including operators who have never configured any
+	// board-enabled pane at all.
+	hostA := &fakeAgmsgClient{hostID: "host-a"} // no sinceRows
+	persistCalls := 0
+	r := NewRelay(NewBoardCache(), RelayConfig{
+		Team: "panemux", Clients: map[string]AgmsgClient{"host-a": hostA},
+		Limit: 100, BackfillLimit: 1000,
+		PersistCursors: func([]CursorEntry) { persistCalls++ },
+	})
+
+	require.NoError(t, r.Poll(context.Background()))
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Equal(t, 0, persistCalls, "a poll with no new rows must never trigger a cursor write")
+}
+
+func TestRelay_Poll_NewRowThenSteadyState_PersistCursorsCalledOnceThenNotAgain(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "5", Team: "panemux", From: "pane-a", To: "pane-b", Body: "hi"},
+	}}
+	persistCalls := 0
+	r := NewRelay(NewBoardCache(), RelayConfig{
+		Team: "panemux", Clients: map[string]AgmsgClient{"host-a": hostA},
+		PaneHosts: map[string]string{"pane-a": "host-a", "pane-b": "host-a"},
+		Limit:     100, BackfillLimit: 1000,
+		PersistCursors: func([]CursorEntry) { persistCalls++ },
+	})
+
+	require.NoError(t, r.Poll(context.Background())) // sees row 5, cursor advances
+	require.NoError(t, r.Poll(context.Background())) // filterRowsAfter("5") -> nothing new
+
+	assert.Equal(t, 1, persistCalls, "cursor write must fire exactly once, only when it actually advanced")
+}
+
+func TestRelay_HasClients_NoClients_False(t *testing.T) {
+	r := newTestRelay(NewBoardCache(), nil, nil)
+	assert.False(t, r.HasClients())
+}
+
+func TestRelay_HasClients_WithClients_True(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, nil)
+	assert.True(t, r.HasClients())
+}
+
+func TestRelay_Poll_HostOperationTimeout_DoesNotBlockOtherHosts(t *testing.T) {
+	// Regression test: a host whose Since call never returns must not wedge
+	// the whole Poll pass — every other host must still get polled within
+	// the per-host timeout, not block forever behind the stuck one. Uses a
+	// tiny injected OperationTimeout so this test doesn't need to actually
+	// wait out the real 10s production default.
+	blocked := &blockingAgmsgClient{hostID: "host-a"}
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	r := NewRelay(NewBoardCache(), RelayConfig{
+		Team:             "panemux",
+		Clients:          map[string]AgmsgClient{"host-a": blocked, "host-b": hostB},
+		Limit:            100,
+		BackfillLimit:    1000,
+		OperationTimeout: 50 * time.Millisecond,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- r.Poll(context.Background()) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a permanently-blocked host must surface as a timeout error, not silently succeed")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return within the per-host timeout budget; a stuck host is blocking the whole pass")
+	}
+	assert.Equal(t, 1, hostB.sinceCallCount(), "host-b must still be polled despite host-a being stuck")
+}
+
+// blockingAgmsgClient's Since never returns on its own — it only returns
+// once ctx is done, so it can only be unblocked by a caller-side timeout.
+type blockingAgmsgClient struct {
+	hostID string
+}
+
+func (b *blockingAgmsgClient) HostID() string { return b.hostID }
+
+func (b *blockingAgmsgClient) Since(ctx context.Context, _, _ string, _ int) ([]Row, error) {
+	<-ctx.Done()
+	return nil, fmt.Errorf("blockingAgmsgClient: %w", ctx.Err())
+}
+
+func (b *blockingAgmsgClient) Send(ctx context.Context, _, _, _, _ string) error {
+	<-ctx.Done()
+	return fmt.Errorf("blockingAgmsgClient: %w", ctx.Err())
+}
+
 func TestRelay_Broadcast_KnownPanesSingleHost_Delivered(t *testing.T) {
 	hostA := &fakeAgmsgClient{hostID: "host-a"}
 	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, map[string]string{
@@ -442,6 +537,29 @@ func TestRelay_Broadcast_SendSucceeds_OwnSendLedgerEntryStillMatchable(t *testin
 
 	row := Row{Host: "host-b", Team: "panemux", From: SystemID, To: "pane-b", Body: "hello"}
 	assert.True(t, r.validFrom("host-b", row), "a successful Send's ledger entry must remain matchable")
+}
+
+func TestRelay_Broadcast_DuplicateSuccessfulBroadcast_BothRowsAcceptedOnPollback(t *testing.T) {
+	// End-to-end regression test for adversarial review round 2's finding
+	// B4a: two successful broadcasts with the identical to/body must each
+	// leave the destination host's next poll of that row able to pass
+	// from-validation — a duplicate is ordinary input (a user or the
+	// command center re-sending the same text), not an attack, and must
+	// not silently lose the second occurrence from history.
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-b": hostB}, map[string]string{
+		"pane-b": "host-b",
+	})
+
+	_, err := r.Broadcast(context.Background(), SystemID, []string{"pane-b"}, "hello")
+	require.NoError(t, err)
+	_, err = r.Broadcast(context.Background(), SystemID, []string{"pane-b"}, "hello")
+	require.NoError(t, err)
+
+	row := Row{Host: "host-b", Team: "panemux", From: SystemID, To: "pane-b", Body: "hello"}
+	assert.True(t, r.validFrom("host-b", row), "first row must pass from-validation")
+	assert.True(t, r.validFrom("host-b", row), "second, independent row must also pass from-validation")
+	assert.False(t, r.validFrom("host-b", row), "a third, non-existent row must not pass")
 }
 
 func TestRelay_Broadcast_UnreachableHost_Error(t *testing.T) {

--- a/internal/board/relay_test.go
+++ b/internal/board/relay_test.go
@@ -1,0 +1,460 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sentMessage struct{ Team, From, To, Body string }
+
+// fakeAgmsgClient is safe for concurrent use: the runLoop tests drive it
+// from a background goroutine while the test goroutine polls its recorded
+// calls, so every field access goes through mu.
+type fakeAgmsgClient struct {
+	sinceErr    error
+	sendErr     error
+	hostID      string
+	sinceRows   []Row
+	sinceLimits []int
+	sendCalls   []sentMessage
+	mu          sync.Mutex
+}
+
+func (f *fakeAgmsgClient) HostID() string { return f.hostID }
+
+func (f *fakeAgmsgClient) Since(_ context.Context, _, afterID string, limit int) ([]Row, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sinceLimits = append(f.sinceLimits, limit)
+	if f.sinceErr != nil {
+		return nil, f.sinceErr
+	}
+	return filterRowsAfter(f.sinceRows, afterID), nil
+}
+
+func (f *fakeAgmsgClient) Send(_ context.Context, team, from, to, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sendCalls = append(f.sendCalls, sentMessage{Team: team, From: from, To: to, Body: body})
+	return f.sendErr
+}
+
+func (f *fakeAgmsgClient) sinceCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sinceLimits)
+}
+
+func newTestRelay(cache *BoardCache, clients map[string]AgmsgClient, paneHosts map[string]string) *Relay {
+	return NewRelay(cache, RelayConfig{
+		Team: "panemux", Clients: clients, PaneHosts: paneHosts,
+		Limit: 100, BackfillLimit: 1000,
+	})
+}
+
+func TestRelay_Poll_NoKnownHosts_NoOp(t *testing.T) {
+	r := newTestRelay(NewBoardCache(), nil, nil)
+	assert.NoError(t, r.Poll(context.Background()))
+}
+
+func TestRelay_Poll_AlreadyCanceledContext_ReturnsErrorImmediately(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.Poll(ctx)
+	require.Error(t, err)
+	assert.Empty(t, hostA.sinceLimits, "no client call should happen once ctx is already canceled")
+}
+
+func TestRelay_Poll_FromKnownLocalPane_ToKnownPaneSameHost_Appended(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: "pane-b", Body: "hi"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a", "pane-b": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "hi", rows[0].Row.Body)
+	assert.Empty(t, hostA.sendCalls, "same-host delivery needs no relay Send")
+}
+
+func TestRelay_Poll_ToKnownPaneDifferentHost_RelaysAndAppendsOnce(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "claude-a", To: "codex-b", Body: "please review"},
+	}}
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"claude-a": "host-a", "codex-b": "host-b"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA, "host-b": hostB}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1, "the row must be appended exactly once, from host-a's own poll")
+	assert.Equal(t, "please review", rows[0].Row.Body)
+
+	require.Len(t, hostB.sendCalls, 1)
+	want := sentMessage{Team: "panemux", From: "claude-a", To: "codex-b", Body: "please review"}
+	assert.Equal(t, want, hostB.sendCalls[0])
+}
+
+// TestRelay_Poll_RelayedRowNotDoubleCounted is the regression test for the
+// central correctness property of cross-host relay: a message relayed to
+// host B keeps its original From (not SystemID). When host B is next
+// polled and that row is read back, from-validation against host B's own
+// known panes must reject it — the original pane isn't local to host B —
+// so it is not re-appended to history a second time.
+func TestRelay_Poll_RelayedRowNotDoubleCounted(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "claude-a", To: "codex-b", Body: "please review"},
+	}}
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"claude-a": "host-a", "codex-b": "host-b"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA, "host-b": hostB}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+	require.Len(t, hostB.sendCalls, 1)
+
+	// Simulate agmsg on host B actually having stored the relayed row, now
+	// visible to a later poll of host B with a host-B-scoped agmsg id.
+	hostB.sinceRows = append(hostB.sinceRows, Row{
+		ID: "1", Team: "panemux", From: "claude-a", To: "codex-b", Body: "please review",
+	})
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	rows := cache.MessagesSince(0)
+	assert.Len(t, rows, 1, "the relayed copy read back from host B must not be appended again")
+	assert.Len(t, hostB.sendCalls, 1, "host B's own row must never itself be re-relayed (no new Send call)")
+}
+
+func TestRelay_Poll_FromSystemIDWithLedgerMatch_Accepted(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	_, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a"}, "hello from command center")
+	require.NoError(t, err)
+	require.Len(t, hostA.sendCalls, 1)
+
+	hostA.sinceRows = []Row{
+		{ID: "1", Team: "panemux", From: SystemID, To: "pane-a", Body: "hello from command center"},
+	}
+	require.NoError(t, r.Poll(context.Background()))
+
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "hello from command center", rows[0].Row.Body)
+}
+
+func TestRelay_Poll_FromSystemIDWithNoLedgerMatch_DroppedAsForgery(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: SystemID, To: "pane-a", Body: "forged"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Empty(t, cache.MessagesSince(0), "an unmatched SystemID from must be dropped, never cached")
+}
+
+func TestRelay_Poll_FromSystemIDWithExpiredLedgerEntry_DroppedAsForgery(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+	r.ledger.ttl = time.Millisecond
+
+	_, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a"}, "hello")
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Millisecond)
+
+	hostA.sinceRows = []Row{
+		{ID: "1", Team: "panemux", From: SystemID, To: "pane-a", Body: "hello"},
+	}
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Empty(t, cache.MessagesSince(0), "an expired ledger entry must no longer match")
+}
+
+func TestRelay_Poll_FromUnknownPane_DroppedAndNotCached(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "stranger", To: "pane-a", Body: "hi"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Empty(t, cache.MessagesSince(0))
+}
+
+func TestRelay_Poll_ToSystemID_StatusBody_RecordsStatusAndAppendsHistory(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: SystemID, Body: `{"kind":"board_status","state":"working"}`},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	snap := cache.StatusSnapshot()
+	require.Contains(t, snap, "pane-a")
+	assert.Equal(t, "working", snap["pane-a"].State)
+
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1, "status rows are still appended to history, per the design doc")
+	assert.Empty(t, hostA.sendCalls, "status reports are never relayed cross-host")
+}
+
+func TestRelay_Poll_ToSystemID_NonStatusBody_AppendedAsOrdinaryMessage(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: SystemID, Body: "just chatting"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Empty(t, cache.StatusSnapshot())
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "just chatting", rows[0].Row.Body)
+}
+
+func TestRelay_Poll_ToUnknownPane_DroppedAndNotCached(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: "no-such-pane", Body: "hi"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	assert.Empty(t, cache.MessagesSince(0))
+}
+
+func TestRelay_Poll_ClientSinceError_LoggedAndDoesNotStopOtherHosts(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceErr: errors.New("agmsg down")}
+	hostB := &fakeAgmsgClient{hostID: "host-b", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-b", To: "pane-b2", Body: "ok"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-b": "host-b", "pane-b2": "host-b"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA, "host-b": hostB}, paneHosts)
+
+	err := r.Poll(context.Background())
+	require.Error(t, err)
+
+	rows := cache.MessagesSince(0)
+	require.Len(t, rows, 1, "host-b must still be processed despite host-a's failure")
+	assert.Equal(t, "ok", rows[0].Row.Body)
+}
+
+func TestRelay_Poll_ColdStartUsesBackfillLimit_SubsequentUseSteadyStateLimit(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, nil)
+
+	require.NoError(t, r.Poll(context.Background()))
+	require.NoError(t, r.Poll(context.Background()))
+
+	require.Len(t, hostA.sinceLimits, 2)
+	assert.Equal(t, 1000, hostA.sinceLimits[0])
+	assert.Equal(t, 100, hostA.sinceLimits[1])
+}
+
+func TestRelay_CursorPersistence_AcrossSimulatedRestart(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: "pane-b", Body: "one"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a", "pane-b": "host-a"}
+	r1 := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+	require.NoError(t, r1.Poll(context.Background()))
+
+	persisted := r1.Cursors()
+	require.Len(t, persisted, 1)
+	assert.Equal(t, "1", persisted[0].Cursor)
+
+	// New relay instance ("restart"), seeded from the persisted cursor.
+	hostA2 := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: "pane-b", Body: "one"},
+		{ID: "2", Team: "panemux", From: "pane-a", To: "pane-b", Body: "two"},
+	}}
+	cache2 := NewBoardCache()
+	r2 := newTestRelay(cache2, map[string]AgmsgClient{"host-a": hostA2}, paneHosts)
+	r2.LoadCursors(persisted)
+	require.NoError(t, r2.Poll(context.Background()))
+
+	rows := cache2.MessagesSince(0)
+	require.Len(t, rows, 1, "only the genuinely new row (id 2) should be delivered after resuming from cursor 1")
+	assert.Equal(t, "two", rows[0].Row.Body)
+}
+
+func TestRelay_CursorPersistence_AtLeastOnceDuplicateAccepted(t *testing.T) {
+	// Simulates a crash between relaying and persisting the cursor: the
+	// same row is seen again on the next Poll and is delivered again, not
+	// silently deduplicated — the documented accepted tradeoff.
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "1", Team: "panemux", From: "pane-a", To: "pane-b", Body: "one"},
+	}}
+	cache := NewBoardCache()
+	paneHosts := map[string]string{"pane-a": "host-a", "pane-b": "host-a"}
+	r := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+
+	require.NoError(t, r.Poll(context.Background()))
+	// Cursor deliberately NOT advanced/reloaded — simulate a crash before
+	// persistence by constructing a fresh relay with no cursor loaded.
+	r2 := newTestRelay(cache, map[string]AgmsgClient{"host-a": hostA}, paneHosts)
+	require.NoError(t, r2.Poll(context.Background()))
+
+	rows := cache.MessagesSince(0)
+	assert.Len(t, rows, 2, "a row seen again after a lost cursor is delivered again, not dropped")
+}
+
+func TestRelay_Poll_PersistCursorsCalledWithSnapshot(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceRows: []Row{
+		{ID: "5", Team: "panemux", From: "pane-a", To: "pane-b", Body: "hi"},
+	}}
+	var captured []CursorEntry
+	r := NewRelay(NewBoardCache(), RelayConfig{
+		Team: "panemux", Clients: map[string]AgmsgClient{"host-a": hostA},
+		PaneHosts: map[string]string{"pane-a": "host-a", "pane-b": "host-a"},
+		Limit:     100, BackfillLimit: 1000,
+		PersistCursors: func(entries []CursorEntry) { captured = entries },
+	})
+
+	require.NoError(t, r.Poll(context.Background()))
+
+	require.Len(t, captured, 1)
+	assert.Equal(t, "host-a", captured[0].Host)
+	assert.Equal(t, "5", captured[0].Cursor)
+}
+
+func TestRelay_Broadcast_KnownPanesSingleHost_Delivered(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, map[string]string{
+		"pane-a": "host-a", "pane-b": "host-a",
+	})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a", "pane-b"}, "hello")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pane-a", "pane-b"}, delivered)
+	assert.Len(t, hostA.sendCalls, 2)
+}
+
+func TestRelay_Broadcast_KnownPanesAcrossTwoHosts_Delivered(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	hostB := &fakeAgmsgClient{hostID: "host-b"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA, "host-b": hostB}, map[string]string{
+		"pane-a": "host-a", "pane-b": "host-b",
+	})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a", "pane-b"}, "hello")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"pane-a", "pane-b"}, delivered)
+	assert.Len(t, hostA.sendCalls, 1)
+	assert.Len(t, hostB.sendCalls, 1)
+}
+
+func TestRelay_Broadcast_OneUnknownPane_AllOrNothing(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, map[string]string{
+		"pane-a": "host-a",
+	})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a", "no-such-pane"}, "hello")
+	require.Error(t, err)
+	var unknownErr *UnknownPaneError
+	require.ErrorAs(t, err, &unknownErr)
+	assert.Equal(t, []string{"no-such-pane"}, unknownErr.IDs)
+	assert.Nil(t, delivered)
+	assert.Empty(t, hostA.sendCalls, "no Send may happen once any pane is unresolved")
+}
+
+func TestRelay_Broadcast_SendFailurePartway_ReportsPartialDelivery(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	hostB := &fakeAgmsgClient{hostID: "host-b", sendErr: errors.New("ssh: connection lost")}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA, "host-b": hostB}, map[string]string{
+		"pane-a": "host-a", "pane-b": "host-b",
+	})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a", "pane-b"}, "hello")
+	require.Error(t, err)
+	assert.Equal(t, []string{"pane-a"}, delivered)
+}
+
+func TestRelay_Broadcast_UnreachableHost_Error(t *testing.T) {
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{}, map[string]string{"pane-a": "host-a"})
+
+	delivered, err := r.Broadcast(context.Background(), SystemID, []string{"pane-a"}, "hello")
+	require.Error(t, err)
+	assert.Empty(t, delivered)
+}
+
+func TestRelay_RunLoop_PollsImmediatelyThenOnEachTick(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a"}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	go func() {
+		r.runLoop(ctx, tick)
+		close(done)
+	}()
+
+	// Immediate poll on entry.
+	require.Eventually(t, func() bool { return hostA.sinceCallCount() == 1 }, time.Second, time.Millisecond)
+
+	tick <- time.Now()
+	require.Eventually(t, func() bool { return hostA.sinceCallCount() == 2 }, time.Second, time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runLoop did not exit after ctx cancellation")
+	}
+}
+
+func TestRelay_RunLoop_PollErrorLoggedNotPanicked(t *testing.T) {
+	hostA := &fakeAgmsgClient{hostID: "host-a", sinceErr: errors.New("agmsg down")}
+	r := newTestRelay(NewBoardCache(), map[string]AgmsgClient{"host-a": hostA}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+
+	assert.NotPanics(t, func() {
+		go func() {
+			r.runLoop(ctx, tick)
+			close(done)
+		}()
+		require.Eventually(t, func() bool { return hostA.sinceCallCount() == 1 }, time.Second, time.Millisecond)
+		cancel()
+		<-done
+	})
+}

--- a/internal/config/agent_board.go
+++ b/internal/config/agent_board.go
@@ -57,15 +57,6 @@ func (c *Config) normalizeAgentBoard() {
 	}
 }
 
-func (c *Config) expandAgentBoardPaths() {
-	if strings.HasPrefix(c.AgentBoard.AgmsgPath, "~/") {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			c.AgentBoard.AgmsgPath = filepath.Join(home, c.AgentBoard.AgmsgPath[2:])
-		}
-	}
-}
-
 // EnsureAuthToken fills in Server.AuthToken when it is not already set,
 // either by reading a previously persisted token file or by generating and
 // persisting a new random token. Failure to resolve, read, or persist a

--- a/internal/config/agent_board_test.go
+++ b/internal/config/agent_board_test.go
@@ -261,16 +261,18 @@ func TestValidate_AgmsgPath_TildePrefixed_NoError(t *testing.T) {
 }
 
 func TestNormalizeAgentBoard_DefaultsTeamAndAgmsgPath(t *testing.T) {
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-
 	tokenPath := filepath.Join(t.TempDir(), "token")
 	cfg, err := loadWithAuthTokenPath(t, validConfigYAML, tokenPath)
 	require.NoError(t, err)
 
 	assert.Equal(t, "panemux", cfg.AgentBoard.Team)
-	assert.Equal(t, filepath.Join(home, ".agents", "skills", "agmsg"), cfg.AgentBoard.AgmsgPath)
-	assert.False(t, strings.HasPrefix(cfg.AgentBoard.AgmsgPath, "~/"))
+	// AgmsgPath is deliberately left un-expanded here: it names a path on
+	// whichever host (local, or any number of remote SSH hosts) it ends up
+	// used against, so there is no single home directory to expand a
+	// leading ~/ against at config-load time. Expansion happens per host at
+	// AgmsgClient construction time in board.go instead — see
+	// docs/agent-board.md's "~ in agmsg_path is expanded by panemux" section.
+	assert.Equal(t, "~/.agents/skills/agmsg", cfg.AgentBoard.AgmsgPath)
 }
 
 func TestNormalizeAgentBoard_PreservesExplicitTeam(t *testing.T) {
@@ -299,7 +301,10 @@ layout:
 func TestDefault_SetsAgentBoardDefaultsAndLeavesTokenEmpty(t *testing.T) {
 	cfg := Default()
 	assert.Equal(t, "panemux", cfg.AgentBoard.Team)
-	assert.False(t, strings.HasPrefix(cfg.AgentBoard.AgmsgPath, "~/"))
+	// Default() must not expand AgmsgPath either, for the same reason
+	// finishLoad's expandPaths doesn't — see
+	// TestNormalizeAgentBoard_DefaultsTeamAndAgmsgPath's comment.
+	assert.Equal(t, "~/.agents/skills/agmsg", cfg.AgentBoard.AgmsgPath)
 	// Default() must never touch the real filesystem for a token — see
 	// finishLoad's doc comment. AuthToken is only ever populated by an
 	// explicit EnsureAuthToken call, which the real startup path (main.go)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,7 +184,6 @@ func Default() *Config {
 		},
 	}
 	cfg.normalizeAgentBoard()
-	cfg.expandAgentBoardPaths()
 	return cfg
 }
 
@@ -472,7 +471,17 @@ func (c *Config) expandPaths() {
 	if active, ok := c.ActiveWorkspace(); ok {
 		c.Layout = active.Layout
 	}
-	c.expandAgentBoardPaths()
+	// AgentBoard.AgmsgPath is deliberately NOT expanded here: it names a
+	// path on whichever host it ends up used against (local or, via SSH,
+	// any number of remote hosts), so there is no single "the" home
+	// directory to expand a leading ~/ against at config-load time — that
+	// used to expand it against panemux's own local home unconditionally,
+	// silently breaking every remote host whose home directory differs (see
+	// docs/agent-board.md's "~ in agmsg_path is expanded by panemux, never
+	// left for the remote shell to expand" section). Expansion happens per
+	// host instead, at AgmsgClient construction time in board.go: locally
+	// via os.UserHomeDir(), remotely via board.ResolveRemoteAgmsgPath's
+	// SSH $HOME probe.
 }
 
 func expandPanesCwd(children []LayoutChild) {

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -15,12 +15,12 @@ const bearerPrefix = "Bearer "
 // wrapping a WebSocket upgrade handler with it rejects the handshake before
 // any upgrade attempt — no separate WS-specific logic is needed.
 //
-// This middleware is not yet wired into registerRoutes: doing so today
-// would require every existing, currently-unauthenticated frontend request
-// to start sending a token it doesn't have. It is built and tested standalone
-// so a later change can connect it once there is an auth-aware frontend and
-// board endpoints to protect — see docs/agent-board.md's API additions
-// section.
+// It is wired into registerRoutes onto the /api/board/* sub-route only
+// (see internal/server/server.go) — not onto any pre-existing /api/* route
+// or /ws/{sessionID}, since those would require every existing, currently-
+// unauthenticated frontend request to start sending a token it doesn't
+// have. Widening it to those routes is a separate, larger change — see
+// docs/agent-board.md's API additions section.
 func bearerAuthMiddleware(token string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/board_routes_test.go
+++ b/internal/server/board_routes_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/board"
+	"panemux/internal/config"
+	"panemux/internal/session"
+)
+
+func testConfigWithToken(token string) *config.Config {
+	cfg := testConfig()
+	cfg.Server.AuthToken = token
+	return cfg
+}
+
+func TestServer_BoardRoutesWired_RequireAuth(t *testing.T) {
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	cache := board.NewBoardCache()
+	srv := New(cfg, mgr, cache, nil, emptyFS)
+
+	paths := []string{"/api/board/status", "/api/board/messages"}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			srv.httpSrv.Handler.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusUnauthorized, rec.Code, "missing token must be rejected")
+		})
+	}
+}
+
+func TestServer_BoardRoutes_WrongToken_Rejected(t *testing.T) {
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	cache := board.NewBoardCache()
+	srv := New(cfg, mgr, cache, nil, emptyFS)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestServer_BoardRoutes_CorrectToken_Reaches200(t *testing.T) {
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	cache := board.NewBoardCache()
+	srv := New(cfg, mgr, cache, nil, emptyFS)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestServer_ExistingAPIRoutes_RemainUnauthenticated(t *testing.T) {
+	// Regression test: scoping bearerAuthMiddleware to /api/board must not
+	// widen to any pre-existing route — the current frontend sends no
+	// token at all.
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, board.NewBoardCache(), nil, emptyFS)
+
+	paths := []string{"/api/layout", "/api/workspaces", "/api/sessions", "/api/display"}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			srv.httpSrv.Handler.ServeHTTP(rec, req)
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+				"existing routes must stay reachable with no Authorization header")
+		})
+	}
+}
+
+func TestServer_WSRoute_RemainsUnauthenticated(t *testing.T) {
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, board.NewBoardCache(), nil, emptyFS)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws/nonexistent-session", nil)
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	// 404 (unknown session) proves the request reached ws.Handler at all,
+	// i.e. it was never intercepted by an auth check.
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 
 	"panemux/internal/api"
+	"panemux/internal/board"
 	"panemux/internal/config"
 	"panemux/internal/session"
 	"panemux/internal/ws"
@@ -29,16 +30,19 @@ type Server struct {
 }
 
 // New creates a new server instance.
-func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Server {
+func New(
+	cfg *config.Config, manager *session.Manager, boardCache *board.BoardCache, boardRelay *board.Relay,
+	frontendFS embed.FS,
+) *Server {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(corsMiddleware)
 	r.Use(securityHeadersMiddleware)
 
-	apiHandler := api.NewHandler(cfg, manager)
+	apiHandler := api.NewHandler(cfg, manager, boardCache, boardRelay)
 	wsHandler := ws.NewHandler(manager)
-	registerRoutes(r, apiHandler, wsHandler, frontendFS)
+	registerRoutes(r, apiHandler, wsHandler, frontendFS, cfg.Server.AuthToken)
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	return &Server{
@@ -55,7 +59,9 @@ func New(cfg *config.Config, manager *session.Manager, frontendFS embed.FS) *Ser
 	}
 }
 
-func registerRoutes(r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, frontendFS embed.FS) {
+func registerRoutes(
+	r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, frontendFS embed.FS, authToken string,
+) {
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/layout", apiHandler.GetLayout)
 		r.Put("/layout", apiHandler.PutLayout)
@@ -79,6 +85,18 @@ func registerRoutes(r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler
 		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
 		r.Get("/detect-shell", apiHandler.GetDetectShell)
 		r.Get("/directories", apiHandler.GetDirectories)
+	})
+	// /api/board/* is the only part of the API gated behind bearer-token
+	// auth today: unlike every other /api/* route and /ws/{sessionID},
+	// nothing relies on these endpoints yet (no frontend calls them), so
+	// gating them from day one costs nothing — retrofitting auth onto the
+	// already-relied-upon unauthenticated routes above is a separate,
+	// larger change. See docs/security.md.
+	r.Route("/api/board", func(r chi.Router) {
+		r.Use(bearerAuthMiddleware(authToken))
+		r.Get("/status", apiHandler.GetBoardStatus)
+		r.Get("/messages", apiHandler.GetBoardMessages)
+		r.Post("/broadcast", apiHandler.PostBoardBroadcast)
 	})
 	r.Get("/ws/{sessionID}", wsHandler.ServeHTTP)
 	registerFrontend(r, frontendFS)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -46,14 +46,14 @@ func testConfig() *config.Config {
 func TestNew_ReturnsServer(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 }
 
 func TestAddr_ReturnsConfiguredAddress(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	assert.Equal(t, "127.0.0.1:8080", srv.Addr())
 }
 
@@ -154,7 +154,7 @@ func TestIsLocalhostOrigin(t *testing.T) {
 func TestServer_APIRoutesWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()
@@ -166,7 +166,7 @@ func TestServer_APIRoutesWired(t *testing.T) {
 func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()
@@ -181,7 +181,7 @@ func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
 func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/tab-position", `{"tab_position":"right"}`)
@@ -192,7 +192,7 @@ func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.
 func TestServer_WorkspaceVerticalBarWidthRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/vertical-bar-width", `{"vertical_bar_width":320}`)
@@ -213,7 +213,7 @@ func performWorkspaceSettingUpdate(t *testing.T, srv *Server, path string, body 
 func TestServer_DirectoriesRouteWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, emptyFS)
+	srv := New(cfg, mgr, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()

--- a/main.go
+++ b/main.go
@@ -98,7 +98,14 @@ func runServer(srv *server.Server, manager *session.Manager, boardRelay *board.R
 
 	boardCtx, cancelBoard := context.WithCancel(context.Background())
 	defer cancelBoard()
-	go boardRelay.Run(boardCtx, defaultBoardPollInterval)
+	// Skip the poll loop entirely when no host is reachable at all: with
+	// zero AgmsgClients every poll is a guaranteed no-op forever (nothing
+	// to read, nothing to relay), so starting it would just tick a ticker
+	// for the life of the process for no reason — including for the many
+	// panemux users who have never configured agent board at all.
+	if boardRelay.HasClients() {
+		go boardRelay.Run(boardCtx, defaultBoardPollInterval)
+	}
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"panemux/internal/board"
 	"panemux/internal/config"
 	"panemux/internal/server"
 	"panemux/internal/session"
@@ -48,7 +49,9 @@ func main() {
 		log.Fatalf("Failed to start sessions: %v", err)
 	}
 
-	srv := server.New(cfg, manager, frontendFS)
+	boardCache, boardRelay := setupBoard(cfg, manager)
+
+	srv := server.New(cfg, manager, boardCache, boardRelay, frontendFS)
 	addr := "http://" + srv.Addr()
 	log.Printf("Listening on %s", addr)
 
@@ -56,7 +59,7 @@ func main() {
 		go openChrome(addr)
 	}
 
-	runServer(srv, manager)
+	runServer(srv, manager, boardRelay)
 }
 
 func parseOptions() cliOptions {
@@ -89,9 +92,13 @@ func loadConfig(opts cliOptions) (*config.Config, error) {
 	return cfg, nil
 }
 
-func runServer(srv *server.Server, manager *session.Manager) {
+func runServer(srv *server.Server, manager *session.Manager, boardRelay *board.Relay) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	boardCtx, cancelBoard := context.WithCancel(context.Background())
+	defer cancelBoard()
+	go boardRelay.Run(boardCtx, defaultBoardPollInterval)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -105,6 +112,7 @@ func runServer(srv *server.Server, manager *session.Manager) {
 		}
 	case <-sigCh:
 		log.Println("Shutting down...")
+		cancelBoard()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
## Summary

Second slice of Agent Board (#165), building on the foundation merged in #166. Scope is intentionally narrower than the full "Phase 1 — Board core": the relay + REST endpoints only, with the PTY bootstrap flow and the command center (`/ws/board-command`) deferred to later PRs — see `docs/agent-board.md`'s status note and the "Scope" section for the reasoning.

- `internal/board/relay.go`: `Relay` type — polls every configured host's agmsg on a schedule (`Poll`/`Run`/`runLoop`), updates `BoardCache`, relays cross-host messages, and exposes `Broadcast` for the REST handler. Includes the from-validation/own-send-ledger forgery check and the row-processing order documented in `docs/agent-board.md`'s Cross-host relay section, with a regression test proving a relayed row is never double-counted in history when the destination host is polled next.
- `internal/board/cursor_store.go`: persists per-(host, team) relay cursors to `~/.config/panemux/board-relay-cursor.json` (`0600`) so a restart resumes roughly where it left off.
- `internal/board/agmsg_path.go`: `ResolveRemoteAgmsgPath` expands a remote `agent_board.agmsg_path`'s leading `~/` against that host's own `$HOME`, probed once over the existing SSH exec channel.
- `internal/board/cache.go`: fixed `BoardCache.MessagesSince` to return `[]CachedRow{Row, Seq}` instead of discarding `Seq` — the REST history endpoint needs it back as the next `since` cursor.
- `internal/api/board.go`: `GET /api/board/status`, `GET /api/board/messages`, `POST /api/board/broadcast` handlers.
- `internal/server/server.go`: wires `bearerAuthMiddleware` onto the new `/api/board/*` sub-route only — every pre-existing `/api/*` route and `/ws/{sessionID}` stay unauthenticated, since retrofitting auth onto routes the current frontend already relies on is a separate, larger change (regression-tested).
- `board.go` (`package main`) + `main.go`: `setupBoard` builds the pane→host map and per-host `AgmsgClient`s from config at startup and starts the relay goroutine alongside the HTTP server, both shut down together on signal.
- Docs updated: `docs/agent-board.md` (status note, `Relay`/`CachedRow` implementation notes, corrected auth scoping, fixed a stale `internal/api`→`internal/server` package label in the testing plan), `docs/architecture.md`, `docs/security.md`, `docs/behavior.md` (new REST section with exact request/response shapes and status codes).

## Test plan

- [x] `make check` passes (fmt, lint, Go + frontend tests, both coverage gates — combined Go coverage 87.7%, well above the 80% gate)
- [x] `go test ./... -race` passes, including the new relay tests under `-race` (first ticker-driven goroutine in this codebase)
- [x] Manual smoke test against the built binary: `GET /api/board/status` returns `401` with no token and `200 {"statuses":{}}` with the correct token; `GET /api/board/messages` returns `200 {"messages":[]}` with no `since` and `400` for a non-numeric `since`; `POST /api/board/broadcast` returns `422` for an empty `to` and `422` naming the pane for an unknown `to`; `GET /api/layout` (pre-existing route) stays reachable with no `Authorization` header

## Deferred to later PRs

- PTY bootstrap flow (process detection, one-time onboarding instruction)
- `/ws/board-command` and `GET /api/board/command/history` (command center)
- Wiring `bearerAuthMiddleware` onto the pre-existing `/api/*` routes and `/ws/{sessionID}`

---
_Generated by [Claude Code](https://claude.ai/code/session_015bGorfVr8zjhtYxZxyEPra)_