### PR TITLE
feat: implement Agent Board bootstrap flow

### DIFF
--- a/board.go
+++ b/board.go
@@ -30,19 +30,22 @@ const (
 	boardStartupProbeTimeout = 10 * time.Second
 )
 
-// setupBoard builds the shared BoardCache and Relay from cfg/manager. It
-// never fails startup — agent board is additive, never load-bearing (see
-// docs/agent-board.md's Design principles) — a host whose connection isn't
-// usable simply gets no AgmsgClient and is logged, not fatal.
-func setupBoard(cfg *config.Config, manager *session.Manager) (*board.BoardCache, *board.Relay) {
+// setupBoard builds the shared BoardCache, Relay, and bootstrapWatcher from
+// cfg/manager. It never fails startup — agent board is additive, never
+// load-bearing (see docs/agent-board.md's Design principles) — a host whose
+// connection isn't usable simply gets no AgmsgClient/bootstrap eligibility
+// and is logged, not fatal.
+func setupBoard(cfg *config.Config, manager *session.Manager) (*board.BoardCache, *board.Relay, *bootstrapWatcher) {
 	cache := board.NewBoardCache()
 
 	paneHosts := map[string]string{}
+	paneModes := map[string]string{}
 	for _, pane := range cfg.AllPanes() {
 		if pane.AgentBoard.Enabled == nil || !*pane.AgentBoard.Enabled {
 			continue
 		}
 		paneHosts[pane.ID] = boardHostForPane(pane)
+		paneModes[pane.ID] = pane.AgentBoard.Mode
 	}
 
 	clients := map[string]board.AgmsgClient{}
@@ -71,7 +74,40 @@ func setupBoard(cfg *config.Config, manager *session.Manager) (*board.BoardCache
 		}
 	}
 
-	return cache, relay
+	bootstrap := newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:       manager,
+		PaneHosts:     paneHosts,
+		PaneModes:     paneModes,
+		ResolvedPaths: resolveBootstrapPaths(cfg, manager, paneHosts),
+		Team:          cfg.AgentBoard.Team,
+		Persist:       persistBootstrapState,
+	})
+	if path, err := board.DefaultBootstrapStateFilePath(); err == nil {
+		if paneIDs, err := board.LoadBootstrapState(path); err == nil {
+			bootstrap.LoadPersistedState(paneIDs)
+		} else {
+			log.Printf("Warning: agent board bootstrap: loading bootstrap state file: %v", err)
+		}
+	}
+
+	return cache, relay, bootstrap
+}
+
+// resolveBootstrapPaths resolves agmsg_path for every distinct board-enabled
+// host, independently of newAgmsgClientForHost's own resolution for the
+// relay's client map — see bootstrapWatcherConfig's ResolvedPaths comment
+// for why this deliberately duplicates that probe rather than sharing its
+// result.
+func resolveBootstrapPaths(
+	cfg *config.Config, manager *session.Manager, paneHosts map[string]string,
+) map[string]string {
+	resolved := map[string]string{}
+	for _, host := range distinctBoardHosts(paneHosts) {
+		if path, ok := resolveAgmsgPathForHost(cfg, manager, paneHosts, host); ok {
+			resolved[host] = path
+		}
+	}
+	return resolved
 }
 
 func persistBoardCursors(entries []board.CursorEntry) {
@@ -82,6 +118,17 @@ func persistBoardCursors(entries []board.CursorEntry) {
 	}
 	if err := board.SaveCursorFile(path, entries); err != nil {
 		log.Printf("Warning: agent board: persisting relay cursor: %v", err)
+	}
+}
+
+func persistBootstrapState(paneIDs []string) {
+	path, err := board.DefaultBootstrapStateFilePath()
+	if err != nil {
+		log.Printf("Warning: agent board bootstrap: resolving bootstrap state file path: %v", err)
+		return
+	}
+	if err := board.SaveBootstrapState(path, paneIDs); err != nil {
+		log.Printf("Warning: agent board bootstrap: persisting bootstrap state: %v", err)
 	}
 }
 
@@ -117,32 +164,54 @@ func distinctBoardHosts(paneHosts map[string]string) []string {
 }
 
 // newAgmsgClientForHost builds the AgmsgClient for host. For the local host
-// this never fails. For a remote host it needs a live session on that host
-// implementing board.BoardExecutor, at least once, to resolve
-// agent_board.agmsg_path's leading ~/ against the remote $HOME — if no
-// board-enabled pane on that host currently has a started session, the host
-// is skipped with a warning rather than failing startup. The RemoteAgmsgClient
-// itself is handed a dynamicBoardExecutor, not that one-time snapshot,
-// so it keeps working across the relay's lifetime even if the particular
-// pane used to resolve agmsg_path is later restarted or deleted — see
-// dynamicBoardExecutor's own comment for why a fixed snapshot is wrong here.
+// this never fails. For a remote host it needs resolveAgmsgPathForHost to
+// succeed (a live session on that host implementing board.BoardExecutor, at
+// least once) — if not, the host is skipped with a warning rather than
+// failing startup. The RemoteAgmsgClient itself is handed a
+// dynamicBoardExecutor, not that one-time snapshot, so it keeps working
+// across the relay's lifetime even if the particular pane used to resolve
+// agmsg_path is later restarted or deleted — see dynamicBoardExecutor's own
+// comment for why a fixed snapshot is wrong here.
 func newAgmsgClientForHost(
 	cfg *config.Config, manager *session.Manager, paneHosts map[string]string, host string,
 ) (board.AgmsgClient, bool) {
+	path, ok := resolveAgmsgPathForHost(cfg, manager, paneHosts, host)
+	if !ok {
+		return nil, false
+	}
 	if host == boardHostIDLocal {
-		// AgentBoard.AgmsgPath is intentionally left un-expanded by
-		// internal/config (see config.go's expandPaths), since a single
-		// config value is shared by every host, local and remote alike.
-		// The local host expands against its own home directory here; a
-		// remote host expands against its own $HOME below, via
-		// ResolveRemoteAgmsgPath's SSH probe.
-		return board.NewLocalAgmsgClient(expandLocalAgmsgPath(cfg.AgentBoard.AgmsgPath)), true
+		return board.NewLocalAgmsgClient(path), true
+	}
+
+	dynamicExecutor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: host}
+	return board.NewRemoteAgmsgClient(host, path, dynamicExecutor), true
+}
+
+// resolveAgmsgPathForHost expands agent_board.agmsg_path's leading ~/ for
+// host: locally against panemux's own home directory (AgentBoard.AgmsgPath
+// is intentionally left un-expanded by internal/config — see config.go's
+// expandPaths — since a single config value is shared by every host, local
+// and remote alike), remotely via a bounded SSH $HOME probe using any live
+// BoardExecutor session currently available for that host. Returns
+// ok=false, having already logged a warning naming host, if no live
+// session/executor is reachable or the probe itself fails — callers use
+// this to skip whatever host-scoped resource they were about to build (an
+// AgmsgClient, a bootstrap-eligibility entry) rather than propagating the
+// error further. Shared by newAgmsgClientForHost and the bootstrap
+// watcher's own setup so the two independently-scoped subsystems (relay
+// client construction vs. bootstrap eligibility) never disagree about how
+// a host's agmsg_path resolves, without coupling them to each other.
+func resolveAgmsgPathForHost(
+	cfg *config.Config, manager *session.Manager, paneHosts map[string]string, host string,
+) (string, bool) {
+	if host == boardHostIDLocal {
+		return expandLocalAgmsgPath(cfg.AgentBoard.AgmsgPath), true
 	}
 
 	executors := findBoardExecutors(manager, paneHosts, host)
 	if len(executors) == 0 {
 		log.Printf("Warning: agent board: no reachable session for host %q, skipping", host)
-		return nil, false
+		return "", false
 	}
 
 	probeCtx, cancel := context.WithTimeout(context.Background(), boardStartupProbeTimeout)
@@ -150,11 +219,9 @@ func newAgmsgClientForHost(
 	path, err := board.ResolveRemoteAgmsgPath(probeCtx, executors[0], cfg.AgentBoard.AgmsgPath)
 	if err != nil {
 		log.Printf("Warning: agent board: resolving agmsg_path on host %q: %v", host, err)
-		return nil, false
+		return "", false
 	}
-
-	dynamicExecutor := &dynamicBoardExecutor{manager: manager, paneHosts: paneHosts, host: host}
-	return board.NewRemoteAgmsgClient(host, path, dynamicExecutor), true
+	return path, true
 }
 
 // expandLocalAgmsgPath expands a leading ~/ in path against panemux's own

--- a/board_test.go
+++ b/board_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"panemux/internal/config"
 	"panemux/internal/session"
 )
 
@@ -185,5 +186,81 @@ func TestExpandLocalAgmsgPath_AbsolutePath_Unchanged(t *testing.T) {
 	got := expandLocalAgmsgPath("/opt/agmsg")
 	if got != "/opt/agmsg" {
 		t.Fatalf("expandLocalAgmsgPath(/opt/agmsg) = %q, want unchanged", got)
+	}
+}
+
+func TestResolveAgmsgPathForHost_Local_ExpandsAgainstLocalHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir: %v", err)
+	}
+	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "~/.agents/skills/agmsg"}}
+
+	path, ok := resolveAgmsgPathForHost(cfg, session.NewManager(), nil, boardHostIDLocal)
+	if !ok {
+		t.Fatal("expected ok=true for the local host")
+	}
+	want := filepath.Join(home, ".agents", "skills", "agmsg")
+	if path != want {
+		t.Fatalf("resolveAgmsgPathForHost(local) = %q, want %q", path, want)
+	}
+}
+
+func TestResolveAgmsgPathForHost_RemoteNoReachableSession_False(t *testing.T) {
+	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/opt/agmsg"}}
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "ssh:build-host"}
+
+	_, ok := resolveAgmsgPathForHost(cfg, manager, paneHosts, "ssh:build-host")
+	if ok {
+		t.Fatal("expected ok=false when no session on the host implements BoardExecutor")
+	}
+}
+
+func TestResolveAgmsgPathForHost_Remote_ResolvesViaLiveExecutor(t *testing.T) {
+	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/opt/agmsg"}}
+	manager := session.NewManager()
+	paneHosts := map[string]string{"pane-a": "ssh:build-host"}
+	manager.Add(&fakeBoardSession{id: "pane-a", tag: "unused-for-absolute-paths"})
+
+	path, ok := resolveAgmsgPathForHost(cfg, manager, paneHosts, "ssh:build-host")
+	if !ok {
+		t.Fatal("expected ok=true when a live BoardExecutor session exists on the host")
+	}
+	if path != "/opt/agmsg" {
+		t.Fatalf("resolveAgmsgPathForHost(remote, absolute path) = %q, want unchanged", path)
+	}
+}
+
+func TestResolveBootstrapPaths_MixOfReachableAndUnreachableHosts(t *testing.T) {
+	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/opt/agmsg"}}
+	manager := session.NewManager()
+	paneHosts := map[string]string{
+		"pane-a": "ssh:reachable-host",
+		"pane-b": "ssh:unreachable-host",
+	}
+	manager.Add(&fakeBoardSession{id: "pane-a", tag: "unused-for-absolute-paths"})
+
+	resolved := resolveBootstrapPaths(cfg, manager, paneHosts)
+
+	if got, ok := resolved["ssh:reachable-host"]; !ok || got != "/opt/agmsg" {
+		t.Fatalf("resolved[reachable-host] = (%q, %v), want (/opt/agmsg, true)", got, ok)
+	}
+	if _, ok := resolved["ssh:unreachable-host"]; ok {
+		t.Fatal("expected no entry for a host with no reachable BoardExecutor session")
+	}
+}
+
+func TestSetupBoard_ReturnsNonNilBootstrapWatcher(t *testing.T) {
+	cfg := config.Default()
+	manager := session.NewManager()
+
+	_, _, bootstrap := setupBoard(cfg, manager)
+
+	if bootstrap == nil {
+		t.Fatal("expected setupBoard to return a non-nil bootstrapWatcher")
+	}
+	if bootstrap.HasWork() {
+		t.Fatal("expected HasWork()=false for a config with no board-enabled panes")
 	}
 }

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"panemux/internal/board"
+	"panemux/internal/session"
+)
+
+// defaultBootstrapPollInterval matches defaultBoardPollInterval. The
+// bootstrap watcher's own 2-tick debounce (see checkPane) adds roughly one
+// extra interval of latency between an agent process starting and the
+// onboarding instruction actually landing in its PTY; polling every 5s
+// rather than 10s keeps that added latency from being felt twice.
+const defaultBootstrapPollInterval = 5 * time.Second
+
+// boardModeTurn and boardModeBoth mirror internal/config's own (unexported)
+// agentBoardModeTurn/agentBoardModeBoth string values. Duplicated here
+// rather than exported from internal/config because bootstrapWatcher
+// deliberately takes no dependency on internal/config at all — see
+// bootstrapWatcherConfig's own comment.
+const (
+	boardModeTurn = "turn"
+	boardModeBoth = "both"
+)
+
+// bootstrapWatcherConfig is the precomputed, static input the bootstrap
+// watcher needs. Building it (which panes are board-enabled, which host each
+// lives on, each pane's configured mode, each host's resolved agmsg_path) is
+// the caller's job (board.go's setupBoard) — bootstrapWatcher itself takes
+// no dependency on internal/config, mirroring board.RelayConfig's own
+// existing dependency direction (see relay.go's RelayConfig comment).
+type bootstrapWatcherConfig struct {
+	Manager       *session.Manager
+	PaneHosts     map[string]string
+	PaneModes     map[string]string
+	ResolvedPaths map[string]string
+	Persist       func(paneIDs []string)
+	Team          string
+}
+
+// bootstrapWatcher polls board-enabled panes for a newly-started, agmsg-
+// detectable coding-agent process and writes a one-time onboarding
+// instruction into that pane's PTY. See docs/agent-board.md's Bootstrap flow
+// section for the full design.
+//
+// No mutex: unlike Relay, every field here is touched only from the single
+// goroutine driving runLoop — nothing else ever reads or writes this
+// watcher's state.
+type bootstrapWatcher struct {
+	manager          *session.Manager
+	paneHosts        map[string]string
+	paneModes        map[string]string
+	resolvedPaths    map[string]string
+	persist          func(paneIDs []string)
+	bootstrapped     map[string]session.Session
+	pending          map[string]session.Session
+	presenceWarned   map[string]bool
+	team             string
+	persistedPaneIDs []string
+	seeded           bool
+}
+
+// newBootstrapWatcher returns a bootstrapWatcher ready to have persisted
+// state loaded (LoadPersistedState) and then be polled or run.
+func newBootstrapWatcher(cfg bootstrapWatcherConfig) *bootstrapWatcher {
+	return &bootstrapWatcher{
+		manager:        cfg.Manager,
+		paneHosts:      cfg.PaneHosts,
+		paneModes:      cfg.PaneModes,
+		resolvedPaths:  cfg.ResolvedPaths,
+		team:           cfg.Team,
+		persist:        cfg.Persist,
+		bootstrapped:   map[string]session.Session{},
+		pending:        map[string]session.Session{},
+		presenceWarned: map[string]bool{},
+	}
+}
+
+// LoadPersistedState seeds the pane IDs that were already bootstrapped as of
+// the last save, consumed exactly once by the first pollOnce call. Call
+// before Run/pollOnce, mirroring Relay.LoadCursors.
+func (b *bootstrapWatcher) LoadPersistedState(paneIDs []string) {
+	b.persistedPaneIDs = paneIDs
+}
+
+// HasWork reports whether there is any board-enabled pane to watch at all.
+// Callers use this to skip starting the poll loop entirely, mirroring
+// Relay.HasClients.
+func (b *bootstrapWatcher) HasWork() bool {
+	return len(b.paneHosts) > 0
+}
+
+// Run polls every interval until ctx is canceled, running one immediate
+// pollOnce first. Mirrors Relay.Run.
+func (b *bootstrapWatcher) Run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	b.runLoop(ctx, ticker.C)
+}
+
+// runLoop is Run's actual loop, factored out so tests can drive it with an
+// injected tick channel instead of real time. Mirrors Relay.runLoop.
+func (b *bootstrapWatcher) runLoop(ctx context.Context, tick <-chan time.Time) {
+	b.pollOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick:
+			b.pollOnce(ctx)
+		}
+	}
+}
+
+// pollOnce checks every board-enabled pane once. On its very first call it
+// seeds bootstrapped from persistedPaneIDs — using each persisted pane ID's
+// *currently live* Session, if any, purely to give bootstrapped an identity
+// to compare future ticks against. persistedPaneIDs is never consulted
+// again after this: from here on, only bootstrapped's own session-identity
+// map governs re-bootstrap decisions. This is what makes seeding safe across
+// a panemux restart (an already-onboarded, still-running agent is seeded
+// before its pane is ever checked, so it is never re-bootstrapped) while
+// still allowing a pane that restarts within this same process's lifetime to
+// be bootstrapped again (its new Session object won't match the seeded one).
+func (b *bootstrapWatcher) pollOnce(ctx context.Context) {
+	if !b.seeded {
+		for _, paneID := range b.persistedPaneIDs {
+			if sess, ok := b.manager.Get(paneID); ok {
+				b.bootstrapped[paneID] = sess
+			}
+		}
+		b.seeded = true
+	}
+	for paneID, host := range b.paneHosts {
+		b.checkPane(ctx, paneID, host)
+	}
+}
+
+// checkPane runs the bootstrap decision for one pane. See
+// docs/agent-board.md's Bootstrap flow section for the algorithm this
+// implements.
+func (b *bootstrapWatcher) checkPane(ctx context.Context, paneID, host string) {
+	sess, ok := b.manager.Get(paneID)
+	if !ok {
+		delete(b.pending, paneID)
+		return
+	}
+	if existing, alreadyBootstrapped := b.bootstrapped[paneID]; alreadyBootstrapped && existing == sess {
+		return
+	}
+
+	detector, ok := sess.(session.AgentTypeDetector)
+	if !ok {
+		delete(b.pending, paneID)
+		return
+	}
+	agmsgType, detected, err := detector.DetectInteractiveAgentType()
+	if err != nil {
+		log.Printf("Warning: agent board bootstrap: detecting agent type for pane %q: %v", paneID, err)
+		delete(b.pending, paneID)
+		return
+	}
+	if !detected {
+		delete(b.pending, paneID)
+		return
+	}
+
+	// Debounce: only proceed once the same session has been seen with an
+	// active, known agent type on two consecutive ticks. This is a partial
+	// mitigation, not a complete one, against writing into a pane the
+	// instant its shell is still settling — see docs/agent-board.md's
+	// Bootstrap flow section for the honest tradeoff this represents.
+	if pendingSess, isPending := b.pending[paneID]; !isPending || pendingSess != sess {
+		b.pending[paneID] = sess
+		return
+	}
+
+	present, checked := b.agmsgPresent(ctx, paneID, host)
+	if !checked {
+		return
+	}
+	if !present {
+		b.warnOnce(paneID, fmt.Sprintf(
+			"agent board bootstrap: agmsg not found on host %q for pane %q, skipping bootstrap", host, paneID,
+		))
+		return
+	}
+
+	instruction := buildBootstrapInstruction(b.resolvedPaths[host], b.team, paneID, agmsgType, b.paneModes[paneID])
+	payload := []byte(instruction + "\r")
+	n, err := sess.Write(payload)
+	if err != nil || n != len(payload) {
+		log.Printf(
+			"Warning: agent board bootstrap: writing onboarding instruction to pane %q: %v (wrote %d/%d bytes)",
+			paneID, err, n, len(payload),
+		)
+		return
+	}
+
+	b.bootstrapped[paneID] = sess
+	delete(b.pending, paneID)
+	b.persistBootstrapped()
+}
+
+// agmsgPresent reports whether agmsg is present on host, and whether that
+// question could be answered at all (checked=false means "couldn't tell this
+// tick, try again next tick" — a transport error or an unreachable host, not
+// "not present").
+func (b *bootstrapWatcher) agmsgPresent(ctx context.Context, paneID, host string) (present bool, checked bool) {
+	path, ok := b.resolvedPaths[host]
+	if !ok {
+		b.warnOnce(paneID, fmt.Sprintf("agent board bootstrap: no resolved agmsg_path for host %q (pane %q)", host, paneID))
+		return false, false
+	}
+
+	if host == boardHostIDLocal {
+		return board.LocalAgmsgPresent(path), true
+	}
+
+	executors := findBoardExecutors(b.manager, b.paneHosts, host)
+	if len(executors) == 0 {
+		b.warnOnce(paneID, fmt.Sprintf("agent board bootstrap: no reachable session for host %q (pane %q)", host, paneID))
+		return false, false
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, boardStartupProbeTimeout)
+	defer cancel()
+	present, err := board.RemoteAgmsgPresent(probeCtx, executors[0], path)
+	if err != nil {
+		b.warnOnce(paneID, fmt.Sprintf(
+			"agent board bootstrap: checking agmsg presence on host %q (pane %q): %v", host, paneID, err,
+		))
+		return false, false
+	}
+	return present, true
+}
+
+func (b *bootstrapWatcher) warnOnce(paneID, message string) {
+	if b.presenceWarned[paneID] {
+		return
+	}
+	b.presenceWarned[paneID] = true
+	log.Printf("Warning: %s", message)
+}
+
+// persistBootstrapped saves the current set of bootstrapped pane IDs,
+// mirroring cursor_store.go's "persist only what actually changed" pattern:
+// this is only ever called right after bootstrapped gains a new entry, never
+// during seeding (which reflects state already on disk, not a change to it).
+func (b *bootstrapWatcher) persistBootstrapped() {
+	if b.persist == nil {
+		return
+	}
+	ids := make([]string, 0, len(b.bootstrapped))
+	for id := range b.bootstrapped {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	b.persist(ids)
+}
+
+// buildBootstrapInstruction builds the one-time onboarding instruction
+// written into a pane's PTY. It tells the agent to invoke agmsg's own
+// scripts (join.sh/send.sh/delivery.sh) directly with their verified
+// positional-argument signatures, rather than agmsg's slash-command
+// shorthand (`/agmsg ...` or `$agmsg ...` depending on agent type — the
+// prefix itself differs per agmsg's own per-type `cmd_prefix` driver
+// setting, so hardcoding either one would silently be wrong for the other
+// half of agmsg's supported agent types). agmsgType is the agmsg-recognized
+// type string session.AgentTypeDetector reported (e.g. "claude-code",
+// "gemini") and is passed as both join.sh's and delivery.sh's own `<type>`
+// argument. mode is the pane's agent_board.mode config value ("" is
+// treated the same as "monitor"/"off": no step 4 at all, since agmsg's own
+// default already behaves like monitor without any explicit call).
+func buildBootstrapInstruction(agmsgPath, team, paneID, agmsgType, mode string) string {
+	var b strings.Builder
+	b.WriteString("Please set up Agent Board messaging for this session using agmsg's own scripts directly")
+	b.WriteString(" (not the /agmsg or $agmsg slash-command, since its exact prefix differs by agent type):\n")
+	fmt.Fprintf(&b, "1. Join the agmsg team %q by running:\n", team)
+	fmt.Fprintf(&b, "   %s/scripts/join.sh %q %q %q \"$(pwd)\" --force\n", agmsgPath, team, paneID, agmsgType)
+	b.WriteString("   Use exactly that agent_id — not a name of your own choosing — since every cross-pane\n")
+	b.WriteString("   and relay address in Agent Board assumes from/to values are pane IDs.\n")
+	b.WriteString("2. From now on, send every board-related message (status reports and messages to other\n")
+	b.WriteString("   panes) with:\n")
+	fmt.Fprintf(&b, "   %s/scripts/send.sh %q %q \"<to>\" \"<body>\" --force\n", agmsgPath, team, paneID)
+	b.WriteString("3. Periodically self-report your status to \"_system\" using that same send.sh invocation,\n")
+	b.WriteString("   with a JSON body shaped exactly like:\n")
+	b.WriteString("   {\"kind\":\"board_status\",\"state\":\"working|idle|waiting\",\"cwd\":\"...\",\"branch\":\"...\",\n")
+	b.WriteString("   \"repo\":\"...\",\"pr_url\":\"...\",\"last_tool\":\"...\",\"summary\":\"...\"}\n")
+	b.WriteString("   Omit fields you don't currently have. Send an update whenever your state changes\n")
+	b.WriteString("   meaningfully.\n")
+	if mode == boardModeTurn || mode == boardModeBoth {
+		b.WriteString("4. Also run:\n")
+		fmt.Fprintf(&b, "   %s/scripts/delivery.sh set %q %q \"$(pwd)\"\n", agmsgPath, mode, agmsgType)
+		b.WriteString("   This prints an AGMSG-DIRECTIVE: block — read it and follow its instructions exactly;\n")
+		b.WriteString("   it configures how you receive incoming board messages from now on.\n")
+	}
+	return b.String()
+}

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -19,6 +19,22 @@ import (
 // rather than 10s keeps that added latency from being felt twice.
 const defaultBootstrapPollInterval = 5 * time.Second
 
+// bootstrapProbeTimeout bounds an individual remote presence probe
+// checkPane makes. Deliberately shorter than boardStartupProbeTimeout
+// (10s, sized for a one-shot startup call): pollOnce runs every board pane
+// sequentially within one defaultBootstrapPollInterval-wide tick, so an
+// unreachable host's probe must not be allowed to eat most of that budget
+// and delay every other pane queued behind it in the same tick.
+const bootstrapProbeTimeout = 3 * time.Second
+
+// maxBootstrapWriteAttempts bounds how many times checkPane retries a
+// failed (but not short/partial) Session.Write before giving up on a pane
+// for the rest of that session's lifetime. A write that returns n==0 with
+// an error hasn't put anything into the pane yet, so a few retries are
+// safe; see the giveUp/writeAttempts fields for why a *short* write is
+// never retried at all.
+const maxBootstrapWriteAttempts = 3
+
 // boardModeTurn and boardModeBoth mirror internal/config's own (unexported)
 // agentBoardModeTurn/agentBoardModeBoth string values. Duplicated here
 // rather than exported from internal/config because bootstrapWatcher
@@ -53,13 +69,25 @@ type bootstrapWatcherConfig struct {
 // goroutine driving runLoop — nothing else ever reads or writes this
 // watcher's state.
 type bootstrapWatcher struct {
-	manager          *session.Manager
-	paneHosts        map[string]string
-	paneModes        map[string]string
-	resolvedPaths    map[string]string
-	persist          func(paneIDs []string)
-	bootstrapped     map[string]session.Session
-	pending          map[string]session.Session
+	manager       *session.Manager
+	paneHosts     map[string]string
+	paneModes     map[string]string
+	resolvedPaths map[string]string
+	persist       func(paneIDs []string)
+	bootstrapped  map[string]session.Session
+	pending       map[string]session.Session
+	// givenUp holds panes checkPane will never attempt to write to again for
+	// the life of the current session object: either a Write returned a
+	// nonzero-but-short n (any retry would type on top of an already
+	// half-written line — see checkPane), or a clean (n==0) failure recurred
+	// maxBootstrapWriteAttempts times in a row. Keyed and compared by
+	// session identity exactly like bootstrapped, so a pane that is later
+	// restarted (a new Session object) is eligible again.
+	givenUp map[string]session.Session
+	// writeAttempts counts consecutive clean (n==0) Write failures per pane,
+	// reset on success and on giving up. Not persisted: it only needs to
+	// survive within one session object's lifetime.
+	writeAttempts    map[string]int
 	presenceWarned   map[string]bool
 	team             string
 	persistedPaneIDs []string
@@ -78,6 +106,8 @@ func newBootstrapWatcher(cfg bootstrapWatcherConfig) *bootstrapWatcher {
 		persist:        cfg.Persist,
 		bootstrapped:   map[string]session.Session{},
 		pending:        map[string]session.Session{},
+		givenUp:        map[string]session.Session{},
+		writeAttempts:  map[string]int{},
 		presenceWarned: map[string]bool{},
 	}
 }
@@ -124,16 +154,28 @@ func (b *bootstrapWatcher) runLoop(ctx context.Context, tick <-chan time.Time) {
 // to compare future ticks against. persistedPaneIDs is never consulted
 // again after this: from here on, only bootstrapped's own session-identity
 // map governs re-bootstrap decisions. This is what makes seeding safe across
-// a panemux restart (an already-onboarded, still-running agent is seeded
-// before its pane is ever checked, so it is never re-bootstrapped) while
-// still allowing a pane that restarts within this same process's lifetime to
-// be bootstrapped again (its new Session object won't match the seeded one).
+// a panemux restart, but only for a pane whose underlying agent process can
+// actually have survived that restart: seeding only ever applies to
+// TypeTmux/TypeSSHTmux sessions, which reattach to an independently-running
+// tmux session on every panemux startup. A TypeLocal/TypeSSH pane's
+// Session.CreateFromConfig always spawns a brand-new shell with nothing
+// running in it — seeding those from persisted state would permanently
+// suppress bootstrap for that pane on every future run, mistaking "we
+// bootstrapped a previous, now-gone process" for "the current process is
+// already onboarded". A pane that restarts within this same process's
+// lifetime is unaffected either way (its new Session object won't match
+// whatever was seeded).
 func (b *bootstrapWatcher) pollOnce(ctx context.Context) {
 	if !b.seeded {
 		for _, paneID := range b.persistedPaneIDs {
-			if sess, ok := b.manager.Get(paneID); ok {
-				b.bootstrapped[paneID] = sess
+			sess, ok := b.manager.Get(paneID)
+			if !ok {
+				continue
 			}
+			if sess.Type() != session.TypeTmux && sess.Type() != session.TypeSSHTmux {
+				continue
+			}
+			b.bootstrapped[paneID] = sess
 		}
 		b.seeded = true
 	}
@@ -152,6 +194,25 @@ func (b *bootstrapWatcher) checkPane(ctx context.Context, paneID, host string) {
 		return
 	}
 	if existing, alreadyBootstrapped := b.bootstrapped[paneID]; alreadyBootstrapped && existing == sess {
+		return
+	}
+	if existing, gaveUp := b.givenUp[paneID]; gaveUp && existing == sess {
+		return
+	}
+
+	// A pane ID or team that doesn't match agmsg's own identifier alphabet
+	// (internal/board.ValidAgmsgIdentifier — the same allowlist
+	// RemoteAgmsgClient already enforces before any RunBoardCommand call)
+	// can never be bootstrapped correctly: it would either break the shell
+	// command the onboarding instruction tells the agent to run, or join
+	// agmsg under an identity the relay can never address back. Skip and
+	// warn once rather than write a broken instruction.
+	if !board.ValidAgmsgIdentifier(paneID) || !board.ValidAgmsgIdentifier(b.team) {
+		b.warnOnce(paneID, fmt.Sprintf(
+			"agent board bootstrap: pane %q or team %q is not a valid agmsg identifier, skipping bootstrap",
+			paneID, b.team,
+		))
+		delete(b.pending, paneID)
 		return
 	}
 
@@ -193,25 +254,72 @@ func (b *bootstrapWatcher) checkPane(ctx context.Context, paneID, host string) {
 	}
 
 	instruction := buildBootstrapInstruction(b.resolvedPaths[host], b.team, paneID, agmsgType, b.paneModes[paneID])
+	b.writeInstruction(paneID, sess, instruction)
+}
+
+// writeInstruction attempts the actual PTY write for paneID's onboarding
+// instruction and updates bootstrapped/givenUp/writeAttempts/pending based
+// on the outcome. Split out of checkPane to keep each function's branching
+// manageable on its own.
+//
+// A short write (n > 0) has already put part of the instruction into the
+// pane — retrying would type the full instruction again on top of that
+// half-written line, compounding the corruption rather than fixing it, so
+// checkPane gives up on that pane immediately. A clean failure (n == 0,
+// nothing written yet) is safe to retry, so it's retried up to
+// maxBootstrapWriteAttempts times before giving up the same way.
+func (b *bootstrapWatcher) writeInstruction(paneID string, sess session.Session, instruction string) {
 	payload := []byte(instruction + "\r")
 	n, err := sess.Write(payload)
-	if err != nil || n != len(payload) {
-		log.Printf(
-			"Warning: agent board bootstrap: writing onboarding instruction to pane %q: %v (wrote %d/%d bytes)",
-			paneID, err, n, len(payload),
-		)
+	if err == nil && n == len(payload) {
+		delete(b.writeAttempts, paneID)
+		b.bootstrapped[paneID] = sess
+		delete(b.pending, paneID)
+		b.persistBootstrapped()
 		return
 	}
 
-	b.bootstrapped[paneID] = sess
-	delete(b.pending, paneID)
-	b.persistBootstrapped()
+	if n > 0 {
+		log.Printf(
+			"Warning: agent board bootstrap: partial write to pane %q (%d/%d bytes); "+
+				"not retrying, since a retry would type on top of a half-written instruction",
+			paneID, n, len(payload),
+		)
+		b.givenUp[paneID] = sess
+		delete(b.pending, paneID)
+		delete(b.writeAttempts, paneID)
+		return
+	}
+
+	b.writeAttempts[paneID]++
+	if b.writeAttempts[paneID] >= maxBootstrapWriteAttempts {
+		log.Printf(
+			"Warning: agent board bootstrap: giving up writing onboarding instruction to pane %q "+
+				"after %d failed attempts: %v",
+			paneID, b.writeAttempts[paneID], err,
+		)
+		b.givenUp[paneID] = sess
+		delete(b.pending, paneID)
+		delete(b.writeAttempts, paneID)
+		return
+	}
+	log.Printf(
+		"Warning: agent board bootstrap: writing onboarding instruction to pane %q: %v (attempt %d/%d)",
+		paneID, err, b.writeAttempts[paneID], maxBootstrapWriteAttempts,
+	)
 }
 
 // agmsgPresent reports whether agmsg is present on host, and whether that
 // question could be answered at all (checked=false means "couldn't tell this
 // tick, try again next tick" — a transport error or an unreachable host, not
-// "not present").
+// "not present"). For a remote host, the probe goes through a
+// dynamicBoardExecutor rather than a single findBoardExecutors candidate
+// directly: a session can still be registered (and report a normal State())
+// after its underlying connection has actually died, so trusting only the
+// first candidate could permanently and silently treat a bootstrap-eligible
+// host as unreachable even while some other pane on it is genuinely
+// live — see dynamicBoardExecutor's own comment in board.go for the full
+// rationale, which applies identically here.
 func (b *bootstrapWatcher) agmsgPresent(ctx context.Context, paneID, host string) (present bool, checked bool) {
 	path, ok := b.resolvedPaths[host]
 	if !ok {
@@ -223,15 +331,10 @@ func (b *bootstrapWatcher) agmsgPresent(ctx context.Context, paneID, host string
 		return board.LocalAgmsgPresent(path), true
 	}
 
-	executors := findBoardExecutors(b.manager, b.paneHosts, host)
-	if len(executors) == 0 {
-		b.warnOnce(paneID, fmt.Sprintf("agent board bootstrap: no reachable session for host %q (pane %q)", host, paneID))
-		return false, false
-	}
-
-	probeCtx, cancel := context.WithTimeout(ctx, boardStartupProbeTimeout)
+	executor := &dynamicBoardExecutor{manager: b.manager, paneHosts: b.paneHosts, host: host}
+	probeCtx, cancel := context.WithTimeout(ctx, bootstrapProbeTimeout)
 	defer cancel()
-	present, err := board.RemoteAgmsgPresent(probeCtx, executors[0], path)
+	present, err := board.RemoteAgmsgPresent(probeCtx, executor, path)
 	if err != nil {
 		b.warnOnce(paneID, fmt.Sprintf(
 			"agent board bootstrap: checking agmsg presence on host %q (pane %q): %v", host, paneID, err,

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -1,0 +1,399 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/session"
+)
+
+// fakeAgentSession is a session.Session that also implements
+// session.AgentTypeDetector and board.BoardExecutor, standing in for a real
+// LocalSession/SSHSession in bootstrap tests. Detection results and write
+// behavior are set directly on the struct; RunBoardCommand answers from a
+// map the same way fakeBoardExecutor (internal/board) does.
+type fakeAgentSession struct {
+	detectErr    error
+	writeErr     error
+	boardErr     error
+	boardOutputs map[string][]byte
+	id           string
+	detectType   string
+	writes       [][]byte
+	detectOK     bool
+	writeShort   bool
+}
+
+func (f *fakeAgentSession) ID() string                     { return f.id }
+func (f *fakeAgentSession) Type() session.Type             { return session.TypeLocal }
+func (f *fakeAgentSession) Title() string                  { return f.id }
+func (f *fakeAgentSession) State() session.State           { return session.StateConnected }
+func (f *fakeAgentSession) Read(p []byte) (int, error)     { return 0, nil }
+func (f *fakeAgentSession) Resize(cols, rows uint16) error { return nil }
+func (f *fakeAgentSession) Close() error                   { return nil }
+
+func (f *fakeAgentSession) Write(p []byte) (int, error) {
+	f.writes = append(f.writes, append([]byte(nil), p...))
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+	if f.writeShort {
+		return len(p) - 1, nil
+	}
+	return len(p), nil
+}
+
+func (f *fakeAgentSession) DetectInteractiveAgentType() (string, bool, error) {
+	return f.detectType, f.detectOK, f.detectErr
+}
+
+func (f *fakeAgentSession) RunBoardCommand(_ context.Context, args []string) ([]byte, error) {
+	if f.boardErr != nil {
+		return nil, f.boardErr
+	}
+	key := strings.Join(args, "\x00")
+	return f.boardOutputs[key], nil
+}
+
+// noAgentSession implements session.Session only (no AgentTypeDetector), for
+// exercising the "capability not present" no-op path.
+type noAgentSession struct{ id string }
+
+func (n *noAgentSession) ID() string                     { return n.id }
+func (n *noAgentSession) Type() session.Type             { return session.TypeLocal }
+func (n *noAgentSession) Title() string                  { return n.id }
+func (n *noAgentSession) State() session.State           { return session.StateConnected }
+func (n *noAgentSession) Read(p []byte) (int, error)     { return 0, nil }
+func (n *noAgentSession) Write(p []byte) (int, error)    { return len(p), nil }
+func (n *noAgentSession) Resize(cols, rows uint16) error { return nil }
+func (n *noAgentSession) Close() error                   { return nil }
+
+// localAgmsgDir creates a tempdir with (or without) scripts/api.sh present,
+// suitable for use as a resolvedPaths["local"] entry.
+func localAgmsgDir(t *testing.T, present bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if present {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "scripts"), 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "api.sh"), []byte("#!/bin/sh\n"), 0600))
+	}
+	return dir
+}
+
+func newLocalWatcher(manager *session.Manager, agmsgPath, team string, paneModes map[string]string) *bootstrapWatcher {
+	return newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:       manager,
+		PaneHosts:     map[string]string{"pane-a": boardHostIDLocal},
+		PaneModes:     paneModes,
+		ResolvedPaths: map[string]string{boardHostIDLocal: agmsgPath},
+		Team:          team,
+	})
+}
+
+func TestBootstrapWatcher_NoAgentDetected_NoWrite(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectOK: false}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	assert.Empty(t, sess.writes)
+}
+
+func TestBootstrapWatcher_DebouncesAcrossTwoTicks(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+
+	w.pollOnce(context.Background())
+	assert.Empty(t, sess.writes, "must not write on the first tick that detects the agent")
+
+	w.pollOnce(context.Background())
+	require.Len(t, sess.writes, 1, "must write on the second consecutive tick for the same session")
+	assert.True(t, strings.HasSuffix(string(sess.writes[0]), "\r"))
+}
+
+func TestBootstrapWatcher_AlreadyBootstrapped_NoRewrite(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+	require.Len(t, sess.writes, 1)
+
+	// Further ticks, with the agent still detected on the same session,
+	// must not write again.
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+	assert.Len(t, sess.writes, 1)
+}
+
+func TestBootstrapWatcher_AgmsgNotPresent_NoWrite_WarnsOnce(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, false), "panemux", nil)
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	assert.Empty(t, sess.writes)
+	assert.True(t, w.presenceWarned["pane-a"])
+}
+
+func TestBootstrapWatcher_RemotePresenceCheck_YesWritesNoDoesNot(t *testing.T) {
+	agmsgPath := "/home/remote-user/agmsg"
+	probeArgs := []string{
+		"sh", "-c", "test -f \"$1\" && printf 'yes' || printf 'no'", "board-agmsg-presence",
+		agmsgPath + "/scripts/api.sh",
+	}
+	probeKey := strings.Join(probeArgs, "\x00")
+
+	t.Run("present", func(t *testing.T) {
+		manager := session.NewManager()
+		sess := &fakeAgentSession{
+			id: "pane-a", detectType: "codex", detectOK: true,
+			boardOutputs: map[string][]byte{probeKey: []byte("yes")},
+		}
+		manager.Add(sess)
+
+		w := newBootstrapWatcher(bootstrapWatcherConfig{
+			Manager:       manager,
+			PaneHosts:     map[string]string{"pane-a": "ssh:build-host"},
+			ResolvedPaths: map[string]string{"ssh:build-host": agmsgPath},
+			Team:          "panemux",
+		})
+		w.pollOnce(context.Background())
+		w.pollOnce(context.Background())
+		require.Len(t, sess.writes, 1)
+	})
+
+	t.Run("not present", func(t *testing.T) {
+		manager := session.NewManager()
+		sess := &fakeAgentSession{
+			id: "pane-a", detectType: "codex", detectOK: true,
+			boardOutputs: map[string][]byte{probeKey: []byte("no")},
+		}
+		manager.Add(sess)
+
+		w := newBootstrapWatcher(bootstrapWatcherConfig{
+			Manager:       manager,
+			PaneHosts:     map[string]string{"pane-a": "ssh:build-host"},
+			ResolvedPaths: map[string]string{"ssh:build-host": agmsgPath},
+			Team:          "panemux",
+		})
+		w.pollOnce(context.Background())
+		w.pollOnce(context.Background())
+		assert.Empty(t, sess.writes)
+	})
+}
+
+func TestBootstrapWatcher_RemotePresenceCheckTransportError_DistinctFromNo(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{
+		id: "pane-a", detectType: "codex", detectOK: true,
+		boardErr: errors.New("ssh: connection lost"),
+	}
+	manager.Add(sess)
+
+	w := newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:       manager,
+		PaneHosts:     map[string]string{"pane-a": "ssh:build-host"},
+		ResolvedPaths: map[string]string{"ssh:build-host": "/opt/agmsg"},
+		Team:          "panemux",
+	})
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	assert.Empty(t, sess.writes)
+	assert.True(t, w.presenceWarned["pane-a"])
+}
+
+func TestBootstrapWatcher_ShortWrite_NotMarkedBootstrapped(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true, writeShort: true}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	require.NotEmpty(t, sess.writes, "a short write attempt still counts as an attempt")
+	_, bootstrapped := w.bootstrapped["pane-a"]
+	assert.False(t, bootstrapped, "a short write must not be treated as a successful bootstrap")
+}
+
+func TestBootstrapWatcher_WriteError_NotMarkedBootstrapped(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{
+		id: "pane-a", detectType: "claude-code", detectOK: true,
+		writeErr: errors.New("pty closed"),
+	}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	_, bootstrapped := w.bootstrapped["pane-a"]
+	assert.False(t, bootstrapped)
+}
+
+func TestBootstrapWatcher_NoAgentTypeDetectorCapability_NoOp(t *testing.T) {
+	manager := session.NewManager()
+	sess := &noAgentSession{id: "pane-a"}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	assert.NotPanics(t, func() {
+		w.pollOnce(context.Background())
+		w.pollOnce(context.Background())
+	})
+}
+
+// TestBootstrapWatcher_PersistedSeed_PreventsReBootstrapOfLiveSession is the
+// central regression test for the seeding design: a pane ID persisted from a
+// previous panemux run, whose session is still alive and still shows an
+// active known agent, must not be re-bootstrapped just because panemux
+// itself restarted. A *different* Session object for the same pane ID
+// (simulating that pane being restarted within the current process) must be
+// bootstrapped again.
+func TestBootstrapWatcher_PersistedSeed_PreventsReBootstrapOfLiveSession(t *testing.T) {
+	manager := session.NewManager()
+	original := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(original)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.LoadPersistedState([]string{"pane-a"})
+
+	// Even though the agent is detected on every tick, seeding must prevent
+	// any write from ever happening for this still-live session.
+	for i := 0; i < 5; i++ {
+		w.pollOnce(context.Background())
+	}
+	assert.Empty(t, original.writes)
+
+	// Now simulate the pane being restarted within this same process: a new
+	// Session object takes its place under the same pane ID.
+	require.NoError(t, manager.Remove("pane-a"))
+	replacement := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(replacement)
+
+	w.pollOnce(context.Background())
+	assert.Empty(t, replacement.writes, "first tick after restart must still debounce")
+	w.pollOnce(context.Background())
+	assert.Len(t, replacement.writes, 1, "the replacement session must be bootstrapped like any new one")
+}
+
+func TestBootstrapWatcher_PersistSuccessfulBootstrap(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(sess)
+
+	var persisted [][]string
+	w := newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:       manager,
+		PaneHosts:     map[string]string{"pane-a": boardHostIDLocal},
+		ResolvedPaths: map[string]string{boardHostIDLocal: localAgmsgDir(t, true)},
+		Team:          "panemux",
+		Persist:       func(paneIDs []string) { persisted = append(persisted, paneIDs) },
+	})
+
+	w.pollOnce(context.Background())
+	assert.Empty(t, persisted, "no persist call before the actual write happens")
+	w.pollOnce(context.Background())
+	require.Len(t, persisted, 1)
+	assert.Equal(t, []string{"pane-a"}, persisted[0])
+}
+
+func TestBootstrapWatcher_HasWork(t *testing.T) {
+	manager := session.NewManager()
+
+	empty := newBootstrapWatcher(bootstrapWatcherConfig{Manager: manager, PaneHosts: map[string]string{}})
+	assert.False(t, empty.HasWork())
+
+	withPanes := newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:   manager,
+		PaneHosts: map[string]string{"pane-a": boardHostIDLocal},
+	})
+	assert.True(t, withPanes.HasWork(), "must report true even before any agent has actually been detected")
+}
+
+func TestBootstrapWatcher_RunLoop_StopsOnContextCancel(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	go func() {
+		w.runLoop(ctx, tick)
+		close(done)
+	}()
+
+	tick <- time.Now() // second tick for the same session -> triggers the write
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runLoop did not stop after context cancellation")
+	}
+	assert.Len(t, sess.writes, 1)
+}
+
+func TestBuildBootstrapInstruction_ModeMonitorOrEmpty_NoDeliveryStep(t *testing.T) {
+	for _, mode := range []string{"", "monitor", "off"} {
+		text := buildBootstrapInstruction("/opt/agmsg", "panemux", "pane-a", "claude-code", mode)
+		assert.NotContains(t, text, "delivery.sh", "mode %q must not include a delivery.sh step", mode)
+	}
+}
+
+func TestBuildBootstrapInstruction_ModeTurnOrBoth_IncludesDeliveryStep(t *testing.T) {
+	for _, mode := range []string{"turn", "both"} {
+		text := buildBootstrapInstruction("/opt/agmsg", "panemux", "pane-a", "gemini", mode)
+		want := `/opt/agmsg/scripts/delivery.sh set "` + mode + `" "gemini" "$(pwd)"`
+		assert.Contains(t, text, want, "mode %q must include its own delivery.sh invocation", mode)
+	}
+}
+
+func TestBuildBootstrapInstruction_ContainsVerifiedScriptInvocations(t *testing.T) {
+	text := buildBootstrapInstruction("/opt/agmsg", "panemux", "pane-a", "codex", "both")
+
+	assert.Contains(t, text, `/opt/agmsg/scripts/join.sh "panemux" "pane-a" "codex" "$(pwd)" --force`)
+	assert.Contains(t, text, `/opt/agmsg/scripts/send.sh "panemux" "pane-a" "<to>" "<body>" --force`)
+	assert.Contains(t, text, `/opt/agmsg/scripts/delivery.sh set "both" "codex" "$(pwd)"`)
+	assert.Contains(t, text, "AGMSG-DIRECTIVE")
+	// The intro sentence explains why slash-command shorthand is avoided, so
+	// it legitimately names both prefixes once; no *line* other than that
+	// intro sentence may actually invoke either shorthand form.
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "slash-command") {
+			continue
+		}
+		assert.False(t, strings.HasPrefix(trimmed, "/agmsg "),
+			"line invokes claude-code-only slash-command shorthand: %q", trimmed)
+		assert.False(t, strings.HasPrefix(trimmed, "$agmsg "),
+			"line invokes codex/gemini-style slash-command shorthand: %q", trimmed)
+	}
+}

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -27,13 +27,19 @@ type fakeAgentSession struct {
 	boardOutputs map[string][]byte
 	id           string
 	detectType   string
+	sessionType  session.Type
 	writes       [][]byte
 	detectOK     bool
 	writeShort   bool
 }
 
-func (f *fakeAgentSession) ID() string                     { return f.id }
-func (f *fakeAgentSession) Type() session.Type             { return session.TypeLocal }
+func (f *fakeAgentSession) ID() string { return f.id }
+func (f *fakeAgentSession) Type() session.Type {
+	if f.sessionType == "" {
+		return session.TypeLocal
+	}
+	return f.sessionType
+}
 func (f *fakeAgentSession) Title() string                  { return f.id }
 func (f *fakeAgentSession) State() session.State           { return session.StateConnected }
 func (f *fakeAgentSession) Read(p []byte) (int, error)     { return 0, nil }
@@ -225,7 +231,13 @@ func TestBootstrapWatcher_RemotePresenceCheckTransportError_DistinctFromNo(t *te
 	assert.True(t, w.presenceWarned["pane-a"])
 }
 
-func TestBootstrapWatcher_ShortWrite_NotMarkedBootstrapped(t *testing.T) {
+// TestBootstrapWatcher_ShortWrite_GivesUpImmediately_NeverRetries is the
+// regression test for the compounding-partial-write finding: once any bytes
+// have already been typed into the pane, retrying would type the full
+// instruction again on top of that half-written line rather than fixing
+// anything, so a short write must give up on the very first attempt, not
+// just avoid being marked bootstrapped.
+func TestBootstrapWatcher_ShortWrite_GivesUpImmediately_NeverRetries(t *testing.T) {
 	manager := session.NewManager()
 	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true, writeShort: true}
 	manager.Add(sess)
@@ -233,13 +245,22 @@ func TestBootstrapWatcher_ShortWrite_NotMarkedBootstrapped(t *testing.T) {
 	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
 	w.pollOnce(context.Background())
 	w.pollOnce(context.Background())
-
-	require.NotEmpty(t, sess.writes, "a short write attempt still counts as an attempt")
+	require.Len(t, sess.writes, 1, "a short write attempt still counts as one attempt")
 	_, bootstrapped := w.bootstrapped["pane-a"]
 	assert.False(t, bootstrapped, "a short write must not be treated as a successful bootstrap")
+
+	// Further ticks (even with the debounce satisfied again) must not
+	// attempt another write at all — givenUp must block it immediately.
+	for i := 0; i < 4; i++ {
+		w.pollOnce(context.Background())
+	}
+	assert.Len(t, sess.writes, 1, "a short write must never be retried, since it would compound a half-typed line")
 }
 
-func TestBootstrapWatcher_WriteError_NotMarkedBootstrapped(t *testing.T) {
+// TestBootstrapWatcher_WriteError_RetriedUpToLimitThenGivesUp covers a clean
+// (n==0) write failure, which is safe to retry a bounded number of times
+// since nothing has actually been typed into the pane yet.
+func TestBootstrapWatcher_WriteError_RetriedUpToLimitThenGivesUp(t *testing.T) {
 	manager := session.NewManager()
 	sess := &fakeAgentSession{
 		id: "pane-a", detectType: "claude-code", detectOK: true,
@@ -248,9 +269,12 @@ func TestBootstrapWatcher_WriteError_NotMarkedBootstrapped(t *testing.T) {
 	manager.Add(sess)
 
 	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
-	w.pollOnce(context.Background())
-	w.pollOnce(context.Background())
+	for i := 0; i < 2+maxBootstrapWriteAttempts+2; i++ {
+		w.pollOnce(context.Background())
+	}
 
+	assert.Len(t, sess.writes, maxBootstrapWriteAttempts,
+		"must retry a clean write failure up to the cap, then stop attempting entirely")
 	_, bootstrapped := w.bootstrapped["pane-a"]
 	assert.False(t, bootstrapped)
 }
@@ -261,22 +285,101 @@ func TestBootstrapWatcher_NoAgentTypeDetectorCapability_NoOp(t *testing.T) {
 	manager.Add(sess)
 
 	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
-	assert.NotPanics(t, func() {
-		w.pollOnce(context.Background())
-		w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	assert.Empty(t, w.bootstrapped)
+	assert.Empty(t, w.pending)
+}
+
+// TestBootstrapWatcher_InvalidPaneIDOrTeam_SkipsBootstrap is the regression
+// test for embedding an unvalidated identifier into the onboarding
+// instruction's shell command lines: a pane ID or team outside agmsg's own
+// identifier alphabet (board.ValidAgmsgIdentifier) can never be addressed
+// correctly by the relay even if the write succeeded, so bootstrap must
+// refuse rather than write a broken instruction.
+func TestBootstrapWatcher_InvalidPaneIDOrTeam_SkipsBootstrap(t *testing.T) {
+	t.Run("invalid pane ID", func(t *testing.T) {
+		manager := session.NewManager()
+		sess := &fakeAgentSession{id: "pane a", detectType: "claude-code", detectOK: true}
+		manager.Add(sess)
+
+		w := newBootstrapWatcher(bootstrapWatcherConfig{
+			Manager:       manager,
+			PaneHosts:     map[string]string{"pane a": boardHostIDLocal},
+			ResolvedPaths: map[string]string{boardHostIDLocal: localAgmsgDir(t, true)},
+			Team:          "panemux",
+		})
+		for i := 0; i < 3; i++ {
+			w.pollOnce(context.Background())
+		}
+		assert.Empty(t, sess.writes)
+	})
+
+	t.Run("invalid team", func(t *testing.T) {
+		manager := session.NewManager()
+		sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+		manager.Add(sess)
+
+		w := newLocalWatcher(manager, localAgmsgDir(t, true), "team; rm -rf", nil)
+		for i := 0; i < 3; i++ {
+			w.pollOnce(context.Background())
+		}
+		assert.Empty(t, sess.writes)
 	})
 }
 
-// TestBootstrapWatcher_PersistedSeed_PreventsReBootstrapOfLiveSession is the
-// central regression test for the seeding design: a pane ID persisted from a
-// previous panemux run, whose session is still alive and still shows an
-// active known agent, must not be re-bootstrapped just because panemux
-// itself restarted. A *different* Session object for the same pane ID
-// (simulating that pane being restarted within the current process) must be
-// bootstrapped again.
-func TestBootstrapWatcher_PersistedSeed_PreventsReBootstrapOfLiveSession(t *testing.T) {
+// TestBootstrapWatcher_RemotePresenceCheck_FailsOverPastDeadFirstCandidate
+// is the regression test for trusting only the alphabetically-first
+// board-enabled pane on a host to answer the presence probe: that pane's
+// own session can be registered but dead (State() can lag reality), which
+// must not block bootstrap for the rest of the host when another pane on
+// it is genuinely reachable.
+func TestBootstrapWatcher_RemotePresenceCheck_FailsOverPastDeadFirstCandidate(t *testing.T) {
+	agmsgPath := "/opt/agmsg"
+	probeKey := strings.Join([]string{
+		"sh", "-c", "test -f \"$1\" && printf 'yes' || printf 'no'", "board-agmsg-presence",
+		agmsgPath + "/scripts/api.sh",
+	}, "\x00")
+
 	manager := session.NewManager()
-	original := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	// "pane-a" sorts first, so dynamicBoardExecutor tries it first; it must
+	// fail over to "pane-b" rather than reporting checked=false forever.
+	dead := &fakeAgentSession{
+		id: "pane-a", detectType: "codex", detectOK: true,
+		boardErr: errors.New("ssh: connection lost"),
+	}
+	alive := &fakeAgentSession{id: "pane-b", boardOutputs: map[string][]byte{probeKey: []byte("yes")}}
+	manager.Add(dead)
+	manager.Add(alive)
+
+	w := newBootstrapWatcher(bootstrapWatcherConfig{
+		Manager:       manager,
+		PaneHosts:     map[string]string{"pane-a": "ssh:build-host", "pane-b": "ssh:build-host"},
+		ResolvedPaths: map[string]string{"ssh:build-host": agmsgPath},
+		Team:          "panemux",
+	})
+	w.pollOnce(context.Background())
+	w.pollOnce(context.Background())
+
+	require.Len(t, dead.writes, 1,
+		"pane-a must still bootstrap via pane-b's working session, despite pane-a's own RunBoardCommand failing")
+}
+
+// TestBootstrapWatcher_PersistedSeed_TmuxPane_PreventsReBootstrapOfLiveSession
+// is the central regression test for the seeding design as it applies to a
+// tmux-backed pane: a persisted pane ID whose session is still alive and
+// still shows an active known agent must not be re-bootstrapped just
+// because panemux itself restarted — this is the case seeding is meant for,
+// since a tmux session (unlike a local/SSH one) reattaches to the same
+// still-running shell across a panemux restart. A *different* Session
+// object for the same pane ID (simulating that pane being restarted within
+// the current process) must be bootstrapped again.
+func TestBootstrapWatcher_PersistedSeed_TmuxPane_PreventsReBootstrapOfLiveSession(t *testing.T) {
+	manager := session.NewManager()
+	original := &fakeAgentSession{
+		id: "pane-a", detectType: "claude-code", detectOK: true, sessionType: session.TypeTmux,
+	}
 	manager.Add(original)
 
 	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
@@ -292,13 +395,37 @@ func TestBootstrapWatcher_PersistedSeed_PreventsReBootstrapOfLiveSession(t *test
 	// Now simulate the pane being restarted within this same process: a new
 	// Session object takes its place under the same pane ID.
 	require.NoError(t, manager.Remove("pane-a"))
-	replacement := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true}
+	replacement := &fakeAgentSession{
+		id: "pane-a", detectType: "claude-code", detectOK: true, sessionType: session.TypeTmux,
+	}
 	manager.Add(replacement)
 
 	w.pollOnce(context.Background())
 	assert.Empty(t, replacement.writes, "first tick after restart must still debounce")
 	w.pollOnce(context.Background())
 	assert.Len(t, replacement.writes, 1, "the replacement session must be bootstrapped like any new one")
+}
+
+// TestBootstrapWatcher_PersistedSeed_LocalPane_StillBootstraps is the
+// regression test for the bug the tmux-only seeding restriction fixes: a
+// local (or SSH) pane's underlying process cannot survive a panemux
+// restart — CreateFromConfig always spawns a brand-new, empty shell — so a
+// pane ID persisted from a previous run must NOT be treated as
+// already-onboarded here, or that pane would never be bootstrapped again on
+// any future run even though the fresh shell has never received the
+// instruction.
+func TestBootstrapWatcher_PersistedSeed_LocalPane_StillBootstraps(t *testing.T) {
+	manager := session.NewManager()
+	sess := &fakeAgentSession{id: "pane-a", detectType: "claude-code", detectOK: true} // sessionType zero value -> local
+	manager.Add(sess)
+
+	w := newLocalWatcher(manager, localAgmsgDir(t, true), "panemux", nil)
+	w.LoadPersistedState([]string{"pane-a"}) // as if this pane was bootstrapped before the restart
+
+	w.pollOnce(context.Background())
+	assert.Empty(t, sess.writes, "first tick must still debounce")
+	w.pollOnce(context.Background())
+	assert.Len(t, sess.writes, 1, "a local pane's fresh shell must be bootstrapped despite being in persisted state")
 }
 
 func TestBootstrapWatcher_PersistSuccessfulBootstrap(t *testing.T) {

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -815,9 +815,10 @@ Implemented in `bootstrap.go` (`package main`) as `bootstrapWatcher`, constructe
 5s — the same interval as the relay), gated the same way the relay is: `HasWork()` (at least one
 board-enabled pane) must be true before the goroutine even starts.
 
-1. A pane config (or the global default) sets `agent_board.enabled: true`, optionally overriding
-   `mode`. (Per-pane `team` override does not exist — every board-enabled pane on one panemux
-   instance joins the single `agent_board.team`.)
+1. A pane config sets `agent_board.enabled: true`, optionally overriding `mode`. (There is no
+   top-level default for `enabled` — `AgentBoardConfig` only carries `team`/`agmsg_path`, shared by
+   every board-enabled pane; each pane opts in individually. Per-pane `team` override does not exist
+   either — every board-enabled pane on one panemux instance joins the single `agent_board.team`.)
 2. Every poll tick, for every board-enabled pane, `bootstrapWatcher.checkPane` calls that pane's
    `session.AgentTypeDetector.DetectInteractiveAgentType()` — implemented by all four session types
    (`LocalSession`, `TmuxLocalSession`, `SSHSession`, `TmuxSSHSession`) — which walks the pane's
@@ -832,10 +833,17 @@ board-enabled pane) must be true before the goroutine even starts.
    pane whose live process doesn't match any of the six is simply never bootstrapped — its shell
    session is otherwise completely unaffected.
 3. **Debounce.** A pane is only eligible to bootstrap once the *same* `session.Session` object has
-   reported the same "known agent type detected" result on two consecutive poll ticks
-   (`bootstrapWatcher.pending`). This is a partial mitigation, not a complete one, against writing
-   into a pane the instant its shell is still settling right after the agent process starts — stated
-   as an honest tradeoff, not a claim of full safety; see [Known limitations](#known-limitations).
+   been seen with a known agent type detected on two consecutive poll ticks (`bootstrapWatcher.pending`,
+   compared by session identity only — the detected type itself is not compared tick-to-tick, so a
+   pane whose agent type genuinely changes between two ticks still debounces on session identity
+   alone and simply uses whichever type the second tick reported). This is a partial mitigation, not
+   a complete one, against writing into a pane the instant its shell is still settling right after
+   the agent process starts — stated as an honest tradeoff, not a claim of full safety; see [Known
+   limitations](#known-limitations). Pane IDs and the configured team are also checked against
+   `board.ValidAgmsgIdentifier` (the same identifier alphabet `RemoteAgmsgClient` already enforces —
+   see [Integration with agmsg](#integration-with-agmsg)) before anything else: a pane ID or team
+   outside that alphabet is skipped with one warning, since it could never be joined or addressed
+   correctly even if the PTY write itself succeeded.
 4. Once debounced, `bootstrapWatcher.agmsgPresent` runs the agmsg detection check from [Integration
    with agmsg](#integration-with-agmsg) (`board.LocalAgmsgPresent`/`board.RemoteAgmsgPresent`,
    `internal/board/agmsg_presence.go`) against a startup-time snapshot of each host's resolved
@@ -843,10 +851,19 @@ board-enabled pane) must be true before the goroutine even starts.
    helper `newAgmsgClientForHost` uses for the relay's own client map — resolved independently for
    bootstrap, not shared, so that coupling bootstrap eligibility to relay client construction can't
    reintroduce the kind of permanent-failure regression `dynamicBoardExecutor` exists to avoid; see
-   [Known limitations](#known-limitations) for the accepted cost of that duplication). If agmsg is
-   not found on that host, or presence can't be determined at all (an unreachable host, a transport
-   error), panemux logs one warning naming the pane and retries on every subsequent tick — no PTY
-   write happens, and the pane's shell session is otherwise unaffected.
+   [Known limitations](#known-limitations) for the accepted cost of that duplication). For a remote
+   host, the probe itself goes through a `dynamicBoardExecutor` (the same fail-over-across-candidates
+   wrapper the relay's own client construction uses), not a single fixed candidate session — a
+   board-enabled pane's session can still be registered (and report a normal `State()`) after its
+   underlying SSH connection has actually died, so trusting only one candidate could otherwise treat
+   a perfectly reachable host as permanently unreachable for bootstrap purposes. The probe itself is
+   bounded by a bootstrap-specific timeout shorter than the relay's own startup-probe timeout, since
+   `pollOnce` checks every board-enabled pane sequentially within one poll interval and an
+   unreachable host's probe must not be allowed to stall every other pane queued behind it in the
+   same tick. If agmsg is not found on that host, or presence can't be determined at all (an
+   unreachable host, a transport error), panemux logs one warning naming the pane and retries on
+   every subsequent tick — no PTY write happens, and the pane's shell session is otherwise
+   unaffected.
 5. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
    used for all terminal input; `buildBootstrapInstruction` in `bootstrap.go`) telling the agent to:
    1. Join agmsg's team by running `join.sh <team> <pane-id> <agmsg-type> "$(pwd)" --force` directly
@@ -895,16 +912,29 @@ board-enabled pane) must be true before the goroutine even starts.
    working exactly as it did before panemux was involved). A write is only treated as successful if
    `Session.Write` returns the full payload length with no error — this is the first place in this
    codebase where panemux writes synthesized input into a pane's PTY rather than relaying real user
-   keystrokes, so a short write is treated the same as a failed one (retried next tick) rather than
-   silently accepted.
+   keystrokes, so a short or failed write is never silently accepted as success. The two failure
+   shapes are handled differently, deliberately: a **short** write (`n > 0`) has already put part of
+   the instruction into the pane, so retrying would type the full instruction again on top of that
+   half-written line, compounding the corruption rather than fixing it — panemux gives up on that
+   pane immediately, with one warning, rather than retry. A **clean** failure (`n == 0`, nothing
+   written yet) is safe to retry, so panemux retries up to `maxBootstrapWriteAttempts` (3) times
+   before giving up the same way. Either way, "given up" is tracked the same way `bootstrapped` is —
+   keyed by pane ID and compared by `session.Session` identity — so a pane that is later restarted
+   (a new `Session` object) is eligible again.
 6. On a successful write, the pane is marked bootstrapped (`bootstrapWatcher.bootstrapped`, keyed by
    pane ID and compared by `session.Session` identity, not by process) and the full set of
    bootstrapped pane IDs is persisted to `~/.config/panemux/board-bootstrap-state.json`
    (`internal/board/bootstrap_store.go`, same atomic-write/`0600` discipline as the relay's cursor
    file). On the very first poll tick after a panemux restart, this persisted set is used once to
-   seed `bootstrapped` with each persisted pane ID's *currently live* session — purely so that an
-   already-onboarded, still-running agent is never re-bootstrapped just because panemux itself
-   restarted — and is never consulted again after that; from then on only session-object identity
+   seed `bootstrapped` with each persisted pane ID's *currently live* session — but **only** for a
+   `TypeTmux`/`TypeSSHTmux` pane, whose underlying tmux session (and whatever process is running
+   inside it) is independent of panemux and can genuinely still be running after a panemux restart. A
+   `TypeLocal`/`TypeSSH` pane's session is recreated from scratch on every panemux startup
+   (`session.CreateFromConfig` always spawns a brand-new shell for these two types, with nothing
+   running in it yet) — seeding one of those from persisted state would wrongly treat "we
+   bootstrapped a previous, now-gone process" as "the current, fresh shell is already onboarded",
+   permanently blocking that pane from ever being bootstrapped again on any future run. Seeding is
+   never consulted again after this first tick either way; from then on only session-object identity
    governs re-bootstrap decisions. See [Known limitations](#known-limitations) for what this
    session-identity granularity does and does not catch.
 
@@ -1316,6 +1346,32 @@ that shaped the design.
   agent process starts in that pane. See [Bootstrap flow](#bootstrap-flow)'s consent-model paragraph
   for why this tradeoff is accepted rather than solved with typing-detection or input-pausing
   machinery.
+- **The onboarding instruction's line-feed-vs-carriage-return input encoding has not been verified
+  against a live instance of all six detectable agent types.** `buildBootstrapInstruction` writes the
+  instruction as multiple `\n`-separated lines with a single trailing `\r` (matching this codebase's
+  existing convention that only `\r` submits input to a pane, per `frontend/src/hooks/useTerminal.ts`'s
+  own `term.onData` handling), on the assumption that each agent's own interactive input handling
+  treats an embedded `\n` as a literal newline rather than as its own submit/Enter event. This has not
+  been confirmed against a real running instance of any of the six types. If that assumption is wrong
+  for a given type, the instruction would arrive fragmented into several separate prompts instead of
+  one coherent message, rather than failing loudly — an operator would see a confused agent, not an
+  error. Stated here as an explicit, unverified risk rather than fixed with an unverified
+  countermeasure (e.g. bracketed-paste wrapping), since neither this document's authors nor its tests
+  have a way to confirm such a countermeasure actually helps without live testing against all six
+  types.
+- **`agmsgDetectableAgentTypes`'s `excludeTokens` matching (`internal/session/local.go`) can produce
+  a false negative for a positional prompt argument that happens to contain an exclude token as its
+  own whitespace-separated word** — e.g. `codex "fix the exec path"` tokenizes to include a
+  standalone `exec` token the same way `codex exec ...` (the real headless-mode invocation this
+  exclusion exists to detect) does, so the interactive invocation would incorrectly be treated as
+  headless and never bootstrapped. This is a pre-existing shape inherited from the pattern
+  `isInteractiveAgentCommand` (the separate, untouched worktree-detection feature; see
+  [architecture.md](architecture.md)) already uses for its own claude/codex exclusions, not something
+  bootstrap introduced — but bootstrap makes it newly load-bearing for five additional agent types.
+  Fixing this correctly needs argv-boundary-aware tokenization (distinguishing "a word inside one
+  quoted argument" from "a separate argument"), which the current process-listing capture does not
+  provide; that is a larger, riskier change than this document's other bootstrap tradeoffs and is
+  left as a known gap rather than attempted here.
 - Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
   called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
   following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -1,26 +1,32 @@
 # Agent Board: Cross-Pane Claude Messaging and Status Aggregation
 
-> **Status: relay and REST status/messages/broadcast implemented; bootstrap and command center not
-> yet usable.** The `internal/board` package's core types (`Row`, `Status`, `AgmsgClient`,
-> `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`, `RemoteAgmsgClient`), the `BoardHostID`/
-> `BoardExecutor` session capability interfaces, the `agent_board`/`command_center`/
-> `server.auth_token` config surface, the relay goroutine (`internal/board/relay.go`, cursor
-> persistence in `internal/board/cursor_store.go`), and the three REST endpoints in [API
-> additions](#api-additions) — `GET /api/board/status`, `GET /api/board/messages`, `POST
-> /api/board/broadcast` — are implemented and tested. `bearerAuthMiddleware` is wired, but **only**
-> onto the new `/api/board/*` sub-route, not onto any pre-existing `/api/*` route or
-> `/ws/{sessionID}` — see [Security model](#security-model) and
+> **Status: relay, REST status/messages/broadcast, and the PTY bootstrap flow are implemented;
+> command center is not yet usable.** The `internal/board` package's core types (`Row`, `Status`,
+> `AgmsgClient`, `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`, `RemoteAgmsgClient`), the
+> `BoardHostID`/`BoardExecutor`/`AgentTypeDetector` session capability interfaces, the
+> `agent_board`/`command_center`/`server.auth_token` config surface, the relay goroutine
+> (`internal/board/relay.go`, cursor persistence in `internal/board/cursor_store.go`), and the three
+> REST endpoints in [API additions](#api-additions) — `GET /api/board/status`, `GET
+> /api/board/messages`, `POST /api/board/broadcast` — are implemented and tested.
+> `bearerAuthMiddleware` is wired, but **only** onto the new `/api/board/*` sub-route, not onto any
+> pre-existing `/api/*` route or `/ws/{sessionID}` — see [Security model](#security-model) and
 > [security.md](security.md#auth-token-and-transport-encryption) for why those stay unauthenticated
-> for now. `setupBoard` in `board.go` (`package main`) builds the `AgmsgClient`s and pane→host map
-> from config at startup and wires the relay goroutine into `main.go`'s lifecycle. A remote host's
+> for now (tracked as a separate follow-up issue, not part of this phase). `setupBoard` in `board.go`
+> (`package main`) builds the `AgmsgClient`s and pane→host map from config at startup and wires both
+> the relay goroutine and the bootstrap watcher into `main.go`'s lifecycle. A remote host's
 > `RemoteAgmsgClient` is handed a `dynamicBoardExecutor` (`board.go`), which re-resolves a live
 > `BoardExecutor` session on that host on every call rather than holding the one pane's session found
 > at startup — an ordinary pane restart/delete of whichever pane was picked first must not
-> permanently break board traffic for the rest of that host. Still design-only:
-> the PTY bootstrap flow (process detection, the one-time onboarding instruction), `/ws/board-command`,
-> `GET /api/board/command/history`, and the command center itself — none of that exists yet, so this
-> document's bootstrap/command-center sections below are not reachable through any current config or
-> endpoint. Update this note (and its cross-links) again once a later phase closes that gap.
+> permanently break board traffic for the rest of that host. The bootstrap watcher
+> (`bootstrapWatcher` in `bootstrap.go`, `package main`) polls every board-enabled pane for a newly
+> started, agmsg-detectable agent process (`session.AgentTypeDetector`, covering the six agmsg agent
+> types agmsg's own `type.conf` marks as process-detectable — see [`internal/session` capability
+> interfaces](#internal-session-capability-interfaces)) and writes a one-time onboarding instruction
+> into that pane's PTY; see [Bootstrap flow](#bootstrap-flow) for the full algorithm. Still
+> design-only: `/ws/board-command`, `GET /api/board/command/history`, and the command center itself —
+> none of that exists yet, so this document's [Command center](#command-center) section below is not
+> reachable through any current config or endpoint. Update this note (and its cross-links) again once
+> a later phase closes that gap.
 
 ## Purpose
 
@@ -340,16 +346,23 @@ check uniformly instead of trying to satisfy it. A pane can still use unforced `
 its *own*, non-board conversations with other agmsg-native agents already on that host (Codex,
 Gemini CLI, etc.) — that path is untouched and still roster-checked normally.
 
-**Panes join with `join.sh <team> <agent_id> <agent_type> <project_path> [--force]`**, typically
-via agmsg's own onboarding (the `/agmsg` skill flow a live Claude session runs itself, or the
-equivalent for another agent type) rather than the raw script directly — see [Bootstrap
-flow](#bootstrap-flow). This registers the pane into `teams/<team>/config.json`. Because board
-sends always pass `--force`, this registration is no longer what gates board delivery — its
-purpose is solely to let other, non-board-aware agmsg agents on the same host (Codex, Gemini CLI,
-etc.) address the pane normally, and to give the pane a working `/agmsg` identity for its own
-non-board use. Once joined, agmsg's own `SessionStart`/`SessionEnd` hooks own that pane's `Monitor`
-(`watch.sh`)-process lifecycle end-to-end (launch, liveness, cleanup) — panemux has no part in it
-and does not need to.
+**Panes join with `join.sh <team> <agent_id> <agent_type> <project_path> [--force]`**, invoked
+directly by the agent as the first step of panemux's own bootstrap instruction (see [Bootstrap
+flow](#bootstrap-flow)) — not via agmsg's slash-command onboarding shorthand. This is a deliberate
+deviation from "run agmsg's normal first-run flow": that shorthand's own invocation prefix is not
+uniform across agmsg's agent types — agmsg's per-type `type.conf` driver files set `cmd_prefix` to
+`/agmsg` for some types (`claude-code`, `cursor`, `grok-build`, `copilot`) and to `$agmsg` for
+others (`codex`, `gemini`, `antigravity`, `opencode`) — so a bootstrap instruction that hardcoded
+either prefix would silently be wrong for roughly half of agmsg's supported agent types. Calling
+`join.sh` with its own verified positional-argument signature sidesteps that divergence entirely,
+at the cost of bypassing whatever additional first-run behavior agmsg's slash-command flow might
+otherwise perform beyond the join itself. This registers the pane into `teams/<team>/config.json`.
+Because board sends always pass `--force`, this registration is no longer what gates board
+delivery — its purpose is solely to let other, non-board-aware agmsg agents on the same host
+(Codex, Gemini CLI, etc.) address the pane normally, and to give the pane a working `/agmsg`/`$agmsg`
+identity for its own non-board use. Once joined, agmsg's own `SessionStart`/`SessionEnd` hooks own
+that pane's `Monitor` (`watch.sh`)-process lifecycle end-to-end (launch, liveness, cleanup) —
+panemux has no part in it and does not need to.
 
 **panemux's own relay and command center are never agmsg roster members, and never go through
 agmsg's own identity-detection layer, so any send they originate uses `--force` for the same reason
@@ -636,6 +649,24 @@ Because panemux owns no schema, it needs no embedded database driver of its own 
 board operation is either a local `exec.Command` or a remote exec-channel command running agmsg's
 own scripts.
 
+`internal/board/agmsg_presence.go` implements the "is agmsg actually installed here" check bootstrap
+depends on: `LocalAgmsgPresent(agmsgPath string) bool` (`os.Stat` on `scripts/api.sh`) and
+`RemoteAgmsgPresent(ctx, executor BoardExecutor, agmsgPath string) (bool, error)`, the latter running
+a fixed, non-tainted `sh -c` probe script over the same `RunBoardCommand` channel `ResolveRemoteAgmsgPath`
+already uses (see [security.md](security.md) for why this probe is safe despite carrying no
+regex-allowlist branch of its own — it takes no caller-supplied data at all). `internal/board/atomic_write.go`
+factors the temp-file-plus-rename write discipline shared by `cursor_store.go` and
+`internal/board/bootstrap_store.go`'s `SaveBootstrapState`/`LoadBootstrapState`
+(`~/.config/panemux/board-bootstrap-state.json`, `0600`) into one helper, since both files need the
+identical atomicity guarantee for an unrelated piece of persisted state.
+
+`bootstrap.go` (`package main`, not `internal/board` — it depends on `internal/session.Manager` the
+same way `board.go` already does) implements `bootstrapWatcher`, the poller described in [Bootstrap
+flow](#bootstrap-flow). It deliberately takes no dependency on `internal/config` at all: like
+`board.RelayConfig`, its `bootstrapWatcherConfig` is a precomputed, static struct (`PaneHosts`,
+`PaneModes`, `ResolvedPaths`, `Team`, `Persist`) that `board.go`'s `setupBoard` builds from config,
+mirroring the same dependency direction `internal/board` itself already uses.
+
 ### `internal/session` capability interfaces
 
 Following the existing optional-capability pattern (`CWDGetter`, `ActiveWorkdirGetter`,
@@ -661,10 +692,25 @@ type BoardHostID interface {
 type BoardExecutor interface {
     RunBoardCommand(ctx context.Context, args []string) ([]byte, error)
 }
+
+// AgentTypeDetector is implemented by every session type. It reports the agmsg-recognized type
+// name (e.g. "claude-code", "codex", "gemini") of any live, interactive coding-agent process
+// currently running as a descendant of this pane's shell, among the set agmsg's own type.conf
+// detect_proc key considers reliably process-detectable. This is narrower than the pre-existing
+// ActiveWorkdirGetter (which only distinguishes Codex/Claude, and additionally resolves
+// transcript-derived workdirs at real I/O cost) and returns WHICH type rather than a bare bool,
+// since bootstrap writes a different onboarding instruction per agent type.
+type AgentTypeDetector interface {
+    DetectInteractiveAgentType() (agmsgType string, ok bool, err error)
+}
 ```
 
-`LocalSession`/`TmuxLocalSession` implement only `BoardHostID` (`"local"`). `SSHSession`/
-`SSHTmuxSession` implement both.
+`LocalSession`/`TmuxLocalSession` implement `BoardHostID` (`"local"`) and `AgentTypeDetector`.
+`SSHSession`/`SSHTmuxSession` implement `BoardHostID`, `BoardExecutor`, and `AgentTypeDetector`.
+`AgentTypeDetector` is a separate, purpose-built primitive for bootstrap — it does not reuse or
+modify the pre-existing `ActiveWorkdirGetter`/`isInteractiveAgentCommand` code path the Claude
+worktree override (see [architecture.md](architecture.md)) depends on, though both share the same
+generic process-tree-walk helper underneath.
 
 ## Local vs remote resource placement
 
@@ -764,49 +810,110 @@ always routed through it by construction.
 
 ## Bootstrap flow
 
+Implemented in `bootstrap.go` (`package main`) as `bootstrapWatcher`, constructed in `board.go`'s
+`setupBoard` and polled on its own goroutine from `main.go`'s lifecycle (`defaultBootstrapPollInterval`,
+5s — the same interval as the relay), gated the same way the relay is: `HasWork()` (at least one
+board-enabled pane) must be true before the goroutine even starts.
+
 1. A pane config (or the global default) sets `agent_board.enabled: true`, optionally overriding
-   `team` or `mode`.
-2. panemux's existing interactive-agent process detection (already used for the Claude worktree
-   override in [architecture.md](architecture.md)) notices a `claude` (or other configured agent)
-   process start in that pane, then runs the agmsg detection check from [Integration with
-   agmsg](#integration-with-agmsg). If agmsg is not found on that host, it logs a warning naming the
-   pane and stops here — no PTY write happens, and the pane's shell session is otherwise unaffected.
-3. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
-   used for all terminal input) telling the agent to: join agmsg's team **using the pane's own ID
-   (the same `<pane-id>` panemux's config and every other part of this document address it by) as
-   the agmsg `agent_id`** — required, and stated explicitly, because agmsg's own onboarding can
-   otherwise prompt for an arbitrary name of the agent's choosing, which would silently break every
-   cross-pane and relay address in this design (they all assume `from`/`to` *are* pane IDs) — via
-   agmsg's own onboarding flow (e.g. `/agmsg` or the equivalent first-run prompt), rely on agmsg's
-   own `Monitor`/hook wiring for delivery exactly as it would if the user had set this up by hand,
-   include the [status self-report](#status-self-report-and-message-flow) fields on every status
-   update, and — this is the one deviation from "just do what agmsg's normal flow does" — send
-   every board-related message (status reports, cross-pane messages) with the raw `send.sh <team>
-   <from> <to> "<body>" --force` invocation rather than `/agmsg send`, per [Integration with
-   agmsg](#integration-with-agmsg). Joining and non-board `/agmsg` use are unaffected by local vs.
-   remote — it is agmsg's own already-installed skill doing the work either way, not something
-   panemux provisions per pane. This step only ever establishes *that pane's* participation; it
-   never touches any other pane or any other agent already using agmsg on that host (a pre-existing
-   Codex agent, for example, keeps working exactly as it did before panemux was involved).
-4. If `mode` is `turn` or `both` (mirroring agmsg's own `/agmsg mode monitor|turn|both|off`, default
-   `monitor`), the bootstrap instruction also tells the agent to run `/agmsg mode <value>` — this
-   is agmsg's own setting, not something panemux tracks or enforces separately. agmsg's own docs
-   mark `turn` as a legacy mode kept for backward compatibility rather than the recommended one;
-   this document does not steer operators toward it, and `mode: turn` in panemux's config is a
-   pass-through of an operator's explicit choice, not a default panemux picks. `off` is agmsg's own
-   way to disable its hook-driven delivery for a pane without leaving the team — panemux's config
-   equivalent is `agent_board.enabled: false`, which is the preferred way to keep a pane out of
-   board features entirely, since it skips bootstrap for that pane rather than bootstrapping it and
-   then telling it to turn itself back off. **This step has a real repo-local side effect worth
-   stating plainly: `/agmsg mode` writes hook wiring into the pane's own project
-   `.claude/settings.local.json`, a file that outlives the pane session and is scoped to that Git
-   repository, not to panemux or to this one pane.** "Additive, never load-bearing" (see [Design
-   principles](#design-principles)) describes what happens when board features are *unavailable* —
-   the pane's shell keeps working normally — not a claim that bootstrap makes zero changes outside
-   panemux's own state. Because this write is agmsg's own onboarding behavior, not something panemux
-   scripts itself, panemux does not attempt to undo it if a pane later disables
-   `agent_board.enabled`; an operator who wants that hook wiring removed does so the same way they
-   would for any other agmsg-managed repo, outside panemux entirely.
+   `mode`. (Per-pane `team` override does not exist — every board-enabled pane on one panemux
+   instance joins the single `agent_board.team`.)
+2. Every poll tick, for every board-enabled pane, `bootstrapWatcher.checkPane` calls that pane's
+   `session.AgentTypeDetector.DetectInteractiveAgentType()` — implemented by all four session types
+   (`LocalSession`, `TmuxLocalSession`, `SSHSession`, `TmuxSSHSession`) — which walks the pane's
+   process tree for a live descendant matching one of the six agmsg agent types agmsg's own
+   `type.conf` driver files mark `detect_proc` (process-name-based auto-detection) for:
+   `claude-code`, `codex`, `cursor`, `gemini`, `grok-build`, `opencode`. The other three CLI types
+   agmsg supports (`antigravity`, `copilot`, `hermes`) declare `detect=explicit` in their own
+   `type.conf` — agmsg's own maintainers judged process detection unreliable for them — and the
+   tenth, `agmsg-app`, is a desktop app, not a spawnable CLI at all (`spawnable=no`). Bootstrap
+   inherits this exact boundary rather than picking its own: a type agmsg itself doesn't trust
+   process detection for is not a type panemux invents its own detection heuristic for either. A
+   pane whose live process doesn't match any of the six is simply never bootstrapped — its shell
+   session is otherwise completely unaffected.
+3. **Debounce.** A pane is only eligible to bootstrap once the *same* `session.Session` object has
+   reported the same "known agent type detected" result on two consecutive poll ticks
+   (`bootstrapWatcher.pending`). This is a partial mitigation, not a complete one, against writing
+   into a pane the instant its shell is still settling right after the agent process starts — stated
+   as an honest tradeoff, not a claim of full safety; see [Known limitations](#known-limitations).
+4. Once debounced, `bootstrapWatcher.agmsgPresent` runs the agmsg detection check from [Integration
+   with agmsg](#integration-with-agmsg) (`board.LocalAgmsgPresent`/`board.RemoteAgmsgPresent`,
+   `internal/board/agmsg_presence.go`) against a startup-time snapshot of each host's resolved
+   `agmsg_path` (`resolveBootstrapPaths` in `board.go`, using the same `resolveAgmsgPathForHost`
+   helper `newAgmsgClientForHost` uses for the relay's own client map — resolved independently for
+   bootstrap, not shared, so that coupling bootstrap eligibility to relay client construction can't
+   reintroduce the kind of permanent-failure regression `dynamicBoardExecutor` exists to avoid; see
+   [Known limitations](#known-limitations) for the accepted cost of that duplication). If agmsg is
+   not found on that host, or presence can't be determined at all (an unreachable host, a transport
+   error), panemux logs one warning naming the pane and retries on every subsequent tick — no PTY
+   write happens, and the pane's shell session is otherwise unaffected.
+5. panemux writes a one-time instruction into the pane's PTY (the same `Session.Write` path already
+   used for all terminal input; `buildBootstrapInstruction` in `bootstrap.go`) telling the agent to:
+   1. Join agmsg's team by running `join.sh <team> <pane-id> <agmsg-type> "$(pwd)" --force` directly
+      — **using the pane's own ID (the same `<pane-id>` panemux's config and every other part of
+      this document address it by) as the agmsg `agent_id`**, required and stated explicitly because
+      agmsg's own onboarding can otherwise prompt for an arbitrary name of the agent's choosing,
+      which would silently break every cross-pane and relay address in this design (they all assume
+      `from`/`to` *are* pane IDs). Invoking `join.sh` directly, rather than through agmsg's
+      slash-command onboarding shorthand, is itself deliberate — see [Integration with
+      agmsg](#integration-with-agmsg) for why hardcoding either of agmsg's two `cmd_prefix`
+      conventions (`/agmsg` vs. `$agmsg`) into one bootstrap instruction would be wrong for roughly
+      half of the six detectable agent types.
+   2. From then on, send every board-related message (status reports, cross-pane messages) with the
+      raw `send.sh <team> <from> <to> "<body>" --force` invocation rather than `/agmsg send`/`$agmsg
+      send`, per [Integration with agmsg](#integration-with-agmsg).
+   3. Include the [status self-report](#status-self-report-and-message-flow) fields on every status
+      update, sent to `_system` via that same `send.sh` invocation.
+   4. Only if `mode` is `turn` or `both` (mirroring agmsg's own `delivery.sh set
+      monitor|turn|both|off`, default `monitor`): also run `delivery.sh set <mode> <agmsg-type>
+      "$(pwd)"` directly (again bypassing the `cmd_prefix` divergence) and read/follow the
+      `AGMSG-DIRECTIVE:` block it prints — this is agmsg's own mechanism for telling an agent how to
+      reconfigure its own delivery behavior, not something panemux parses or acts on itself. agmsg's
+      own docs mark `turn` as a legacy mode kept for backward compatibility rather than the
+      recommended one; this document does not steer operators toward it, and `mode: turn` in
+      panemux's config is a pass-through of an operator's explicit choice, not a default panemux
+      picks. `off` is agmsg's own way to disable its hook-driven delivery for a pane without leaving
+      the team — panemux's config equivalent is `agent_board.enabled: false`, which is the preferred
+      way to keep a pane out of board features entirely, since it skips bootstrap for that pane
+      rather than bootstrapping it and then telling it to turn itself back off. **This step has a
+      real repo-local side effect worth stating plainly: agmsg's own `delivery.sh set` writes hook
+      wiring into the pane's own project config (e.g. `.claude/settings.local.json` for
+      `claude-code`; the exact file is agmsg's own per-type convention, not something panemux
+      controls), which outlives the pane session and is scoped to that Git repository, not to
+      panemux or to this one pane.** "Additive, never load-bearing" (see [Design
+      principles](#design-principles)) describes what happens when board features are *unavailable*
+      — the pane's shell keeps working normally — not a claim that bootstrap makes zero changes
+      outside panemux's own state. Because this write is agmsg's own behavior, not something panemux
+      scripts itself, panemux does not attempt to undo it if a pane later disables
+      `agent_board.enabled`; an operator who wants that hook wiring removed does so the same way
+      they would for any other agmsg-managed repo, outside panemux entirely.
+
+   Joining and non-board `/agmsg`/`$agmsg` use are unaffected by local vs. remote — it is agmsg's own
+   already-installed skill doing the work either way, not something panemux provisions per pane. This
+   step only ever establishes *that pane's* participation; it never touches any other pane or any
+   other agent already using agmsg on that host (a pre-existing Codex agent, for example, keeps
+   working exactly as it did before panemux was involved). A write is only treated as successful if
+   `Session.Write` returns the full payload length with no error — this is the first place in this
+   codebase where panemux writes synthesized input into a pane's PTY rather than relaying real user
+   keystrokes, so a short write is treated the same as a failed one (retried next tick) rather than
+   silently accepted.
+6. On a successful write, the pane is marked bootstrapped (`bootstrapWatcher.bootstrapped`, keyed by
+   pane ID and compared by `session.Session` identity, not by process) and the full set of
+   bootstrapped pane IDs is persisted to `~/.config/panemux/board-bootstrap-state.json`
+   (`internal/board/bootstrap_store.go`, same atomic-write/`0600` discipline as the relay's cursor
+   file). On the very first poll tick after a panemux restart, this persisted set is used once to
+   seed `bootstrapped` with each persisted pane ID's *currently live* session — purely so that an
+   already-onboarded, still-running agent is never re-bootstrapped just because panemux itself
+   restarted — and is never consulted again after that; from then on only session-object identity
+   governs re-bootstrap decisions. See [Known limitations](#known-limitations) for what this
+   session-identity granularity does and does not catch.
+
+**Consent model, stated explicitly.** Setting `agent_board.enabled: true` on a pane *is* the consent
+mechanism for this PTY write — it is not a new category of risk beyond what that config flag already
+implies enabling. The 2-tick debounce in step 3 narrows, but does not eliminate, the window in which
+an operator who happens to be typing their own input into a pane at the exact moment an agent process
+starts there could have panemux's instruction interleaved with it; this is a stated, accepted
+tradeoff (see [Known limitations](#known-limitations)), not a claim of a race-free design.
 
 ## Command center
 
@@ -1177,10 +1284,38 @@ that shaped the design.
   cross-agent interoperability agmsg provides that a panemux-owned protocol never could. See [agmsg
   compatibility contract](#agmsg-compatibility-contract) for how this exposure is meant to be
   caught mechanically rather than discovered by a user.
-- Bootstrap is not free of side effects outside panemux's own state: `/agmsg mode turn|both` (see
-  [Bootstrap flow](#bootstrap-flow)) writes hook wiring into the pane's project
-  `.claude/settings.local.json`, which persists in that Git repository after the pane closes and is
-  never reverted by panemux, including when a pane later disables `agent_board.enabled`.
+- Bootstrap is not free of side effects outside panemux's own state: `delivery.sh set turn|both` (see
+  [Bootstrap flow](#bootstrap-flow)) writes hook wiring into the pane's project config (agmsg's own
+  per-type convention — e.g. `.claude/settings.local.json` for `claude-code`), which persists in that
+  Git repository after the pane closes and is never reverted by panemux, including when a pane later
+  disables `agent_board.enabled`.
+- **Bootstrap tracks "already onboarded" at session-object granularity, not process granularity.**
+  panemux has no way to observe a coding-agent *process* restarting inside a pane whose underlying
+  `session.Session` never changed — there is no PID exposed anywhere in `internal/session`'s public
+  surface for bootstrap to key off of instead (see [`internal/session` capability
+  interfaces](#internal-session-capability-interfaces)). Concretely: once a pane has been
+  bootstrapped, if the agent process inside it exits and a new one starts in the same still-open
+  pane, that new process is not re-detected and does not get a fresh onboarding instruction — only
+  closing and reopening the pane (which creates a new `session.Session`) resets bootstrap eligibility
+  for it. This mirrors, and is accepted for the same reason as, the equivalent limitation already
+  documented above for the relay's `AgmsgClient` construction.
+- **A remote host with no reachable session when `setupBoard` runs never becomes bootstrap-eligible
+  for the rest of that process's lifetime, even if a board-enabled pane on it becomes reachable
+  later** — the same one-shot-at-startup limitation already documented above for
+  `newAgmsgClientForHost`'s `Clients` map applies identically to `resolveBootstrapPaths`'
+  `ResolvedPaths`, and for the same underlying reason: neither is retried on a schedule.
+- **Bootstrap's `resolveBootstrapPaths` and the relay's `newAgmsgClientForHost` each independently
+  probe every remote host's `agmsg_path` once at startup, rather than sharing one resolution.** This
+  is a deliberate choice, not an oversight: coupling bootstrap eligibility to relay client
+  construction (or vice versa) would let a failure in one subsystem silently disable the other, which
+  is exactly the kind of cross-subsystem coupling `dynamicBoardExecutor` was introduced to avoid at
+  the session level. The accepted cost is one extra `sh -c` round-trip per remote host at startup.
+- **The 2-tick bootstrap debounce is a partial mitigation, not a race-free design.** It narrows, but
+  does not eliminate, the window in which an operator's own keystrokes into a pane could interleave
+  with panemux's synthesized onboarding instruction if both happen at almost exactly the moment an
+  agent process starts in that pane. See [Bootstrap flow](#bootstrap-flow)'s consent-model paragraph
+  for why this tradeoff is accepted rather than solved with typing-detection or input-pausing
+  machinery.
 - Self-reported status depends on the agent's cooperation each time — see the honest tradeoff
   called out in [Status self-report](#status-self-report-and-message-flow). A pane that stops
   following its bootstrap instruction (e.g. a very long uninterrupted tool-use turn) simply stops

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ Optional capability interfaces extend the base `Session` contract without breaki
 - `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
 
-### `internal/board` (relay + REST status/messages/broadcast implemented; bootstrap and command center still planned)
+### `internal/board` (relay, REST status/messages/broadcast, and bootstrap implemented; command center still planned)
 
 A package that replaces transcript-based Claude activity inference with a self-reported channel:
 panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh` calls rather
@@ -80,10 +80,14 @@ The package's foundational pieces are implemented and tested: `Row`/`Status` and
 model](agent-board.md#security-model) describes), and the two `AgmsgClient` implementations —
 `LocalAgmsgClient` (plain `exec.Command`, no shell involved) and `RemoteAgmsgClient` (the SSH exec
 channel, with the base64-encode-then-allowlist body escaping and identifier allowlisting
-[security.md](security.md#agent-board-remote-writes) describes). Two new optional session capability
-interfaces, `BoardHostID` and `BoardExecutor`, extend the same pattern as
+[security.md](security.md#agent-board-remote-writes) describes). Three new optional session capability
+interfaces, `BoardHostID`, `BoardExecutor`, and `AgentTypeDetector`, extend the same pattern as
 `CWDGetter`/`ActiveWorkdirGetter` above and are implemented on all four session types
-(`BoardHostID`) and on `SSHSession`/`TmuxSSHSession` (`BoardExecutor`'s `RunBoardCommand`).
+(`BoardHostID`, `AgentTypeDetector`) and on `SSHSession`/`TmuxSSHSession` (`BoardExecutor`'s
+`RunBoardCommand`). `AgentTypeDetector.DetectInteractiveAgentType` is a separate, purpose-built
+primitive for bootstrap (below) — it shares only the generic process-tree-walk helper with the
+pre-existing `ActiveWorkdirGetter`/`isInteractiveAgentCommand` path this section already documents,
+not its Codex/Claude-only matching logic.
 
 Also implemented and tested: the relay goroutine (`internal/board/relay.go`'s `Relay`, run from
 `main.go` via `board.go`'s `setupBoard`) that polls every configured host's agmsg on a schedule,
@@ -98,9 +102,14 @@ That middleware is wired **only** onto the new `/api/board/*` sub-route; every p
 route and `/ws/{sessionID}` remain unauthenticated, since retrofitting auth onto routes the current
 frontend already relies on is a separate, larger change.
 
-Not yet implemented: the bootstrap flow that writes a one-time onboarding instruction into a pane's
-PTY, the `/ws/board-command` WS endpoint, `GET /api/board/command/history`, and the command center
-itself.
+Also implemented and tested: the bootstrap flow (`bootstrapWatcher` in `bootstrap.go`, `package
+main`) that polls board-enabled panes via `AgentTypeDetector` for a newly started, agmsg-detectable
+agent process and writes a one-time onboarding instruction into that pane's PTY (the same
+`Session.Write` path used for real terminal input) — see [agent-board.md's Bootstrap
+flow](agent-board.md#bootstrap-flow) for the full detection/debounce/persistence algorithm.
+
+Not yet implemented: the `/ws/board-command` WS endpoint, `GET /api/board/command/history`, and the
+command center itself.
 
 The same design also specifies a **command center**: a single headless `claude -p --resume`
 subprocess, invoked per query, that reads and writes the board exclusively through panemux's own

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -335,9 +335,18 @@ Full design and rationale live in [agent-board.md](agent-board.md); this section
 request/response shapes and status codes of what is actually implemented today. Unlike every route
 above, every endpoint in this section requires `Authorization: Bearer <server.auth_token>` — see
 [security.md](security.md#auth-token-and-transport-encryption). A missing or incorrect token returns
-`401` before the handler runs. The bootstrap flow, `/ws/board-command`, and `GET
-/api/board/command/history` are not implemented yet and are not documented here — see
-[agent-board.md](agent-board.md)'s status note.
+`401` before the handler runs. `/ws/board-command` and `GET /api/board/command/history` are not
+implemented yet and are not documented here — see [agent-board.md](agent-board.md)'s status note.
+
+**Bootstrap flow** (not a REST/WS endpoint — a background behavior). For every pane with
+`agent_board.enabled: true`, panemux polls every 5s for a live, agmsg-detectable coding-agent
+process (one of six agent types; see [agent-board.md's Bootstrap
+flow](agent-board.md#bootstrap-flow)) and, once detected on two consecutive polls and agmsg is
+confirmed present on that pane's host, writes a one-time onboarding instruction directly into the
+pane's terminal — visible in the browser the same way any other terminal output is. This happens
+with no operator action beyond setting the config flag; there is no API call to trigger or observe
+it directly (its effect is only visible in the pane's own terminal output and, once the agent
+follows the instruction, in `GET /api/board/status`/`/messages` after the relay's next poll).
 
 ### `GET /api/board/status`
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,17 +80,42 @@ internally, so `RunBoardCommand` remains responsible only for the POSIX shell es
 including the wrapper script text itself, before the remote command string is built.
 
 `send.sh` and `api.sh` are the two agmsg scripts this design's message read/write path runs
-remotely; each runs against agmsg's own local store on that host. The only other remote command
-panemux itself ever executes is a fixed, non-tainted `sh -c 'printf '%s' "$HOME"'` probe
-(`internal/board/agmsg_path.go`'s `remoteHomeProbeCmd`), run once per remote host to resolve
-`agent_board.agmsg_path`'s leading `~/` against that host's own home directory before it is ever
-placed in a `RunBoardCommand` argument list — see [agent-board.md](agent-board.md)'s "`~` in
-`agmsg_path` is expanded by panemux" section. panemux only ever detects an existing agmsg
-installation — it never installs, updates, or otherwise manages agmsg on the operator's behalf,
-locally or remotely. The relay goroutine that drives this on a schedule (`internal/board/relay.go`)
-and the `/api/board/*` REST surface (`GET /status`, `GET /messages`, `POST /broadcast`) are
-implemented — see [agent-board.md](agent-board.md)'s status note. The bootstrap flow that writes an
-onboarding instruction into a pane's PTY, and the command center, are not yet implemented.
+remotely; each runs against agmsg's own local store on that host. The only other remote commands
+panemux itself ever executes are two fixed, non-tainted `sh -c` probes, neither of which takes any
+caller-supplied data: `internal/board/agmsg_path.go`'s `remoteHomeProbeCmd`
+(`sh -c 'printf '%s' "$HOME"'`), run once per remote host to resolve `agent_board.agmsg_path`'s
+leading `~/` against that host's own home directory before it is ever placed in a `RunBoardCommand`
+argument list — see [agent-board.md](agent-board.md)'s "`~` in `agmsg_path` is expanded by panemux"
+section — and `internal/board/agmsg_presence.go`'s `remoteAgmsgPresenceProbeScript`
+(`test -f "$1" && printf 'yes' || printf 'no'`), run by the bootstrap watcher (and, independently,
+whenever the relay resolves a host's client) to check whether `scripts/api.sh` exists at the
+already-resolved `agmsg_path` before treating that host as bootstrap-eligible. Because
+`remoteAgmsgPresenceProbeScript` takes its one variable input (the path to test) as a positional
+parameter (`$1`), not string-interpolated into the script body, it carries no taint from
+`agent_board.agmsg_path` into the script text itself — the same discipline
+`sendBase64WrapperScript` above uses, just with no caller-supplied value needing a preceding
+regex-allowlist branch at all here, since the path being tested is `agent_board.agmsg_path` already
+resolved to an absolute path by the `~` expansion step, itself derived from operator config, not
+runtime request data. panemux only ever detects an existing agmsg installation — it never installs,
+updates, or otherwise manages agmsg on the operator's behalf, locally or remotely. The relay
+goroutine that drives this on a schedule (`internal/board/relay.go`), the bootstrap watcher
+(`bootstrapWatcher` in `bootstrap.go`, `package main`), and the `/api/board/*` REST surface
+(`GET /status`, `GET /messages`, `POST /broadcast`) are implemented — see
+[agent-board.md](agent-board.md)'s status note. The command center is not yet implemented.
+
+**The bootstrap watcher's PTY write is not a command-execution sink and is out of scope for this
+document's `exec.Command`-focused rules above.** `bootstrapWatcher` writes a synthesized onboarding
+instruction into a pane's PTY via `Session.Write` — the same path real user keystrokes already go
+through — not via `exec.Command`, so none of the shell-argument-escaping or CodeQL taint-chain
+reasoning above applies to that write itself: there is no shell parsing panemux's own Go code
+performs on that text, and no distinction between "trusted" and "tainted" content for a PTY write
+the way there is for a command-string argument. The one identifier bootstrap itself passes into a `RunBoardCommand` call — the already-resolved
+`agmsg_path` used to build the presence probe's `$1` — is quoted with the same `shellQuotePath`-style
+discipline `RunBoardCommand` already applies uniformly to every argument, board-related or not.
+`agent_board.team`, a pane's own ID, and the agmsg-recognized type string
+`session.AgentTypeDetector` returns are written only into the PTY instruction text, never into a
+`RunBoardCommand` call bootstrap itself makes; they are operator config or panemux's own fixed
+detection-table output either way, not external request data.
 
 ### Auth token and transport encryption
 

--- a/internal/board/agmsg_presence.go
+++ b/internal/board/agmsg_presence.go
@@ -1,0 +1,46 @@
+package board
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LocalAgmsgPresent reports whether scripts/api.sh exists under agmsgPath
+// (already ~-expanded to an absolute path) on the local filesystem. This is
+// the same "detection, not installation" check
+// docs/agent-board.md#integration-with-agmsg specifies for bootstrap
+// eligibility: a false result means the operator hasn't installed agmsg
+// there, not that panemux failed to check.
+func LocalAgmsgPresent(agmsgPath string) bool {
+	_, err := os.Stat(filepath.Join(agmsgPath, "scripts", "api.sh"))
+	return err == nil
+}
+
+// remoteAgmsgPresenceProbeScript is a fixed, non-tainted script that checks
+// whether $1 exists, mirroring sendBase64WrapperScript's shape (fixed
+// script text, tainted-but-quoted data arrives only via a positional
+// parameter, never interpolated into the script itself). It always exits 0
+// — the caller reads "yes"/"no" from stdout rather than the exit code, the
+// same convention remoteHomeProbeCmd's caller uses, so a real
+// transport/exec failure (a non-nil error from RunBoardCommand) is never
+// confused with "the file doesn't exist".
+const remoteAgmsgPresenceProbeScript = `test -f "$1" && printf 'yes' || printf 'no'`
+const remoteAgmsgPresenceProbeScriptName = "board-agmsg-presence"
+
+// RemoteAgmsgPresent reports whether scripts/api.sh exists under agmsgPath
+// (already ~-expanded to an absolute path) on the remote host reached
+// through executor.
+func RemoteAgmsgPresent(ctx context.Context, executor BoardExecutor, agmsgPath string) (bool, error) {
+	apiScript := agmsgPath + "/scripts/api.sh"
+	args := []string{
+		"sh", "-c", remoteAgmsgPresenceProbeScript, remoteAgmsgPresenceProbeScriptName, apiScript,
+	}
+	out, err := executor.RunBoardCommand(ctx, args)
+	if err != nil {
+		return false, fmt.Errorf("agmsg: checking remote scripts/api.sh presence: %w", err)
+	}
+	return strings.TrimSpace(string(out)) == "yes", nil
+}

--- a/internal/board/agmsg_presence_test.go
+++ b/internal/board/agmsg_presence_test.go
@@ -1,0 +1,79 @@
+package board
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalAgmsgPresent_ScriptsExist_True(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "scripts"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scripts", "api.sh"), []byte("#!/bin/sh\n"), 0600))
+
+	assert.True(t, LocalAgmsgPresent(dir))
+}
+
+func TestLocalAgmsgPresent_ScriptsMissing_False(t *testing.T) {
+	dir := t.TempDir() // exists, but scripts/api.sh does not
+	assert.False(t, LocalAgmsgPresent(dir))
+}
+
+func TestLocalAgmsgPresent_PathDoesNotExist_False(t *testing.T) {
+	assert.False(t, LocalAgmsgPresent(filepath.Join(t.TempDir(), "nonexistent")))
+}
+
+// remoteAgmsgPresenceProbeKey builds the fakeBoardExecutor outputs key for
+// the fixed presence-probe command RemoteAgmsgPresent issues against
+// apiScriptPath, mirroring RemoteAgmsgPresent's own args construction.
+func remoteAgmsgPresenceProbeKey(apiScriptPath string) string {
+	return strings.Join(
+		[]string{"sh", "-c", remoteAgmsgPresenceProbeScript, remoteAgmsgPresenceProbeScriptName, apiScriptPath},
+		"\x00",
+	)
+}
+
+func TestRemoteAgmsgPresent_ScriptsExist_True(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		remoteAgmsgPresenceProbeKey("/home/remote-user/agmsg/scripts/api.sh"): []byte("yes"),
+	}}
+
+	present, err := RemoteAgmsgPresent(context.Background(), exec, "/home/remote-user/agmsg")
+	require.NoError(t, err)
+	assert.True(t, present)
+}
+
+func TestRemoteAgmsgPresent_ScriptsMissing_False(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		remoteAgmsgPresenceProbeKey("/home/remote-user/agmsg/scripts/api.sh"): []byte("no"),
+	}}
+
+	present, err := RemoteAgmsgPresent(context.Background(), exec, "/home/remote-user/agmsg")
+	require.NoError(t, err)
+	assert.False(t, present)
+}
+
+func TestRemoteAgmsgPresent_TrimsWhitespaceFromProbeResponse(t *testing.T) {
+	exec := &fakeBoardExecutor{outputs: map[string][]byte{
+		remoteAgmsgPresenceProbeKey("/home/remote-user/agmsg/scripts/api.sh"): []byte("yes\n"),
+	}}
+
+	present, err := RemoteAgmsgPresent(context.Background(), exec, "/home/remote-user/agmsg")
+	require.NoError(t, err)
+	assert.True(t, present)
+}
+
+func TestRemoteAgmsgPresent_ExecutorError_Wrapped(t *testing.T) {
+	wantErr := errors.New("ssh: connection lost")
+	exec := &fakeBoardExecutor{err: wantErr}
+
+	_, err := RemoteAgmsgPresent(context.Background(), exec, "/home/remote-user/agmsg")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/internal/board/atomic_write.go
+++ b/internal/board/atomic_write.go
@@ -1,0 +1,41 @@
+package board
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to path via a temp file plus rename, creating
+// the parent directory if needed, so a crash or power loss mid-write can
+// never leave a truncated or half-written file on disk — a rename onto an
+// existing path is atomic on the platforms panemux targets, unlike a direct
+// write. label identifies the file kind in error messages (e.g. "relay
+// cursor file", "bootstrap state file").
+func atomicWriteFile(path string, data []byte, mode os.FileMode, label string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("creating %s directory: %w", label, err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp %s: %w", label, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp %s: %w", label, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp %s: %w", label, err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return fmt.Errorf("setting %s mode: %w", label, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replacing %s: %w", label, err)
+	}
+	return nil
+}

--- a/internal/board/bootstrap_store.go
+++ b/internal/board/bootstrap_store.go
@@ -1,0 +1,53 @@
+package board
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const bootstrapStateFileName = "board-bootstrap-state.json"
+const bootstrapStateFileMode os.FileMode = 0600
+
+// LoadBootstrapState reads the pane IDs the bootstrap watcher had already
+// written its onboarding instruction to as of the last save. A missing file
+// is the normal state before the first successful save, not an error, and
+// returns a nil slice.
+func LoadBootstrapState(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading bootstrap state file: %w", err)
+	}
+	var paneIDs []string
+	if err := json.Unmarshal(data, &paneIDs); err != nil {
+		return nil, fmt.Errorf("parsing bootstrap state file: %w", err)
+	}
+	return paneIDs, nil
+}
+
+// SaveBootstrapState persists paneIDs, creating the parent directory if
+// needed. The write goes through a temp file plus rename, not a direct
+// WriteFile, so a crash or power loss mid-write can never leave a truncated
+// or half-written state file on disk — a rename onto an existing path is
+// atomic on the platforms panemux targets, unlike a direct write.
+func SaveBootstrapState(path string, paneIDs []string) error {
+	data, err := json.Marshal(paneIDs)
+	if err != nil {
+		return fmt.Errorf("encoding bootstrap state file: %w", err)
+	}
+	return atomicWriteFile(path, data, bootstrapStateFileMode, "bootstrap state file")
+}
+
+// DefaultBootstrapStateFilePath returns ~/.config/panemux/board-bootstrap-state.json.
+func DefaultBootstrapStateFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", bootstrapStateFileName), nil
+}

--- a/internal/board/bootstrap_store_test.go
+++ b/internal/board/bootstrap_store_test.go
@@ -1,0 +1,70 @@
+package board
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveBootstrapState_ThenLoad_RoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bootstrap.json")
+	paneIDs := []string{"pane-a", "pane-b"}
+
+	require.NoError(t, SaveBootstrapState(path, paneIDs))
+
+	loaded, err := LoadBootstrapState(path)
+	require.NoError(t, err)
+	assert.Equal(t, paneIDs, loaded)
+}
+
+func TestSaveBootstrapState_SetsFileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bootstrap.json")
+	require.NoError(t, SaveBootstrapState(path, []string{"pane-a"}))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestSaveBootstrapState_CreatesParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "dir", "bootstrap.json")
+	require.NoError(t, SaveBootstrapState(path, []string{"pane-a"}))
+
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+}
+
+func TestLoadBootstrapState_MissingFile_ReturnsNilNotError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+
+	paneIDs, err := LoadBootstrapState(path)
+	require.NoError(t, err)
+	assert.Nil(t, paneIDs)
+}
+
+func TestLoadBootstrapState_MalformedJSON_Error(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bootstrap.json")
+	require.NoError(t, os.WriteFile(path, []byte("not valid json"), 0600))
+
+	_, err := LoadBootstrapState(path)
+	assert.Error(t, err)
+}
+
+func TestLoadBootstrapState_EmptyArray_ReturnsEmptySlice(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bootstrap.json")
+	require.NoError(t, os.WriteFile(path, []byte("[]"), 0600))
+
+	paneIDs, err := LoadBootstrapState(path)
+	require.NoError(t, err)
+	assert.Empty(t, paneIDs)
+}
+
+func TestDefaultBootstrapStateFilePath_ContainsExpectedSuffix(t *testing.T) {
+	path, err := DefaultBootstrapStateFilePath()
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(path, filepath.Join(".config", "panemux", "board-bootstrap-state.json")))
+}

--- a/internal/board/cursor_store.go
+++ b/internal/board/cursor_store.go
@@ -49,31 +49,7 @@ func SaveCursorFile(path string, entries []CursorEntry) error {
 	if err != nil {
 		return fmt.Errorf("encoding relay cursor file: %w", err)
 	}
-	dir := filepath.Dir(path)
-	if mkdirErr := os.MkdirAll(dir, 0750); mkdirErr != nil {
-		return fmt.Errorf("creating relay cursor directory: %w", mkdirErr)
-	}
-	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("creating temp relay cursor file: %w", err)
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath) // no-op once the rename below succeeds
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return fmt.Errorf("writing temp relay cursor file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing temp relay cursor file: %w", err)
-	}
-	if err := os.Chmod(tmpPath, cursorFileMode); err != nil {
-		return fmt.Errorf("setting relay cursor file mode: %w", err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("replacing relay cursor file: %w", err)
-	}
-	return nil
+	return atomicWriteFile(path, data, cursorFileMode, "relay cursor file")
 }
 
 // DefaultCursorFilePath returns ~/.config/panemux/board-relay-cursor.json.

--- a/internal/board/remote_client.go
+++ b/internal/board/remote_client.go
@@ -60,6 +60,17 @@ func validateAgmsgIdentifier(label, value string) error {
 	return nil
 }
 
+// ValidAgmsgIdentifier reports whether value is safe to use as an agmsg
+// team/from/to identifier — the same regex-allowlist RunBoardCommand calls
+// already enforce internally via validateAgmsgIdentifier. Exported so
+// callers outside internal/board (bootstrap.go) can reject a pane ID or
+// team name up front, before it is ever embedded in a command line the
+// agent itself will type and execute — see docs/agent-board.md's Bootstrap
+// flow section.
+func ValidAgmsgIdentifier(value string) bool {
+	return validAgmsgIdentifier.MatchString(value)
+}
+
 var _ AgmsgClient = (*RemoteAgmsgClient)(nil)
 
 // RemoteAgmsgClient runs agmsg's scripts on a remote host over the SSH exec

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -169,6 +169,25 @@ func (s *LocalSession) GetActiveWorkdirs() ([]string, error) {
 	return resolveInteractiveAgentWorkdirs(processes, pid, baseCWD)
 }
 
+// DetectInteractiveAgentType reports the agmsg type name of any live agent
+// process currently running as a descendant of this pane's shell, among
+// agmsgDetectableAgentTypes. It skips the transcript/workdir resolution
+// GetActiveWorkdirs does, so it's cheap enough to poll frequently — see
+// AgentTypeDetector.
+func (s *LocalSession) DetectInteractiveAgentType() (string, bool, error) {
+	if s.pid == 0 {
+		return "", false, errors.New("session has no PID")
+	}
+
+	processes, err := listProcessesFn()
+	if err != nil {
+		return "", false, err
+	}
+
+	_, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, s.pid)
+	return agmsgType, ok, nil
+}
+
 func getPIDCWD(pid int) (string, error) {
 	switch runtime.GOOS {
 	case "linux":
@@ -260,12 +279,121 @@ func parsePSOutput(out []byte) ([]processInfo, error) {
 }
 
 func newestInteractiveAgentDescendantPID(processes []processInfo, rootPID int) (int, bool) {
+	return newestMatchingDescendantPID(processes, rootPID, isInteractiveAgentCommand)
+}
+
+// agmsgAgentType describes one agmsg-recognized agent type panemux can
+// detect via process name.
+type agmsgAgentType struct {
+	agmsgType string   // the exact type name agmsg's own scripts expect (join.sh/whoami.sh/delivery.sh's <type> argument)
+	patterns  []string // binary basenames; a trailing "*" matches as a prefix, mirroring agmsg's own detect_proc syntax
+	// excludeTokens: if any of these appear as an argument, this is a
+	// known headless/non-interactive invocation of the same binary and
+	// must not match — mirrors isInteractiveAgentCommand's existing
+	// claude/codex exclusions.
+	excludeTokens []string
+}
+
+// agmsgDetectableAgentTypes mirrors agmsg's own type.conf `detect_proc` key
+// for every type that declares one (verified against agmsg v1.1.13,
+// github.com/fujibee/agmsg/scripts/drivers/types/<type>/type.conf, 2026-08).
+// agmsg itself does NOT attempt process-based detection for antigravity,
+// copilot, or hermes (all three use `detect=explicit` instead — agmsg's own
+// maintainers judged process-name detection unreliable for them), and
+// agmsg-app is not a spawnable CLI at all (it's the desktop app's own
+// human-user identity). Agent Board's bootstrap flow inherits this same
+// boundary rather than inventing a wider one panemux can't independently
+// verify: an operator on one of the undetectable types can still join
+// agmsg by hand.
+//
+// The claude-code and codex exclude-token lists are independently
+// confirmed via agmsg's own template.md wording (claude -p/--print, codex
+// exec are explicitly called out as non-interactive). No equivalent
+// headless-invocation carve-out is documented for the other four types as
+// of the verified version; treat their absence here as "not documented",
+// not as a positive claim that no such flag exists.
+var agmsgDetectableAgentTypes = []agmsgAgentType{
+	{
+		agmsgType: "claude-code", patterns: []string{"claude", "claude-code", "claude-*"},
+		excludeTokens: []string{"-p", "--print"},
+	},
+	{agmsgType: "codex", patterns: []string{"codex", "codex-*"}, excludeTokens: []string{"exec"}},
+	{agmsgType: "cursor", patterns: []string{"cursor-agent", "cursor-agent-*"}},
+	{agmsgType: "gemini", patterns: []string{"gemini", "gemini-*"}},
+	{agmsgType: "grok-build", patterns: []string{"grok", "grok-*"}},
+	{agmsgType: "opencode", patterns: []string{"opencode", "opencode-*"}},
+}
+
+// detectAgmsgAgentType reports the agmsg type name of command, if it
+// matches one of agmsgDetectableAgentTypes and isn't a known headless
+// invocation of that same binary.
+func detectAgmsgAgentType(command string) (string, bool) {
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "", false
+	}
+	binary := strings.ToLower(filepath.Base(fields[0]))
+	for _, t := range agmsgDetectableAgentTypes {
+		if !matchesAnyAgentPattern(binary, t.patterns) {
+			continue
+		}
+		if containsAnyToken(fields[1:], t.excludeTokens...) {
+			return "", false
+		}
+		return t.agmsgType, true
+	}
+	return "", false
+}
+
+func matchesAnyAgentPattern(binary string, patterns []string) bool {
+	for _, p := range patterns {
+		if prefix, ok := strings.CutSuffix(p, "*"); ok {
+			if strings.HasPrefix(binary, prefix) {
+				return true
+			}
+		} else if binary == p {
+			return true
+		}
+	}
+	return false
+}
+
+// newestKnownAgentTypeDescendantPID is AgentTypeDetector's primitive: like
+// newestInteractiveAgentDescendantPID, but matches any of
+// agmsgDetectableAgentTypes (not just claude/codex) and reports which type
+// matched, since Agent Board's bootstrap instruction differs by type.
+func newestKnownAgentTypeDescendantPID(processes []processInfo, rootPID int) (pid int, agmsgType string, ok bool) {
+	children := childProcessMap(processes)
+	stack := append([]processInfo(nil), children[rootPID]...)
+
+	if proc, found := processByPID(processes, rootPID); found {
+		if t, matched := detectAgmsgAgentType(proc.Command); matched {
+			pid, agmsgType, ok = rootPID, t, true
+		}
+	}
+
+	for len(stack) > 0 {
+		proc := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		stack = append(stack, children[proc.PID]...)
+
+		if t, matched := detectAgmsgAgentType(proc.Command); matched {
+			if !ok || proc.PID > pid {
+				pid, agmsgType, ok = proc.PID, t, true
+			}
+		}
+	}
+
+	return pid, agmsgType, ok
+}
+
+func newestMatchingDescendantPID(processes []processInfo, rootPID int, match func(string) bool) (int, bool) {
 	children := childProcessMap(processes)
 	stack := append([]processInfo(nil), children[rootPID]...)
 	matched := 0
 	ok := false
 
-	if proc, found := processByPID(processes, rootPID); found && isInteractiveAgentCommand(proc.Command) {
+	if proc, found := processByPID(processes, rootPID); found && match(proc.Command) {
 		matched = rootPID
 		ok = true
 	}
@@ -275,7 +403,7 @@ func newestInteractiveAgentDescendantPID(processes []processInfo, rootPID int) (
 		stack = stack[:len(stack)-1]
 		stack = append(stack, children[proc.PID]...)
 
-		if isInteractiveAgentCommand(proc.Command) {
+		if match(proc.Command) {
 			if !ok || proc.PID > matched {
 				matched = proc.PID
 				ok = true

--- a/internal/session/local.go
+++ b/internal/session/local.go
@@ -36,6 +36,16 @@ var validClaudeSessionID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 const (
 	interactiveAgentCodex  = "codex"
 	interactiveAgentClaude = "claude"
+
+	// agmsgTypeClaudeCode, agmsgTypeGemini, and agmsgTypeOpencode are
+	// agmsgDetectableAgentTypes' own agmsg-recognized type/binary-name
+	// strings, factored out purely to satisfy goconst's package-wide
+	// duplicate-literal check (their many other occurrences are all in
+	// _test.go files, which goconst deliberately excludes — see
+	// .golangci.yml).
+	agmsgTypeClaudeCode = "claude-code"
+	agmsgTypeGemini     = "gemini"
+	agmsgTypeOpencode   = "opencode"
 )
 
 // LocalSession is a local PTY-based terminal session.
@@ -314,14 +324,17 @@ type agmsgAgentType struct {
 // not as a positive claim that no such flag exists.
 var agmsgDetectableAgentTypes = []agmsgAgentType{
 	{
-		agmsgType: "claude-code", patterns: []string{"claude", "claude-code", "claude-*"},
+		agmsgType: agmsgTypeClaudeCode, patterns: []string{interactiveAgentClaude, agmsgTypeClaudeCode, "claude-*"},
 		excludeTokens: []string{"-p", "--print"},
 	},
-	{agmsgType: "codex", patterns: []string{"codex", "codex-*"}, excludeTokens: []string{"exec"}},
+	{
+		agmsgType: interactiveAgentCodex, patterns: []string{interactiveAgentCodex, "codex-*"},
+		excludeTokens: []string{"exec"},
+	},
 	{agmsgType: "cursor", patterns: []string{"cursor-agent", "cursor-agent-*"}},
-	{agmsgType: "gemini", patterns: []string{"gemini", "gemini-*"}},
+	{agmsgType: agmsgTypeGemini, patterns: []string{agmsgTypeGemini, "gemini-*"}},
 	{agmsgType: "grok-build", patterns: []string{"grok", "grok-*"}},
-	{agmsgType: "opencode", patterns: []string{"opencode", "opencode-*"}},
+	{agmsgType: agmsgTypeOpencode, patterns: []string{agmsgTypeOpencode, "opencode-*"}},
 }
 
 // detectAgmsgAgentType reports the agmsg type name of command, if it

--- a/internal/session/local_test.go
+++ b/internal/session/local_test.go
@@ -252,6 +252,93 @@ func TestIsInteractiveAgentCommand(t *testing.T) {
 	assert.False(t, isInteractiveAgentCommand("python worker.py"))
 }
 
+func TestDetectAgmsgAgentType(t *testing.T) {
+	tests := []struct {
+		command  string
+		wantType string
+		wantOK   bool
+	}{
+		{"claude", "claude-code", true},
+		{"/usr/local/bin/claude --resume", "claude-code", true},
+		{"claude-code", "claude-code", true},
+		{"claude-code-nightly", "claude-code", true}, // matches the claude-* wildcard
+		{"claude -p", "", false},
+		{"claude --print", "", false},
+		{"codex", "codex", true},
+		{"/usr/local/bin/codex --model gpt-5", "codex", true},
+		{"codex-nightly", "codex", true}, // matches the codex-* wildcard
+		{"codex exec", "", false},
+		{"cursor-agent", "cursor", true},
+		{"gemini", "gemini", true},
+		{"grok", "grok-build", true},
+		{"opencode", "opencode", true},
+		{"python worker.py", "", false},
+		{"", "", false},
+		// Types agmsg itself does not process-detect (detect=explicit in its
+		// own type.conf) must never match here either.
+		{"agy", "", false}, // antigravity's cli
+		{"copilot", "", false},
+		{"hermes", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.command, func(t *testing.T) {
+			gotType, gotOK := detectAgmsgAgentType(tc.command)
+			assert.Equal(t, tc.wantOK, gotOK)
+			assert.Equal(t, tc.wantType, gotType)
+		})
+	}
+}
+
+func TestNewestKnownAgentTypeDescendantPID_FindsClaudeAmongOthers(t *testing.T) {
+	processes := []processInfo{
+		{PID: 100, PPID: 1, Command: "/bin/zsh"},
+		{PID: 120, PPID: 100, Command: "codex exec"}, // headless, excluded
+		{PID: 140, PPID: 100, Command: "claude"},
+	}
+
+	pid, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, 100)
+	require.True(t, ok)
+	assert.Equal(t, 140, pid)
+	assert.Equal(t, "claude-code", agmsgType)
+}
+
+func TestNewestKnownAgentTypeDescendantPID_FindsGemini(t *testing.T) {
+	processes := []processInfo{
+		{PID: 100, PPID: 1, Command: "/bin/zsh"},
+		{PID: 150, PPID: 100, Command: "gemini"},
+	}
+
+	pid, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, 100)
+	require.True(t, ok)
+	assert.Equal(t, 150, pid)
+	assert.Equal(t, "gemini", agmsgType)
+}
+
+func TestNewestKnownAgentTypeDescendantPID_PrefersNewestAcrossTypes(t *testing.T) {
+	processes := []processInfo{
+		{PID: 100, PPID: 1, Command: "/bin/zsh"},
+		{PID: 140, PPID: 100, Command: "claude"},
+		{PID: 160, PPID: 100, Command: "opencode"},
+	}
+
+	pid, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, 100)
+	require.True(t, ok)
+	assert.Equal(t, 160, pid)
+	assert.Equal(t, "opencode", agmsgType)
+}
+
+func TestNewestKnownAgentTypeDescendantPID_NoneFound(t *testing.T) {
+	processes := []processInfo{
+		{PID: 100, PPID: 1, Command: "/bin/zsh"},
+		{PID: 110, PPID: 100, Command: "git status"},
+	}
+
+	pid, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, 100)
+	assert.False(t, ok)
+	assert.Zero(t, pid)
+	assert.Empty(t, agmsgType)
+}
+
 func TestCodexSessionPath(t *testing.T) {
 	path, ok := codexSessionPath([]string{
 		"/tmp/other.log",
@@ -566,6 +653,73 @@ func TestParseClaudeProjectCWD_TrackedBackupTieBreakUsesAlphabeticalLastPath(t *
 	cwd, err := parseClaudeProjectCWD(data)
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Dir(worktreeFile), cwd)
+}
+
+func TestLocalSession_DetectInteractiveAgentType_NoPID_Error(t *testing.T) {
+	sess := &LocalSession{pid: 0}
+	_, _, err := sess.DetectInteractiveAgentType()
+	assert.Error(t, err)
+}
+
+func TestLocalSession_DetectInteractiveAgentType_Present(t *testing.T) {
+	tests := []struct {
+		command  string
+		wantType string
+	}{
+		{"claude", "claude-code"},
+		{"gemini", "gemini"},
+		{"opencode", "opencode"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.command, func(t *testing.T) {
+			sess := &LocalSession{pid: 100}
+
+			original := listProcessesFn
+			t.Cleanup(func() { listProcessesFn = original })
+			listProcessesFn = func() ([]processInfo, error) {
+				return []processInfo{
+					{PID: 100, PPID: 1, Command: "/bin/zsh"},
+					{PID: 110, PPID: 100, Command: tc.command},
+				}, nil
+			}
+
+			agmsgType, ok, err := sess.DetectInteractiveAgentType()
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantType, agmsgType)
+		})
+	}
+}
+
+func TestLocalSession_DetectInteractiveAgentType_NoKnownAgent_False(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+
+	original := listProcessesFn
+	t.Cleanup(func() { listProcessesFn = original })
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 100, PPID: 1, Command: "/bin/zsh"},
+			{PID: 110, PPID: 100, Command: "git status"},
+		}, nil
+	}
+
+	agmsgType, ok, err := sess.DetectInteractiveAgentType()
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, agmsgType)
+}
+
+func TestLocalSession_DetectInteractiveAgentType_ListProcessesError_Propagated(t *testing.T) {
+	sess := &LocalSession{pid: 100}
+	wantErr := errors.New("ps failed")
+
+	original := listProcessesFn
+	t.Cleanup(func() { listProcessesFn = original })
+	listProcessesFn = func() ([]processInfo, error) { return nil, wantErr }
+
+	_, _, err := sess.DetectInteractiveAgentType()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
 }
 
 func TestGetActiveWorkdir_NoDescendantMatchReturnsEmpty(t *testing.T) {
@@ -1468,6 +1622,59 @@ func TestDetectLocalShellDscl_NoUserShellLine_Error(t *testing.T) {
 	_, err := detectLocalShellDscl("tomo", runner)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "UserShell not found")
+}
+
+func TestTmuxLocalSession_DetectInteractiveAgentType_ClaudePresent(t *testing.T) {
+	prevTmuxOutput := tmuxLocalOutputFn
+	prevListProcesses := listProcessesFn
+	t.Cleanup(func() {
+		tmuxLocalOutputFn = prevTmuxOutput
+		listProcessesFn = prevListProcesses
+	})
+
+	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {
+		if len(args) == 5 && args[4] == "#{pane_pid}" {
+			return []byte("220\n"), nil
+		}
+		return nil, errors.New("unexpected tmux args")
+	}
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{
+			{PID: 220, PPID: 1, Command: "/bin/zsh"},
+			{PID: 230, PPID: 220, Command: "claude"},
+		}, nil
+	}
+
+	sess := &TmuxLocalSession{tmuxSession: "demo"}
+	agmsgType, ok, err := sess.DetectInteractiveAgentType()
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "claude-code", agmsgType)
+}
+
+func TestTmuxLocalSession_DetectInteractiveAgentType_NoKnownAgent_False(t *testing.T) {
+	prevTmuxOutput := tmuxLocalOutputFn
+	prevListProcesses := listProcessesFn
+	t.Cleanup(func() {
+		tmuxLocalOutputFn = prevTmuxOutput
+		listProcessesFn = prevListProcesses
+	})
+
+	tmuxLocalOutputFn = func(args ...string) ([]byte, error) {
+		if len(args) == 5 && args[4] == "#{pane_pid}" {
+			return []byte("220\n"), nil
+		}
+		return nil, errors.New("unexpected tmux args")
+	}
+	listProcessesFn = func() ([]processInfo, error) {
+		return []processInfo{{PID: 220, PPID: 1, Command: "/bin/zsh"}}, nil
+	}
+
+	sess := &TmuxLocalSession{tmuxSession: "demo"}
+	agmsgType, ok, err := sess.DetectInteractiveAgentType()
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, agmsgType)
 }
 
 func TestTmuxLocalSessionGetActiveWorkdir_UsesPanePIDAndBaseCWD(t *testing.T) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -68,6 +68,20 @@ type ActiveWorkdirGetter interface {
 	GetActiveWorkdirs() ([]string, error)
 }
 
+// AgentTypeDetector is implemented by every session type. It reports the
+// agmsg-recognized type name (e.g. "claude-code", "codex", "gemini") of any
+// live, interactive coding-agent process currently running as a descendant
+// of this pane's shell, among the set agmsg's own type.conf `detect_proc`
+// key considers reliably process-detectable — see agmsgDetectableAgentTypes.
+// This is narrower than ActiveWorkdirGetter (which only distinguishes
+// Codex/Claude, and additionally resolves transcript-derived workdirs at
+// real I/O cost) and returns WHICH type rather than a bare bool, since
+// Agent Board's bootstrap flow writes a different onboarding instruction
+// per agent type.
+type AgentTypeDetector interface {
+	DetectInteractiveAgentType() (agmsgType string, ok bool, err error)
+}
+
 // GitContext describes the repository state for a session's working directory.
 type GitContext struct {
 	Branch    string

--- a/internal/session/ssh.go
+++ b/internal/session/ssh.go
@@ -925,6 +925,14 @@ func (s *SSHSession) GetActiveWorkdirs() ([]string, error) {
 	)
 }
 
+// DetectInteractiveAgentType reports the agmsg type name of any live agent
+// process currently running on this SSH connection — see AgentTypeDetector.
+func (s *SSHSession) DetectInteractiveAgentType() (string, bool, error) {
+	return detectRemoteAgentTypeFromSessionFactory(func() (sshSessionRunner, error) {
+		return s.client.NewSession()
+	})
+}
+
 // InspectGitContext resolves Git metadata on the remote host for the provided
 // absolute working directory.
 func (s *SSHSession) InspectGitContext(cwd string) (GitContext, error) {
@@ -977,6 +985,38 @@ func activeRemoteWorkdirsFromSessionFactory(
 
 func activeRemoteWorkdirs(runner sshSessionRunner, logScope, baseCWD string, rootPID int) ([]string, error) {
 	return activeRemoteWorkdirsWithOutput(runner.Output, logScope, baseCWD, rootPID)
+}
+
+// detectRemoteAgentTypeFromSessionFactory is AgentTypeDetector's SSH
+// primitive: it stops at "which agent type is present", skipping the
+// transcript/workdir resolution activeRemoteWorkdirsFromSessionFactory does
+// afterward — cheap enough to poll frequently.
+func detectRemoteAgentTypeFromSessionFactory(newRunner func() (sshSessionRunner, error)) (string, bool, error) {
+	rootRunner, err := newRunner()
+	if err != nil {
+		return "", false, fmt.Errorf("new ssh session for remote shell pid: %w", err)
+	}
+	defer rootRunner.Close()
+
+	rootPID, err := remoteShellPID(rootRunner)
+	if err != nil {
+		return "", false, err
+	}
+
+	return detectRemoteAgentType(outputFromSessionFactory(newRunner), rootPID)
+}
+
+func detectRemoteAgentType(run remoteOutputFunc, rootPID int) (string, bool, error) {
+	out, err := run(sshListProcessesCmd)
+	if err != nil {
+		return "", false, fmt.Errorf("list remote processes: %w", err)
+	}
+	processes, err := parsePSOutput(append([]byte("PID PPID COMMAND\n"), out...))
+	if err != nil {
+		return "", false, err
+	}
+	_, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, rootPID)
+	return agmsgType, ok, nil
 }
 
 func activeRemoteWorkdirsWithOutput(

--- a/internal/session/ssh_test.go
+++ b/internal/session/ssh_test.go
@@ -767,6 +767,46 @@ func TestActiveRemoteWorkdirFromSessionFactory_UsesSeparateRunners(t *testing.T)
 	assert.Equal(t, 4, index)
 }
 
+func TestDetectRemoteAgentTypeFromSessionFactory_FindsGemini(t *testing.T) {
+	outputs := map[string][]byte{
+		sshShellPIDCmd:      []byte("220\n"),
+		sshListProcessesCmd: []byte(" 220 1 zsh\n 240 220 gemini\n"),
+	}
+	factory := func() (sshSessionRunner, error) {
+		return &fakeSSHRunner{outputs: outputs}, nil
+	}
+
+	agmsgType, ok, err := detectRemoteAgentTypeFromSessionFactory(factory)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "gemini", agmsgType)
+}
+
+func TestDetectRemoteAgentTypeFromSessionFactory_IgnoresHeadlessCodex(t *testing.T) {
+	outputs := map[string][]byte{
+		sshShellPIDCmd:      []byte("220\n"),
+		sshListProcessesCmd: []byte(" 220 1 zsh\n 240 220 codex exec\n"),
+	}
+	factory := func() (sshSessionRunner, error) {
+		return &fakeSSHRunner{outputs: outputs}, nil
+	}
+
+	agmsgType, ok, err := detectRemoteAgentTypeFromSessionFactory(factory)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, agmsgType)
+}
+
+func TestDetectRemoteAgentTypeFromSessionFactory_ShellPIDError_Propagated(t *testing.T) {
+	factory := func() (sshSessionRunner, error) {
+		return &fakeSSHRunner{outputs: map[string][]byte{}}, nil
+	}
+
+	_, ok, err := detectRemoteAgentTypeFromSessionFactory(factory)
+	require.Error(t, err)
+	assert.False(t, ok)
+}
+
 func TestActiveRemoteWorkdir_RootPIDScopesRemoteAgents(t *testing.T) {
 	runner := &fakeSSHRunner{
 		outputs: map[string][]byte{
@@ -884,6 +924,36 @@ func TestTmuxSSHActiveWorkdirFromSessionFactory_UsesSeparateRunners(t *testing.T
 	// Separate runners are used for: tmux pane info, process list, open-files
 	// probe, and PID cwd fallback.
 	assert.Equal(t, 4, index)
+}
+
+func TestTmuxSSHDetectInteractiveAgentTypeFromSessionFactory_FindsOpencode(t *testing.T) {
+	outputs := map[string][]byte{
+		"tmux display-message -p -t 'demo' '#{pane_pid}\t#{pane_current_path}'": []byte("220\t/repo/main\n"),
+		sshListProcessesCmd: []byte(" 220 1 zsh\n 240 220 opencode\n"),
+	}
+	factory := func() (sshSessionRunner, error) {
+		return &fakeSSHRunner{outputs: outputs}, nil
+	}
+
+	agmsgType, ok, err := tmuxSSHDetectInteractiveAgentTypeFromSessionFactory(factory, "demo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "opencode", agmsgType)
+}
+
+func TestTmuxSSHDetectInteractiveAgentTypeFromSessionFactory_NoKnownAgent(t *testing.T) {
+	outputs := map[string][]byte{
+		"tmux display-message -p -t 'demo' '#{pane_pid}\t#{pane_current_path}'": []byte("220\t/repo/main\n"),
+		sshListProcessesCmd: []byte(" 220 1 zsh\n 230 220 git status\n"),
+	}
+	factory := func() (sshSessionRunner, error) {
+		return &fakeSSHRunner{outputs: outputs}, nil
+	}
+
+	agmsgType, ok, err := tmuxSSHDetectInteractiveAgentTypeFromSessionFactory(factory, "demo")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, agmsgType)
 }
 
 func TestRemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {

--- a/internal/session/tmux_local.go
+++ b/internal/session/tmux_local.go
@@ -138,6 +138,45 @@ func (s *TmuxLocalSession) GetActiveWorkdirs() ([]string, error) {
 	return tmuxLocalActiveWorkdirs(s.tmuxSession)
 }
 
+// DetectInteractiveAgentType reports the agmsg type name of any live agent
+// process currently running under this tmux pane — see AgentTypeDetector.
+func (s *TmuxLocalSession) DetectInteractiveAgentType() (string, bool, error) {
+	return tmuxLocalDetectInteractiveAgentType(s.tmuxSession)
+}
+
+func tmuxLocalDetectInteractiveAgentType(tmuxSession string) (string, bool, error) {
+	target, err := validateTmuxSessionName(tmuxSession)
+	if err != nil {
+		return "", false, err
+	}
+	out, err := tmuxLocalOutputFn(
+		"display-message",
+		"-p",
+		"-t",
+		target,
+		"#{pane_pid}",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("tmux pane pid: %w", err)
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", false, fmt.Errorf("parse tmux pane pid: %w", err)
+	}
+	if pid == 0 {
+		return "", false, errors.New("tmux pane pid missing")
+	}
+
+	processes, err := listProcessesFn()
+	if err != nil {
+		return "", false, err
+	}
+
+	_, agmsgType, ok := newestKnownAgentTypeDescendantPID(processes, pid)
+	return agmsgType, ok, nil
+}
+
 func tmuxLocalActiveWorkdirs(tmuxSession string) ([]string, error) {
 	target, err := validateTmuxSessionName(tmuxSession)
 	if err != nil {

--- a/internal/session/tmux_ssh.go
+++ b/internal/session/tmux_ssh.go
@@ -172,6 +172,44 @@ func (s *TmuxSSHSession) GetActiveWorkdirs() ([]string, error) {
 	)
 }
 
+// DetectInteractiveAgentType reports the agmsg type name of any live agent
+// process currently running under the active remote tmux pane — see
+// AgentTypeDetector.
+func (s *TmuxSSHSession) DetectInteractiveAgentType() (string, bool, error) {
+	return tmuxSSHDetectInteractiveAgentTypeFromSessionFactory(
+		func() (sshSessionRunner, error) {
+			return s.client.NewSession()
+		},
+		s.tmuxSession,
+	)
+}
+
+func tmuxSSHDetectInteractiveAgentTypeFromSessionFactory(
+	newRunner func() (sshSessionRunner, error), tmuxSession string,
+) (string, bool, error) {
+	paneRunner, err := newRunner()
+	if err != nil {
+		return "", false, fmt.Errorf("new ssh session for active tmux pane info: %w", err)
+	}
+	defer paneRunner.Close()
+
+	out, err := paneRunner.Output(
+		fmt.Sprintf(
+			"tmux display-message -p -t '%s' '#{pane_pid}\t#{pane_current_path}'",
+			tmuxSession,
+		),
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("tmux pane info over ssh: %w", err)
+	}
+	panePID, _, err := parseRemoteTmuxPaneInfo(out)
+	if err != nil {
+		return "", false, err
+	}
+
+	return detectRemoteAgentType(outputFromSessionFactory(newRunner), panePID)
+}
+
 // InspectGitContext resolves Git metadata on the remote host for the provided
 // absolute working directory.
 func (s *TmuxSSHSession) InspectGitContext(cwd string) (GitContext, error) {

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		log.Fatalf("Failed to start sessions: %v", err)
 	}
 
-	boardCache, boardRelay := setupBoard(cfg, manager)
+	boardCache, boardRelay, boardBootstrap := setupBoard(cfg, manager)
 
 	srv := server.New(cfg, manager, boardCache, boardRelay, frontendFS)
 	addr := "http://" + srv.Addr()
@@ -59,7 +59,7 @@ func main() {
 		go openChrome(addr)
 	}
 
-	runServer(srv, manager, boardRelay)
+	runServer(srv, manager, boardRelay, boardBootstrap)
 }
 
 func parseOptions() cliOptions {
@@ -92,7 +92,9 @@ func loadConfig(opts cliOptions) (*config.Config, error) {
 	return cfg, nil
 }
 
-func runServer(srv *server.Server, manager *session.Manager, boardRelay *board.Relay) {
+func runServer(
+	srv *server.Server, manager *session.Manager, boardRelay *board.Relay, boardBootstrap *bootstrapWatcher,
+) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
@@ -105,6 +107,11 @@ func runServer(srv *server.Server, manager *session.Manager, boardRelay *board.R
 	// panemux users who have never configured agent board at all.
 	if boardRelay.HasClients() {
 		go boardRelay.Run(boardCtx, defaultBoardPollInterval)
+	}
+	// Same reasoning as boardRelay.HasClients() above: no board-enabled pane
+	// at all means every tick would be a guaranteed no-op.
+	if boardBootstrap.HasWork() {
+		go boardBootstrap.Run(boardCtx, defaultBootstrapPollInterval)
 	}
 
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## Summary

Completes the last piece of issue #165's Phase 1 ("Board core"): the **bootstrap flow**. Two earlier PRs (#166, #167) built the relay, `BoardCache`, and the REST status/messages/broadcast endpoints; this PR adds the piece that gets a pane's agent onto agmsg in the first place.

- Polls every board-enabled pane every 5s for a newly-started, agmsg-detectable coding-agent process via a new `session.AgentTypeDetector` capability interface, implemented identically on all four session types (local, tmux-local, SSH, tmux-SSH).
- Detection deliberately covers all **six** agent types agmsg's own `type.conf` marks as process-detectable — `claude-code`, `codex`, `cursor`, `gemini`, `grok-build`, `opencode` — not Claude/Codex only, matching agmsg's own multi-agent design intent rather than an arbitrary narrower subset. (The three types agmsg itself doesn't trust process detection for — `antigravity`, `copilot`, `hermes` — and the non-CLI `agmsg-app` are excluded for the same reason agmsg excludes them, not by panemux's own guess.)
- Once detected on 2 consecutive polls (debounce) and agmsg is confirmed present on that pane's host, writes a one-time onboarding instruction directly into the pane's PTY via `Session.Write` — the same path real user keystrokes go through. The instruction invokes agmsg's `join.sh`/`send.sh`/`delivery.sh` scripts directly with their verified positional-argument signatures, rather than agmsg's `/agmsg`/`$agmsg` slash-command shorthand, since that shorthand's prefix differs by agent type.
- New `internal/board/agmsg_presence.go` (local/remote agmsg-installed checks) and `internal/board/bootstrap_store.go` (persisted bootstrap state, atomic-write discipline shared with `cursor_store.go` via new `internal/board/atomic_write.go`).
- Session-identity-based idempotency with a 2-tick debounce, wired into `board.go`/`main.go`'s existing relay lifecycle.
- Docs updated: `docs/agent-board.md`, `docs/architecture.md`, `docs/behavior.md`, `docs/security.md`.

An independent adversarial review (separate agent, isolated worktree, Opus 5) of the first commit found several real bugs, all fixed in the second commit:
- Persisted-seed logic was seeding local/SSH panes (which get a brand-new shell on every panemux restart) the same way as tmux panes (whose shell survives independently), which would have permanently blocked bootstrap for any local/SSH pane after its first successful run.
- The remote agmsg-presence probe trusted only the first candidate session on a host, so a registered-but-dead session could permanently block bootstrap for every pane on that host — now routed through the same `dynamicBoardExecutor` fail-over the relay already uses.
- A failed PTY write was retried forever with no distinction between "nothing was typed" and "part of the instruction was typed" — a short write is now never retried (it would compound a half-written line); a clean failure is retried up to a small bounded cap.
- Pane ID/team were embedded in a shell command line the agent will run without being validated against agmsg's own identifier alphabet first.
- The presence probe reused a 10s timeout sized for a one-shot startup call inside a 5s poll loop; given its own shorter, bootstrap-specific timeout.

Two findings were deliberately left unfixed and documented instead as known limitations, since a code fix couldn't be verified without live testing: whether every one of the six agent types treats an embedded `\n` as a literal newline vs. an Enter/submit event in the synthesized PTY input, and a tokenization false-negative where a prompt argument containing the literal word "exec" could be misclassified as a headless `codex exec` invocation.

Widening bearer-token auth to all pre-existing `/api/*` routes and `/ws/{sessionID}` remains out of scope for this PR, as agreed earlier in the issue discussion — tracked as a separate follow-up.

## Test plan

- [x] `make check` passes (fmt, vet, lint, Go tests with `-race`, frontend tests, Go coverage 87.7%/frontend coverage well above the 80% gate)
- [x] New unit tests cover: 6-agent-type detection across all 4 session types, debounce, session-identity-based re-bootstrap eligibility (including the tmux-vs-local restart distinction), persisted-state seeding, agmsg presence/absence on local and remote hosts, dead-first-candidate fail-over, short-write vs. clean-write-failure retry behavior, invalid pane-ID/team rejection, `HasWork`/`Run`/`runLoop` lifecycle, and the onboarding instruction text (mode-gating, verified script invocations, no slash-command shorthand dependency)
- [x] `docs/agent-board.md`'s status note, Bootstrap flow section, and Known limitations updated to match the implemented (not originally-planned) design

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015bGorfVr8zjhtYxZxyEPra

---
_Generated by [Claude Code](https://claude.ai/code/session_015bGorfVr8zjhtYxZxyEPra)_