### PR TITLE
feat: implement Agent Board command center (issue #165 Phase 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,16 @@
 
 GOLANGCI_LINT_VERSION := v2.12.2
 
+# Resolve the exact path `go install` places golangci-lint at (GOBIN if set,
+# otherwise $GOPATH/bin), and always invoke that path explicitly rather than
+# a bare `golangci-lint` from $PATH. A bare invocation can silently resolve
+# to an unrelated, unpinned golangci-lint earlier on $PATH (e.g. one
+# preinstalled system-wide) even after this file's own install step just
+# put the correct pinned version at $GOBIN/$GOPATH/bin — the install would
+# succeed and the very next lint run would still lint with the wrong
+# binary. Pinning the invocation path removes that ambiguity entirely.
+GOLANGCI_LINT_BIN := $(shell bin="$$(go env GOBIN)"; if [ -z "$$bin" ]; then bin="$$(go env GOPATH)/bin"; fi; echo "$$bin")/golangci-lint
+
 # ── Dependencies ──────────────────────────────────────────────────────────────
 
 install-deps: lint-go-deps install-hooks
@@ -87,17 +97,17 @@ lint: lint-go lint-frontend
 
 lint-go-deps:
 	@expected_version="$$(printf '%s' '$(GOLANGCI_LINT_VERSION)' | sed 's/^v//')"; \
-	current_version="$$(command -v golangci-lint >/dev/null 2>&1 && golangci-lint --version 2>/dev/null | awk 'NR==1 {print $$4; exit}' || true)"; \
+	current_version="$$(test -x '$(GOLANGCI_LINT_BIN)' && '$(GOLANGCI_LINT_BIN)' --version 2>/dev/null | awk 'NR==1 {print $$4; exit}' || true)"; \
 	if [ "$$current_version" = "$$expected_version" ]; then \
 	  :; \
 	else \
-	  echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)"; \
+	  echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(GOLANGCI_LINT_BIN)"; \
 	  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	fi
 
 lint-go: fmt-check-go lint-go-deps
 	go vet ./...
-	golangci-lint run ./...
+	'$(GOLANGCI_LINT_BIN)' run ./...
 
 lint-frontend:
 	cd frontend && npx tsc --noEmit

--- a/board_mcp_server.go
+++ b/board_mcp_server.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"panemux/internal/boardmcp"
+)
+
+const (
+	envBoardMCPBaseURL = "PANEMUX_BOARD_BASE_URL"
+	envBoardMCPToken   = "PANEMUX_BOARD_TOKEN" //nolint:gosec // G101: an env var name, not a credential value
+)
+
+// runBoardMCPServer implements the panemux `__board-mcp-server` hidden
+// subcommand: a stdio MCP server exposing the three board tools, backed by
+// an HTTP client hitting panemux's own loopback REST API. See
+// docs/agent-board.md's Command center section for why this re-invokes the
+// panemux binary itself as the command center's MCP server rather than
+// starting a second listening process — the subprocess speaks MCP over
+// stdio to whichever `claude -p` process spawned it and is never itself
+// reachable over the network.
+func runBoardMCPServer(ctx context.Context, getenv func(string) string, stdin io.Reader, stdout io.Writer) error {
+	baseURL := getenv(envBoardMCPBaseURL)
+	if baseURL == "" {
+		return fmt.Errorf("%s is not set", envBoardMCPBaseURL)
+	}
+	token := getenv(envBoardMCPToken)
+	if token == "" {
+		return fmt.Errorf("%s is not set", envBoardMCPToken)
+	}
+
+	client := boardmcp.NewHTTPBoardAPIClient(baseURL, token)
+	if err := boardmcp.NewServer(client).Serve(ctx, stdin, stdout); err != nil {
+		return fmt.Errorf("serving board mcp: %w", err)
+	}
+	return nil
+}

--- a/board_mcp_server_test.go
+++ b/board_mcp_server_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func fakeGetenv(values map[string]string) func(string) string {
+	return func(key string) string { return values[key] }
+}
+
+func TestRunBoardMCPServerMissingBaseURLReturnsError(t *testing.T) {
+	err := runBoardMCPServer(context.Background(), fakeGetenv(map[string]string{
+		envBoardMCPToken: "tok",
+	}), strings.NewReader(""), &bytes.Buffer{})
+
+	if err == nil {
+		t.Fatal("expected an error when PANEMUX_BOARD_BASE_URL is unset")
+	}
+}
+
+func TestRunBoardMCPServerMissingTokenReturnsError(t *testing.T) {
+	err := runBoardMCPServer(context.Background(), fakeGetenv(map[string]string{
+		envBoardMCPBaseURL: "http://127.0.0.1:8080",
+	}), strings.NewReader(""), &bytes.Buffer{})
+
+	if err == nil {
+		t.Fatal("expected an error when PANEMUX_BOARD_TOKEN is unset")
+	}
+}
+
+func TestRunBoardMCPServerServesInitializeRequest(t *testing.T) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n")
+	var stdout bytes.Buffer
+
+	err := runBoardMCPServer(context.Background(), fakeGetenv(map[string]string{
+		envBoardMCPBaseURL: "http://127.0.0.1:1",
+		envBoardMCPToken:   "tok",
+	}), stdin, &stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"protocolVersion"`) {
+		t.Fatalf("expected an initialize response in stdout, got %q", stdout.String())
+	}
+}

--- a/command_center.go
+++ b/command_center.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	"panemux/internal/commandcenter"
@@ -65,14 +67,19 @@ func setupCommandCenter(cfg *config.Config) *commandcenter.Runner {
 // the configured host must be used as-is in that case.
 func commandCenterBaseURL(cfg *config.Config) string {
 	host := cfg.Server.Host
+	// net.Listen requires the wildcard IPv6 bind bracketed ("[::]") — a bare
+	// "::" is not itself a form it accepts — so a config value may arrive
+	// either way. Strip any pre-existing brackets before the wildcard/host
+	// checks below so both "::" and "[::]" are recognized identically, and
+	// so net.JoinHostPort (which adds its own brackets for any address
+	// containing a colon) never receives an already-bracketed host and
+	// double-brackets it.
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	switch host {
 	case "", "0.0.0.0":
 		host = "127.0.0.1"
 	case "::":
 		host = "::1"
 	}
-	if strings.Contains(host, ":") {
-		host = "[" + host + "]"
-	}
-	return fmt.Sprintf("http://%s:%d", host, cfg.Server.Port)
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(cfg.Server.Port))
 }

--- a/command_center.go
+++ b/command_center.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"panemux/internal/commandcenter"
 	"panemux/internal/config"
@@ -38,12 +39,7 @@ func setupCommandCenter(cfg *config.Config) *commandcenter.Runner {
 		return nil
 	}
 
-	// The command center's own claude -p subprocess always talks to
-	// loopback, regardless of what interface server.host binds to — it runs
-	// as a local subprocess on the same host panemux itself runs on, and
-	// 127.0.0.1 always reaches a service bound to any local interface,
-	// including a non-loopback server.host.
-	baseURL := fmt.Sprintf("http://127.0.0.1:%d", cfg.Server.Port)
+	baseURL := commandCenterBaseURL(cfg)
 	token := cfg.Server.AuthToken
 
 	return commandcenter.NewRunner(commandcenter.RunnerConfig{
@@ -58,4 +54,25 @@ func setupCommandCenter(cfg *config.Config) *commandcenter.Runner {
 			return commandcenter.BuildMCPConfig(execPath, baseURL, token)
 		},
 	})
+}
+
+// commandCenterBaseURL returns the URL the command center's own claude -p
+// subprocess should call to reach panemux's own REST API. 127.0.0.1 (or its
+// IPv6 equivalent) is substituted only for a wildcard bind (empty,
+// "0.0.0.0", or "::") — a specific non-wildcard, non-loopback bind (e.g.
+// "192.168.1.50") is NOT reachable via 127.0.0.1, since binding to a
+// specific interface restricts the listening socket to that one address;
+// the configured host must be used as-is in that case.
+func commandCenterBaseURL(cfg *config.Config) string {
+	host := cfg.Server.Host
+	switch host {
+	case "", "0.0.0.0":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return fmt.Sprintf("http://%s:%d", host, cfg.Server.Port)
 }

--- a/command_center.go
+++ b/command_center.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"panemux/internal/commandcenter"
+	"panemux/internal/config"
+)
+
+// setupCommandCenter builds the command center's Runner when
+// command_center.enabled is true, wired with real session/history paths and
+// the current executable re-invoked as its own narrow MCP server (see
+// docs/agent-board.md's Command center section). It returns nil when
+// disabled, or when no auth token is configured — the command center's MCP
+// server authenticates every REST call it makes with that token, so running
+// without one would mean every query fails at the first tool call. server.New
+// treats a nil Runner as "don't register /ws/board-command at all," matching
+// agent board's own "additive, never load-bearing" bootstrap philosophy.
+func setupCommandCenter(cfg *config.Config) *commandcenter.Runner {
+	if !cfg.CommandCenter.Enabled {
+		return nil
+	}
+	if cfg.Server.AuthToken == "" {
+		log.Printf("Warning: command center: enabled but no server.auth_token is configured, skipping")
+		return nil
+	}
+
+	sessionPath, err := commandcenter.DefaultSessionFilePath()
+	if err != nil {
+		log.Printf("Warning: command center: resolving session file path: %v", err)
+		return nil
+	}
+	historyPath, err := commandcenter.DefaultHistoryFilePath()
+	if err != nil {
+		log.Printf("Warning: command center: resolving history file path: %v", err)
+		return nil
+	}
+
+	// The command center's own claude -p subprocess always talks to
+	// loopback, regardless of what interface server.host binds to — it runs
+	// as a local subprocess on the same host panemux itself runs on, and
+	// 127.0.0.1 always reaches a service bound to any local interface,
+	// including a non-loopback server.host.
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", cfg.Server.Port)
+	token := cfg.Server.AuthToken
+
+	return commandcenter.NewRunner(commandcenter.RunnerConfig{
+		SessionPath:  sessionPath,
+		HistoryPath:  historyPath,
+		AllowedTools: commandcenter.AllowedTools(),
+		BuildMCPConfig: func() (string, func(), error) {
+			execPath, err := os.Executable()
+			if err != nil {
+				return "", nil, fmt.Errorf("resolving panemux executable path: %w", err)
+			}
+			return commandcenter.BuildMCPConfig(execPath, baseURL, token)
+		},
+	})
+}

--- a/command_center.go
+++ b/command_center.go
@@ -65,6 +65,10 @@ func setupCommandCenter(cfg *config.Config) *commandcenter.Runner {
 // "192.168.1.50") is NOT reachable via 127.0.0.1, since binding to a
 // specific interface restricts the listening socket to that one address;
 // the configured host must be used as-is in that case.
+// loopbackIPv4 is the literal IPv4 loopback host string substituted for a
+// wildcard server.host bind.
+const loopbackIPv4 = "127.0.0.1"
+
 func commandCenterBaseURL(cfg *config.Config) string {
 	host := cfg.Server.Host
 	// net.Listen requires the wildcard IPv6 bind bracketed ("[::]") — a bare
@@ -77,7 +81,7 @@ func commandCenterBaseURL(cfg *config.Config) string {
 	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	switch host {
 	case "", "0.0.0.0":
-		host = "127.0.0.1"
+		host = loopbackIPv4
 	case "::":
 		host = "::1"
 	}

--- a/command_center_test.go
+++ b/command_center_test.go
@@ -64,6 +64,23 @@ func TestCommandCenterBaseURL(t *testing.T) {
 			want: "http://192.168.1.50:8080",
 		},
 		{name: "IPv6 literal host is bracketed", host: "::1", want: "http://[::1]:8080"},
+		{
+			// A bare "::" cannot actually be passed to net.Listen — the real
+			// bindable wildcard form is "[::]" — so this must resolve the
+			// same way the bare-"::" case above does, not fall through to
+			// the generic bracketing branch and become double-bracketed
+			// ("http://[[::]]:8080").
+			name: "bracketed IPv6 wildcard becomes IPv6 loopback, not double-bracketed",
+			host: "[::]",
+			want: "http://[::1]:8080",
+		},
+		{
+			// A host value that already arrives bracketed must not be
+			// bracketed a second time.
+			name: "already-bracketed IPv6 literal is not double-bracketed",
+			host: "[::1]",
+			want: "http://[::1]:8080",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/command_center_test.go
+++ b/command_center_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"panemux/internal/config"
+)
+
+func TestSetupCommandCenterDisabledReturnsNil(t *testing.T) {
+	cfg := &config.Config{
+		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: "tok"},
+		CommandCenter: config.CommandCenterConfig{Enabled: false},
+	}
+
+	runner := setupCommandCenter(cfg)
+
+	if runner != nil {
+		t.Fatal("expected nil runner when command_center.enabled is false")
+	}
+}
+
+func TestSetupCommandCenterEnabledWithTokenReturnsRunner(t *testing.T) {
+	cfg := &config.Config{
+		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: "tok"},
+		CommandCenter: config.CommandCenterConfig{Enabled: true},
+	}
+
+	runner := setupCommandCenter(cfg)
+
+	if runner == nil {
+		t.Fatal("expected a non-nil runner when command_center.enabled is true and a token is set")
+	}
+}
+
+func TestSetupCommandCenterEnabledWithoutTokenReturnsNil(t *testing.T) {
+	cfg := &config.Config{
+		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: ""},
+		CommandCenter: config.CommandCenterConfig{Enabled: true},
+	}
+
+	runner := setupCommandCenter(cfg)
+
+	if runner != nil {
+		t.Fatal("expected nil runner when no auth token is configured, even if command_center.enabled is true")
+	}
+}

--- a/command_center_test.go
+++ b/command_center_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestSetupCommandCenterDisabledReturnsNil(t *testing.T) {
 	cfg := &config.Config{
-		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: "tok"},
+		Server:        config.ServerConfig{Host: loopbackIPv4, Port: 8080, AuthToken: "tok"},
 		CommandCenter: config.CommandCenterConfig{Enabled: false},
 	}
 
@@ -21,7 +21,7 @@ func TestSetupCommandCenterDisabledReturnsNil(t *testing.T) {
 
 func TestSetupCommandCenterEnabledWithTokenReturnsRunner(t *testing.T) {
 	cfg := &config.Config{
-		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: "tok"},
+		Server:        config.ServerConfig{Host: loopbackIPv4, Port: 8080, AuthToken: "tok"},
 		CommandCenter: config.CommandCenterConfig{Enabled: true},
 	}
 
@@ -34,7 +34,7 @@ func TestSetupCommandCenterEnabledWithTokenReturnsRunner(t *testing.T) {
 
 func TestSetupCommandCenterEnabledWithoutTokenReturnsNil(t *testing.T) {
 	cfg := &config.Config{
-		Server:        config.ServerConfig{Host: "127.0.0.1", Port: 8080, AuthToken: ""},
+		Server:        config.ServerConfig{Host: loopbackIPv4, Port: 8080, AuthToken: ""},
 		CommandCenter: config.CommandCenterConfig{Enabled: true},
 	}
 
@@ -51,7 +51,7 @@ func TestCommandCenterBaseURL(t *testing.T) {
 		host string
 		want string
 	}{
-		{name: "loopback host used as-is", host: "127.0.0.1", want: "http://127.0.0.1:8080"},
+		{name: "loopback host used as-is", host: loopbackIPv4, want: "http://" + loopbackIPv4 + ":8080"},
 		{name: "empty wildcard becomes loopback", host: "", want: "http://127.0.0.1:8080"},
 		{name: "0.0.0.0 wildcard becomes loopback", host: "0.0.0.0", want: "http://127.0.0.1:8080"},
 		{name: "IPv6 wildcard becomes IPv6 loopback", host: "::", want: "http://[::1]:8080"},

--- a/command_center_test.go
+++ b/command_center_test.go
@@ -44,3 +44,34 @@ func TestSetupCommandCenterEnabledWithoutTokenReturnsNil(t *testing.T) {
 		t.Fatal("expected nil runner when no auth token is configured, even if command_center.enabled is true")
 	}
 }
+
+func TestCommandCenterBaseURL(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "loopback host used as-is", host: "127.0.0.1", want: "http://127.0.0.1:8080"},
+		{name: "empty wildcard becomes loopback", host: "", want: "http://127.0.0.1:8080"},
+		{name: "0.0.0.0 wildcard becomes loopback", host: "0.0.0.0", want: "http://127.0.0.1:8080"},
+		{name: "IPv6 wildcard becomes IPv6 loopback", host: "::", want: "http://[::1]:8080"},
+		{
+			// A specific non-wildcard, non-loopback bind is NOT reachable via
+			// 127.0.0.1 — binding a specific interface restricts the listening
+			// socket to that one address. Must use the configured host itself.
+			name: "specific non-loopback host used as-is, not substituted",
+			host: "192.168.1.50",
+			want: "http://192.168.1.50:8080",
+		},
+		{name: "IPv6 literal host is bracketed", host: "::1", want: "http://[::1]:8080"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Server: config.ServerConfig{Host: tc.host, Port: 8080}}
+			got := commandCenterBaseURL(cfg)
+			if got != tc.want {
+				t.Fatalf("commandCenterBaseURL(host=%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -1,17 +1,17 @@
 # Agent Board: Cross-Pane Claude Messaging and Status Aggregation
 
-> **Status: relay, REST status/messages/broadcast, and the PTY bootstrap flow are implemented;
-> command center is not yet usable.** The `internal/board` package's core types (`Row`, `Status`,
-> `AgmsgClient`, `BoardCache`, `ownSendLedger`, `LocalAgmsgClient`, `RemoteAgmsgClient`), the
+> **Status: Phase 1 (Board core) and Phase 2 (Command center) are both implemented.** The
+> `internal/board` package's core types (`Row`, `Status`, `AgmsgClient`, `BoardCache`,
+> `ownSendLedger`, `LocalAgmsgClient`, `RemoteAgmsgClient`), the
 > `BoardHostID`/`BoardExecutor`/`AgentTypeDetector` session capability interfaces, the
 > `agent_board`/`command_center`/`server.auth_token` config surface, the relay goroutine
 > (`internal/board/relay.go`, cursor persistence in `internal/board/cursor_store.go`), and the three
-> REST endpoints in [API additions](#api-additions) — `GET /api/board/status`, `GET
+> Phase 1 REST endpoints in [API additions](#api-additions) — `GET /api/board/status`, `GET
 > /api/board/messages`, `POST /api/board/broadcast` — are implemented and tested.
-> `bearerAuthMiddleware` is wired, but **only** onto the new `/api/board/*` sub-route, not onto any
-> pre-existing `/api/*` route or `/ws/{sessionID}` — see [Security model](#security-model) and
+> `bearerAuthMiddleware` is wired onto the `/api/board/*` sub-route, not onto any pre-existing
+> `/api/*` route or `/ws/{sessionID}` — see [Security model](#security-model) and
 > [security.md](security.md#auth-token-and-transport-encryption) for why those stay unauthenticated
-> for now (tracked as a separate follow-up issue, not part of this phase). `setupBoard` in `board.go`
+> (tracked as a separate follow-up issue, orthogonal to both phases). `setupBoard` in `board.go`
 > (`package main`) builds the `AgmsgClient`s and pane→host map from config at startup and wires both
 > the relay goroutine and the bootstrap watcher into `main.go`'s lifecycle. A remote host's
 > `RemoteAgmsgClient` is handed a `dynamicBoardExecutor` (`board.go`), which re-resolves a live
@@ -22,11 +22,28 @@
 > started, agmsg-detectable agent process (`session.AgentTypeDetector`, covering the six agmsg agent
 > types agmsg's own `type.conf` marks as process-detectable — see [`internal/session` capability
 > interfaces](#internal-session-capability-interfaces)) and writes a one-time onboarding instruction
-> into that pane's PTY; see [Bootstrap flow](#bootstrap-flow) for the full algorithm. Still
-> design-only: `/ws/board-command`, `GET /api/board/command/history`, and the command center itself —
-> none of that exists yet, so this document's [Command center](#command-center) section below is not
-> reachable through any current config or endpoint. Update this note (and its cross-links) again once
-> a later phase closes that gap.
+> into that pane's PTY; see [Bootstrap flow](#bootstrap-flow) for the full algorithm.
+>
+> **Phase 2 (Command center)** — `internal/commandcenter` (the `Runner` subprocess-per-query
+> lifecycle, `SessionState`/`HistoryEntry` persistence, `BuildMCPConfig`) and `internal/boardmcp` (the
+> narrow JSON-RPC-over-stdio MCP server exposing exactly `board_status`/`board_messages`/
+> `board_broadcast`, backed by an `HTTPBoardAPIClient` that calls panemux's own REST API) implement
+> the design in [Command center](#command-center) below as written, with one addition the original
+> design didn't anticipate: **`GET /api/session-token`** (deliberately unauthenticated, see
+> [API additions](#api-additions) and [docs/behavior.md](behavior.md#get-apisession-token)) so the
+> browser dashboard itself can learn the bearer token needed to authenticate `/api/board/*` and
+> `/ws/board-command` — nothing in the original design specified how the frontend, as opposed to the
+> command center subprocess, would ever learn a token that may have been randomly generated on first
+> run. `setupCommandCenter` in `command_center.go` (`package main`) builds the `Runner` when
+> `command_center.enabled` is true and a `server.auth_token` is configured, wiring it into
+> `server.New` alongside the board cache/relay; `/ws/board-command` is registered only when a `Runner`
+> is present, so a disabled command center leaves that route entirely absent (a plain `404`) rather
+> than reachable-but-erroring. `panemux __board-mcp-server` (`board_mcp_server.go`, `package main`) is
+> the hidden subcommand the command center's own `claude -p` subprocess re-invokes as its MCP server,
+> per [Process lifecycle](#process-lifecycle) below. The Spotlight palette (`CommandPalette.tsx`) and
+> persistent history panel (`CommandHistoryPanel.tsx`) are implemented per
+> [ui-design.md's Agent Board UI section](ui-design.md#agent-board-ui-planned), including the
+> concrete decisions that section originally deferred to implementation time.
 
 ## Purpose
 
@@ -1041,17 +1058,25 @@ flow still applies.
 
 ### UI
 
-- A global keyboard shortcut opens a Spotlight-style modal palette (exact binding to be decided at
-  implementation time, avoiding conflicts with OS-level shortcuts and existing terminal bindings).
+- `Cmd/Ctrl+Shift+K` opens a Spotlight-style modal palette (`CommandPalette.tsx`), registered on the
+  keydown capture phase so it reaches the handler even when a terminal pane currently has focus.
+  Plain `Cmd/Ctrl+K` was deliberately not used: it's already bound in many shells/readline setups a
+  terminal pane could be running, and would be swallowed as literal pane input rather than reaching
+  the browser as a shortcut.
 - The palette shows recent history inline on open (via the history endpoint above) and streams the
-  live response as it's generated.
-- A separate, persistently accessible history panel (following the same UI pattern as the existing
-  workspace-summary overlay) exposes the same history outside the quick-palette flow, for scrolling
-  back further than what the palette shows inline.
+  live response turn-by-turn as it's generated, only opening its own `/ws/board-command` connection
+  while the palette itself is open.
+- A separate, persistently accessible history panel (`CommandHistoryPanel.tsx`, reachable via a small
+  "Command History" button) exposes the same history outside the quick-palette flow, for scrolling
+  back further than what the palette shows inline. It reads only the REST history endpoint — it needs
+  no WS connection of its own.
+- Both surfaces are gated on `command_center_enabled` from `GET /api/session-token`: neither the
+  keyboard shortcut nor the history button is wired up at all when the command center is disabled,
+  rather than being present but non-functional.
 
 See [ui-design.md's Agent Board UI section](ui-design.md#agent-board-ui-planned) for how these
-surfaces are meant to reuse this repository's existing dialog/overlay patterns and status vocabulary
-instead of introducing a parallel visual language.
+surfaces reuse this repository's existing dialog/overlay patterns and status vocabulary instead of
+introducing a parallel visual language.
 
 ### Scope, kept intentionally narrow for now
 
@@ -1062,23 +1087,26 @@ hypothetical future requirements.
 
 ## API additions
 
-The first three rows are implemented; see [docs/behavior.md](behavior.md#agent-board-rest-api) for
-exact request/response shapes and status codes. All three require the bearer token described in
-[Security model](#security-model), but — a deliberate, narrower choice than an earlier revision of
-this document specified — that gate today covers **only** `/api/board/*`, not the pre-existing
-`/api/*` routes or `/ws/{sessionID}`: nothing yet relies on the board endpoints (no frontend calls
-them), so gating them from day one costs nothing, while retrofitting auth onto the already-relied-
-upon unauthenticated routes is a separate, larger change with its own frontend work — see
-[security.md](security.md#auth-token-and-transport-encryption). The last two rows (command center)
-remain design-only.
+Every row is implemented; see [docs/behavior.md](behavior.md#agent-board-rest-api) for exact
+request/response shapes and status codes. Every `/api/board/*` endpoint requires the bearer token
+described in [Security model](#security-model), but — a deliberate, narrower choice than an earlier
+revision of this document specified — that gate covers **only** `/api/board/*`, not the pre-existing
+`/api/*` routes or `/ws/{sessionID}`: retrofitting auth onto the already-relied-upon unauthenticated
+routes is a separate, larger change with its own frontend work — see
+[security.md](security.md#auth-token-and-transport-encryption). `GET /api/session-token` is the one
+deliberate exception to "every `/api/board/*` endpoint requires the token" — see its own row below
+and [docs/behavior.md](behavior.md#get-apisession-token) for why. `WS /ws/board-command` is
+authenticated too, but via a WebSocket subprotocol rather than the `Authorization` header — see
+[docs/behavior.md](behavior.md#command-center-websocket-protocol).
 
 | Endpoint | Purpose |
 |---|---|
 | `GET /api/board/status` | A snapshot of panemux's in-memory status cache — no `AgmsgClient` call happens on this request (see [Architecture](#architecture)) |
 | `GET /api/board/messages?since=<seq>` | History feed for the dashboard UI. `<seq>` is `BoardCache`'s own panemux-local sequence number (see [Package layout](#package-layout)), not an agmsg-native `id` — those aren't comparable across hosts |
 | `POST /api/board/broadcast` | `{ "to": ["pane-a","pane-b"], "body": "..." }`; sends directly to each target's own host via `AgmsgClient` (never via PTY injection, so it is safe to send to a pane mid-turn); delivery to the pane is immediate, but the message appears in `GET /api/board/messages`' history only after the relay's next poll cycle reads it back — see [Known limitations](#known-limitations) |
-| `WS /ws/board-command` (design-only) | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
-| `GET /api/board/command/history` (design-only) | Command center's own captured conversation history — see [Command center](#command-center) |
+| `WS /ws/board-command` | Command center chat: client sends `{"prompt": "..."}`, server streams the headless Claude response — see [Command center](#command-center) |
+| `GET /api/board/command/history` | Command center's own captured conversation history — see [Command center](#command-center) |
+| `GET /api/session-token` | **Deliberately unauthenticated** — hands the browser dashboard the bearer token it needs to call every route above and open the WS connection, since there is no other way for the frontend's own JavaScript to learn a token that may have been randomly generated on first run. Not part of the original design; added because nothing in it specified how the browser itself (as opposed to the command center subprocess) would learn the token. Lives at `/api/session-token`, not `/api/board/session-token` — see [docs/behavior.md](behavior.md#get-apisession-token) for why that distinction is load-bearing, not stylistic. |
 
 ## Config additions
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -44,6 +44,18 @@
 > persistent history panel (`CommandHistoryPanel.tsx`) are implemented per
 > [ui-design.md's Agent Board UI section](ui-design.md#agent-board-ui-planned), including the
 > concrete decisions that section originally deferred to implementation time.
+>
+> **An adversarial review after the initial implementation found and fixed several real bugs,
+> including two verified live against the real `claude` CLI: the subprocess argument construction let
+> a `-`-prefixed prompt be parsed as a CLI flag, and separately made every ordinary (non-flag) prompt
+> fail outright due to a variadic-flag argv bug — meaning the command center had never actually
+> completed a successful query before the fix.** See
+> [security.md's Command center subprocess execution](security.md#command-center-subprocess-execution)
+> for the full detail and how each was verified, and
+> [security.md's Auth token and transport encryption](security.md#auth-token-and-transport-encryption)
+> for a related fix to `GET /api/session-token`'s own guard (it does not rely on CORS, contrary to an
+> earlier revision of that section). A live, end-to-end query through the real browser → WS → Runner →
+> real `claude` subprocess stack was used to confirm the fix, not just the unit tests.
 
 ## Purpose
 
@@ -1025,9 +1037,16 @@ tradeoff (see [Known limitations](#known-limitations)), not a claim of a race-fr
   avoids for a feature kept to [one session per instance](#scope-kept-intentionally-narrow-for-now).
 - **Failure modes.** A subprocess that exits non-zero, emits malformed `stream-json`, or times out
   surfaces as an explicit error frame on the WS connection — never a silently empty response, so the
-  frontend can distinguish "no output yet" from "the query failed." A failed query never corrupts
-  `--resume` continuity for the next one: the persisted session id is replaced only by a fresh
-  first-run capture, never derived from a failed query's absent or partial output.
+  frontend can distinguish "no output yet" from "the query failed." The timeout is a real, enforced
+  `context.WithTimeout` wrapping the subprocess's own context
+  (`commandcenter.RunnerConfig.QueryTimeout`, default 5 minutes) — not merely aspirational: the WS
+  handler's own request context comes from an already-hijacked HTTP connection, which the standard
+  library never cancels on client disconnect, so this timeout is what actually bounds a hung or
+  abandoned query's lifetime. A failed query never corrupts `--resume` continuity for the next one:
+  the persisted session id is replaced only by a fresh first-run capture, never derived from a failed
+  query's absent or partial output — and a `--resume`d query that itself fails clears the stale
+  session id it was resuming, so a `claude`-side session that no longer exists (e.g. the operator
+  cleared `~/.claude`) doesn't leave every future query retrying the same dead id forever.
 
 ### Authorization
 

--- a/docs/agent-board.md
+++ b/docs/agent-board.md
@@ -213,6 +213,7 @@ flowchart TB
         Relay["Relay goroutine<br/>polls agmsg every few seconds"]
         Cache[("BoardCache<br/>in-memory, panemux-owned")]
         CmdCenter["Command center<br/>claude -p --resume (per query)"]
+        McpServer["panemux __board-mcp-server<br/>(claude's own MCP child process)"]
         LocalAgmsg[("Local agmsg<br/>(optional install)")]
     end
 
@@ -230,7 +231,8 @@ flowchart TB
     Server --> Relay
     Server --> CmdCenter
     Server --> Cache
-    CmdCenter -->|"REST, loopback<br/>same endpoints Browser uses"| Server
+    CmdCenter -->|"--mcp-config child process<br/>MCP tool calls, stdio JSON-RPC"| McpServer
+    McpServer -->|"REST, loopback<br/>same endpoints Browser uses"| Server
     Relay --> Cache
     Relay -->|"api.sh / send.sh --force"| LocalAgmsg
     Relay -->|"SSH exec channel<br/>api.sh / send.sh"| AgmsgA
@@ -243,6 +245,11 @@ Every host in this picture is either the one host panemux itself runs on, or a h
 ever reaches through an SSH exec channel it already holds for that pane's session — never a host
 panemux is installed on. See [Local vs remote resource
 placement](#local-vs-remote-resource-placement) for that constraint in more detail.
+
+The command center's own REST call is made by `McpServer` (`panemux __board-mcp-server`,
+`internal/boardmcp`'s `Server` over stdio JSON-RPC) on the LLM's behalf, never by `CmdCenter`
+(the `claude -p` subprocess) directly — see [Command center](#command-center)'s "Permissions"
+subsection for why an MCP tool, not a `Bash`+`curl` call, is what's allow-listed.
 
 ### Responsibility boundaries
 
@@ -259,11 +266,13 @@ flowchart TB
         BoardCache[("Status + history cache<br/>in-memory, panemux-owned")]
         Relay["Relay goroutine<br/>polls agmsg every few seconds"]
         CmdCenter["Command center<br/>claude -p --resume"]
+        McpServer["__board-mcp-server<br/>claude's own MCP child process"]
         AgmsgClient["AgmsgClient<br/>the only caller of agmsg's scripts"]
 
         AuthAPI -->|"GET /api/board/status, /messages"| BoardCache
         AuthAPI --> CmdCenter
-        CmdCenter -->|"POST /api/board/broadcast<br/>(same path a browser request takes)"| AuthAPI
+        CmdCenter -->|"MCP tool calls<br/>stdio JSON-RPC"| McpServer
+        McpServer -->|"POST /api/board/broadcast<br/>(same path a browser request takes)"| AuthAPI
         Relay -->|"writes status and history"| BoardCache
         Relay --> AgmsgClient
     end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ Optional capability interfaces extend the base `Session` contract without breaki
 - `CWDGetter` — implemented by `LocalSession` and `SSHSession`; returns the live working directory of the running shell. `LocalSession` reads it via `lsof` (macOS) or `/proc/<pid>/cwd` (Linux). `SSHSession` runs `pwd` over a new exec channel on the existing SSH connection.
 - `SSHConnNamer` — implemented by `SSHSession`; returns the panemux connection alias used when building the `code --remote ssh-remote+<host>` command.
 
-### `internal/board` (relay, REST status/messages/broadcast, and bootstrap implemented; command center still planned)
+### `internal/board`, `internal/commandcenter`, `internal/boardmcp` (Phase 1 board core and Phase 2 command center both implemented)
 
 A package that replaces transcript-based Claude activity inference with a self-reported channel:
 panes report status (including branch/PR/cwd, gathered by the agent's own `git`/`gh` calls rather
@@ -108,19 +108,25 @@ agent process and writes a one-time onboarding instruction into that pane's PTY 
 `Session.Write` path used for real terminal input) — see [agent-board.md's Bootstrap
 flow](agent-board.md#bootstrap-flow) for the full detection/debounce/persistence algorithm.
 
-Not yet implemented: the `/ws/board-command` WS endpoint, `GET /api/board/command/history`, and the
-command center itself.
+Also implemented: the **command center** — a single headless `claude -p --resume` subprocess,
+invoked per query by `internal/commandcenter`'s `Runner` (`SessionState`/`HistoryEntry`
+persistence, `BuildMCPConfig`), that reads and writes the board exclusively through panemux's own
+authenticated REST API, never agmsg directly. It never calls agmsg's scripts itself — `internal/board`
+stays the only code in panemux that does — because the subprocess is instead pointed at a narrow,
+purpose-built MCP server, `internal/boardmcp`'s `Server`, exposing exactly `board_status`/
+`board_messages`/`board_broadcast` as MCP tools backed by an `HTTPBoardAPIClient` that calls the same
+REST endpoints the browser dashboard uses. `panemux __board-mcp-server` (`board_mcp_server.go`,
+`package main`) is the hidden subcommand the `claude -p` subprocess re-invokes as that MCP server's
+child process, per its own `--mcp-config`; the LLM itself never composes the HTTP call or a shell
+invocation. `/ws/board-command` (streaming) and `GET /api/board/command/history` are its REST/WS
+surface; `setupCommandCenter` in `command_center.go` (`package main`) wires the `Runner` into
+`server.New` when `command_center.enabled` is true and a `server.auth_token` is configured. This is a
+substantial, independently-tested part of the design's own scope (its own process lifecycle,
+permission model, and streaming API), not a minor addendum to the messaging/relay piece described
+above.
 
-The same design also specifies a **command center**: a single headless `claude -p --resume`
-subprocess, invoked per query, that reads and writes the board exclusively through panemux's own
-authenticated REST API (never agmsg directly) via a narrow, purpose-built MCP server panemux
-provides — so `internal/board` stays the only code that ever calls agmsg's scripts even though the
-command center is a second, independent consumer of the board's data. This is a substantial part of
-the design's own scope (its own process lifecycle, permission model, and streaming API), not a minor
-addendum to the messaging/relay piece described above.
-
-Full design and rationale for both pieces live in [agent-board.md](agent-board.md); do not treat
-that document's API/config surface as implemented until its status note says so.
+Full design and rationale for both pieces live in [agent-board.md](agent-board.md), whose status
+note confirms both Phase 1 (board core) and Phase 2 (command center) are implemented.
 
 ### `internal/api`
 
@@ -368,4 +374,4 @@ Architecture-level security summary:
 - All workspace panes are started at backend startup, including panes in inactive workspaces. This keeps tab switching fast and preserves terminal state, at the cost of using resources for hidden workspaces.
 - Dynamic session creation exists, but current UI behavior mainly creates new local panes; this is not yet a full remote session orchestration product.
 - The implemented `internal/board` cross-host relay (see [agent-board.md](agent-board.md)) makes panemux a persistent relay for agent-to-agent messages between hosts it cannot make talk to each other directly, closer to a TURN server than a STUN server: panemux stays in the data path for the life of the exchange rather than helping two hosts connect directly and stepping aside, and it sees each relayed message as plaintext in process memory between the two encrypted SSH hops.
-- The still-planned command center design spawns a `claude -p` subprocess per query rather than keeping one warm — simpler process lifecycle and no persistent extra process, at the cost of response latency that includes subprocess startup on every query (see [agent-board.md's Process lifecycle](agent-board.md#process-lifecycle)).
+- The command center spawns a `claude -p` subprocess per query rather than keeping one warm — simpler process lifecycle and no persistent extra process, at the cost of response latency that includes subprocess startup on every query (see [agent-board.md's Process lifecycle](agent-board.md#process-lifecycle)).

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -332,11 +332,39 @@ Returns display preferences such as header/status-bar visibility.
 ## Agent Board REST API
 
 Full design and rationale live in [agent-board.md](agent-board.md); this section documents only the
-request/response shapes and status codes of what is actually implemented today. Unlike every route
-above, every endpoint in this section requires `Authorization: Bearer <server.auth_token>` — see
+request/response shapes and status codes of what is actually implemented today. Every `/api/board/*`
+endpoint in this section requires `Authorization: Bearer <server.auth_token>` — see
 [security.md](security.md#auth-token-and-transport-encryption). A missing or incorrect token returns
-`401` before the handler runs. `/ws/board-command` and `GET /api/board/command/history` are not
-implemented yet and are not documented here — see [agent-board.md](agent-board.md)'s status note.
+`401` before the handler runs. The one exception is `GET /api/session-token`, documented in its own
+subsection below, which is deliberately unauthenticated.
+
+### `GET /api/session-token`
+
+Returns the bearer token the browser dashboard needs to authenticate every other `/api/board/*`
+request and the `/ws/board-command` connection — there is no other way for the frontend's own
+JavaScript to learn a token that may have been randomly generated on first run (see
+`config.Config.EnsureAuthToken`, [security.md](security.md#auth-token-and-transport-encryption)) and
+is never sent to the browser any other way. **This endpoint is deliberately not behind
+`bearerAuthMiddleware`** — nothing could bootstrap the token without already knowing it otherwise —
+and relies instead on the same protection every other pre-existing, unauthenticated `/api/*` route
+already relies on: the server's CORS policy only lets a loopback origin read a cross-origin response
+body at all (see `corsMiddleware`/`isLocalhostOrigin` in `internal/server`), and the operator's own
+host is already the trust boundary for those routes.
+
+Response:
+
+```json
+{ "token": "a1b2c3...", "command_center_enabled": true }
+```
+
+- `200`: always — there is no failure mode for this handler beyond the server not running at all.
+
+Note this route lives at `/api/session-token`, not under `/api/board/`, despite belonging
+conceptually to Agent Board: chi routes any path starting with `/api/board/` into the
+`bearerAuthMiddleware`-wrapped sub-router regardless of where else a handler for that literal path is
+registered, so a route literally named `/api/board/session-token` would always require the token it
+exists to hand out. This is not a stylistic choice — an earlier revision of this endpoint lived at
+that path and was silently caught by the auth middleware it was supposed to bypass.
 
 **Bootstrap flow** (not a REST/WS endpoint — a background behavior). For every pane with
 `agent_board.enabled: true`, panemux polls every 5s for a live, agmsg-detectable coding-agent
@@ -425,6 +453,64 @@ Request body:
   `{ "error": "...", "delivered": ["pane-a"] }` — the pane IDs successfully delivered to before the
   failure — so the caller can tell which panes to avoid re-sending to on retry.
 - `200`: `{ "delivered": ["pane-a", "pane-b"] }`, the pane IDs the broadcast actually reached
+
+### `GET /api/board/command/history`
+
+Returns the command center's own captured turn-by-turn conversation history — read directly from a
+local file the WS handler (below) appends to while streaming a query's output, never re-derived from
+Claude Code's transcript after the fact. Requires the bearer token like every other route in this
+section.
+
+Response:
+
+```json
+{
+  "entries": [
+    { "at": "2026-08-10T12:00:00Z", "raw": { "type": "system", "subtype": "init", "session_id": "abc" } },
+    { "at": "2026-08-10T12:00:03Z", "raw": { "type": "result", "result": "..." } }
+  ]
+}
+```
+
+`raw` is exactly one line of the command center subprocess's own `--output-format=stream-json`
+output, unmodified. There is no pagination; the whole captured history is returned every time.
+
+- `200`: entries returned (`"entries":[]` when the command center has never run or `command_center`
+  is disabled — an empty or missing history file is not an error)
+- `500`: the history file exists but could not be read (a genuinely corrupt file, not the ordinary
+  missing-file case above)
+
+## Command Center WebSocket Protocol
+
+Endpoint: `GET /ws/board-command` — the Spotlight palette's chat connection. Full design lives in
+[agent-board.md](agent-board.md#command-center).
+
+**Authentication is different from every other route on this page.** Browsers cannot set an
+`Authorization` header on a WebSocket upgrade request, so the token instead travels as a WebSocket
+subprotocol: the client dials with `new WebSocket(url, [token])`, and the server reads it from the
+`Sec-WebSocket-Protocol` request header, comparing it to `server.auth_token` in constant time. A
+missing or incorrect value returns `401` and the upgrade never happens. This is a deliberate choice
+over a `?token=...` query parameter, which would leak the token into server access logs, browser
+history, and same-origin `Referer` headers. On success the server echoes the same value back in its
+own `Sec-WebSocket-Protocol` response header, completing the handshake per the WebSocket spec.
+
+Once connected, the client may send any number of prompts sequentially over the same connection:
+
+- client → server (text frame): `{"prompt": "..."}`
+- server → client (text frames), one of:
+  - `{"type":"line","raw":{...}}` — one raw `--output-format=stream-json` line from the command
+    center subprocess, forwarded as it arrives
+  - `{"type":"error","message":"..."}` — the query failed (non-zero exit, malformed stream-json
+    output, or a context cancellation/timeout); always the last frame for that query
+  - `{"type":"done"}` — the query finished successfully; always the last frame for that query
+  - `{"type":"busy"}` — a query was already in flight against the command center's single session
+    (see [agent-board.md's Concurrency](agent-board.md#process-lifecycle)); the new prompt was
+    rejected outright, not queued
+
+A client that disconnects mid-query does not stop the underlying subprocess or corrupt the next
+query's `--resume` continuity — the server keeps draining (but no longer forwarding) the query's
+remaining output so the subprocess is never left blocked, and the command center's own busy state is
+released normally once it finishes.
 
 ## WebSocket Protocol
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -345,11 +345,14 @@ request and the `/ws/board-command` connection — there is no other way for the
 JavaScript to learn a token that may have been randomly generated on first run (see
 `config.Config.EnsureAuthToken`, [security.md](security.md#auth-token-and-transport-encryption)) and
 is never sent to the browser any other way. **This endpoint is deliberately not behind
-`bearerAuthMiddleware`** — nothing could bootstrap the token without already knowing it otherwise —
-and relies instead on the same protection every other pre-existing, unauthenticated `/api/*` route
-already relies on: the server's CORS policy only lets a loopback origin read a cross-origin response
-body at all (see `corsMiddleware`/`isLocalhostOrigin` in `internal/server`), and the operator's own
-host is already the trust boundary for those routes.
+`bearerAuthMiddleware`** — nothing could bootstrap the token without already knowing it otherwise.
+
+It is gated by its own, narrower check instead: the caller's `RemoteAddr` must be a loopback IP *and*
+its `Host` header must also name a loopback authority (`localhost`/`127.0.0.1`/`::1`, any port). Both
+are required — see [security.md's Auth token and transport
+encryption](security.md#auth-token-and-transport-encryption) for why RemoteAddr alone doesn't defend
+against DNS rebinding, and why relying on CORS here (an earlier revision of this document's claim) was
+wrong. A non-loopback `server.host` deployment cannot use this endpoint at all, by design.
 
 Response:
 
@@ -357,7 +360,8 @@ Response:
 { "token": "a1b2c3...", "command_center_enabled": true }
 ```
 
-- `200`: always — there is no failure mode for this handler beyond the server not running at all.
+- `403`: the caller failed the loopback RemoteAddr+Host check above
+- `200`: otherwise, always — there is no other failure mode for this handler
 
 Note this route lives at `/api/session-token`, not under `/api/board/`, despite belonging
 conceptually to Agent Board: chi routes any path starting with `/api/board/` into the
@@ -511,6 +515,14 @@ A client that disconnects mid-query does not stop the underlying subprocess or c
 query's `--resume` continuity — the server keeps draining (but no longer forwarding) the query's
 remaining output so the subprocess is never left blocked, and the command center's own busy state is
 released normally once it finishes.
+
+Two further protections back the "never blocked forever" guarantee above, both defensive: the
+subprocess's own context carries a 5-minute default timeout (`commandcenter.RunnerConfig.QueryTimeout`),
+so a hung or abandoned `claude` invocation is force-killed rather than running indefinitely even if
+nothing else notices it; and every server→client write carries its own 10-second write deadline, so a
+client that stops reading without closing its TCP connection (a sleeping laptop, a dropped network
+with no FIN) fails the write — and falls into the same drain-without-forwarding path described above —
+instead of blocking the server goroutine forever.
 
 ## WebSocket Protocol
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -524,6 +524,26 @@ client that stops reading without closing its TCP connection (a sleeping laptop,
 with no FIN) fails the write — and falls into the same drain-without-forwarding path described above —
 instead of blocking the server goroutine forever.
 
+**A query killed by the timeout above is not treated as a `--resume` rejection.** The client sees a
+distinct `{"type":"error","message":"claude query timed out after 5m0s"}` (or whatever
+`QueryTimeout` is configured to), and the command center's persisted session id is left untouched —
+running long says nothing about whether `claude` would still recognize that id on a fresh attempt.
+Only a genuine resume failure (the CLI's own non-zero exit when it no longer recognizes the id — e.g.
+the user cleared `~/.claude`, or the session was garbage collected) clears the persisted id, so it
+isn't retried forever; a timeout on an otherwise-healthy, still-resumable conversation never does.
+
+**A malformed `--output-format=stream-json` line cancels the subprocess immediately**, rather than
+waiting for the subprocess to exit on its own (which, for a wedged or misbehaving `claude` process,
+could otherwise hold the single-query busy flag for up to the full `QueryTimeout`). The client has
+already received the corresponding `{"type":"error",...}` frame by the time this happens.
+
+**The persisted `--resume` session id is validated before every use, not only when this Runner itself
+wrote it.** `--resume`'s value is optional in the claude CLI's own argument parser, so a value
+beginning with `-` would be parsed as a new CLI flag rather than a `--resume` value if passed through
+as-is. A persisted id that doesn't match `^[A-Za-z0-9][A-Za-z0-9._-]*$` (the shape of every id claude
+itself has ever been observed to emit) is treated exactly like no persisted id at all: the query runs
+without `--resume`, and whatever session id that fresh run captures is persisted in its place.
+
 ## WebSocket Protocol
 
 Endpoint: `GET /ws/{sessionID}`

--- a/docs/security.md
+++ b/docs/security.md
@@ -117,6 +117,35 @@ discipline `RunBoardCommand` already applies uniformly to every argument, board-
 `RunBoardCommand` call bootstrap itself makes; they are operator config or panemux's own fixed
 detection-table output either way, not external request data.
 
+### Command center subprocess execution
+
+`internal/commandcenter/runner.go`'s `Runner` is the one other place in this repository, besides
+`internal/session`, that calls `exec.Command`/`exec.CommandContext` on a value not fully known at
+compile time. Per this document's own [General Rules](#general-rules): the command name
+(`r.claudeBin`) is a hardcoded literal (`"claude"`) unless an operator explicitly overrides it via
+`RunnerConfig.ClaudeBin` — there is no code path that derives it from request data, environment
+variables, or anything else CodeQL would treat as tainted. The arguments after it are a mix of fixed
+literal flags (`-p`, `--output-format=stream-json`, `--verbose`), a `--resume <session-id>` pulled
+from `SessionState` (itself only ever written by `Runner` from a value `claude` itself reported in an
+earlier run — never client-supplied), a `--mcp-config <path>` pointing at a temp file `Runner` itself
+created, an `--allowedTools` list `commandcenter.AllowedTools()` computes from fixed string literals,
+and finally the user's free-text prompt as the last argument. None of this goes through a shell —
+`exec.CommandContext` passes each argument as a discrete argv element — so there is no shell-injection
+risk from the prompt regardless of its content, matching this document's existing rule that
+"[a]rguments after the command may be user-supplied only when the target binary cannot reinterpret
+them as commands": the `claude` CLI's own argument parser is the only thing that ever sees the prompt
+as anything other than an opaque string, and it is always the final positional argument, after every
+flag this call ever passes.
+
+The `PANEMUX_BOARD_TOKEN`/`PANEMUX_BOARD_BASE_URL` values the `claude -p` subprocess's own MCP-server
+child process reads never reach `Runner`'s own `exec.Command` argv at all — they are set in the MCP
+config file's `env` block (see "Auth token and transport encryption" below for that file's own
+handling), read by `panemux __board-mcp-server` via `os.Getenv` in `board_mcp_server.go`. This is not
+a violation of this document's "do not use `os.Getenv` values in flows that reach `exec.Command`"
+rule: `runBoardMCPServer` never calls `exec.Command` itself, it only makes outbound HTTP requests
+(`internal/boardmcp.HTTPBoardAPIClient`) — an entirely different sink with no shell/argv-reinterpretation
+risk to defend against.
+
 ### Auth token and transport encryption
 
 `internal/config`'s `ServerConfig.AuthToken` (`server.auth_token` in `config.yaml`) and the
@@ -132,14 +161,56 @@ proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
 [agent-board.md](agent-board.md#security-model) for the full rationale.
 
 `internal/server`'s constant-time bearer-token middleware (`bearerAuthMiddleware`, `internal/server/auth.go`)
-is implemented, unit-tested, and wired into `registerRoutes` — but **only** onto the new
-`r.Route("/api/board", ...)` sub-route (`GET /status`, `GET /messages`, `POST /broadcast`), not onto
-any pre-existing `/api/*` route or `/ws/{sessionID}`. Widening it to those routes without a matching
-frontend change would break every existing, currently-unauthenticated request, so that remains a
-separate, larger change. `internal/server/board_routes_test.go` covers this scoping as a regression:
-missing/incorrect token on `/api/board/*` is rejected with `401`, the correct token reaches `200`,
-and pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no `Authorization` header
-at all. See [agent-board.md](agent-board.md)'s status note.
+is implemented, unit-tested, and wired into `registerRoutes` — but **only** onto the
+`r.Route("/api/board", ...)` sub-route (`GET /status`, `GET /messages`, `POST /broadcast`, `GET
+/command/history`), not onto any pre-existing `/api/*` route or `/ws/{sessionID}`. Widening it to
+those routes without a matching frontend change would break every existing, currently-unauthenticated
+request, so that remains a separate, larger change. `internal/server/board_routes_test.go` covers this
+scoping as a regression: missing/incorrect token on `/api/board/*` is rejected with `401`, the correct
+token reaches `200`, and pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no
+`Authorization` header at all. See [agent-board.md](agent-board.md)'s status note.
+
+**`WS /ws/board-command` cannot use the `Authorization` header at all** — browsers do not allow a
+WebSocket upgrade request to carry arbitrary headers. `internal/ws/board_command.go`'s
+`BoardCommandHandler` instead reads the token from the `Sec-WebSocket-Protocol` request header (the
+client dials with `new WebSocket(url, [token])`), validated with the same
+`subtle.ConstantTimeCompare` discipline as `bearerAuthMiddleware`, and echoes the same value back in
+the response header on success, completing the WebSocket handshake per spec. **A `?token=...` query
+parameter was deliberately not used**: unlike a header, a query parameter is written into the
+server's own access logs (`middleware.Logger` logs the full request line for every request, including
+this one) and into the browser's navigation history if the WS URL were ever opened as a normal page,
+and would be replayed in the `Referer` header of any same-origin follow-up navigation — a subprotocol
+value has none of those leak paths. This route is registered in `internal/server/server.go` only when
+a `*commandcenter.Runner` is non-nil (`command_center.enabled: true` and a token configured); when
+disabled the route is absent entirely, not present-but-rejecting, so there is nothing there for an
+unauthenticated probe to even find.
+
+**`GET /api/session-token` is the one deliberate, unauthenticated exception**, and exists specifically
+to let the browser dashboard learn the token it needs for every route above — there is no other way
+for client-side JavaScript to learn a value that may have been randomly generated on first run. It
+relies on the same protection every other pre-existing unauthenticated `/api/*` route already relies
+on: `corsMiddleware`'s `isLocalhostOrigin` check only lets a loopback origin read a cross-origin
+response body at all, and the operator's own host is already the trust boundary for those routes. It
+is deliberately registered at `/api/session-token`, **not** `/api/board/session-token`: chi routes any
+path starting with `/api/board/` into the `bearerAuthMiddleware`-wrapped sub-router regardless of
+where else a handler for that literal path is registered — an earlier revision of this endpoint lived
+at that path and was silently caught by the very middleware it exists to bypass, discovered only by
+an end-to-end `curl` check against the real running server, not by any handler-level unit test (those
+construct their own flat test router and never exercise chi's actual mount-precedence behavior).
+`internal/server/board_routes_test.go`'s `TestServer_SessionTokenRoute_RemainsUnauthenticated` is a
+regression test against the real `server.New()`-constructed router specifically because a
+handler-level test would not have caught this class of bug.
+
+**The command center's own MCP config file is the one place this feature writes the bearer token to
+disk, deliberately temporarily.** `internal/commandcenter.BuildMCPConfig` writes a JSON file (mode
+`0600`, created via `os.CreateTemp` then explicitly `os.Chmod`'d) embedding the token as a
+`PANEMUX_BOARD_TOKEN` environment variable value for the `claude -p` subprocess's own MCP server
+child process (`panemux __board-mcp-server`) to read; the caller's `cleanup` func removes it once that
+subprocess has exited. This is a strictly smaller exposure than the existing `~/.config/panemux/token`
+file the token already lives in permanently — the temp file exists only for one query's subprocess
+lifetime and is never written to `~/.config/panemux/config.yaml` — but it is still a plaintext
+token-bearing file on disk, hence the explicit `0600` rather than relying on `os.CreateTemp`'s default
+mode.
 
 ## General Rules
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -248,6 +248,28 @@ network-reachable access, not to be handed out to it. An operator running panemu
 provision the frontend's token some other way (e.g. a reverse proxy that injects it); that mechanism
 does not exist yet and is tracked as a follow-up, not solved by this endpoint.
 
+**The RemoteAddr+Host loopback checks alone still have a gap: they trust `r.RemoteAddr` even when the
+request actually arrived through a reverse proxy**, and a proxy sitting on the loopback interface
+itself produces a genuinely loopback `RemoteAddr` for every request it forwards, no matter its real
+origin — the two checks above cannot distinguish "the browser dialed this box directly" from "a local
+proxy relayed someone else's request to this box." `GetBoardSessionToken` closes this with a third,
+`isProxiedRequest` check: any request carrying an `X-Forwarded-For`, `X-Real-IP`, or `Forwarded` header
+is rejected outright, on the theory that a direct loopback browser request never carries proxy
+metadata — only a proxy adds those headers. This is a fail-closed heuristic, not a guarantee: a proxy
+that strips or never sets any of these three headers still defeats it, and the accepted limitation
+above (no token-bootstrap path for a genuinely non-loopback `server.host`) already covers that
+residual case by design — an operator fronting panemux with such a proxy must provision the token some
+other way, the same as any other non-loopback deployment.
+
+**A `server.host` of `0.0.0.0` is explicitly treated as loopback-equivalent for the `r.Host` check.**
+`isLoopbackAuthority` accepts `"0.0.0.0"` alongside `localhost`/`127.0.0.1`/`::1`: a server bound to
+`0.0.0.0` listens on every interface including loopback, so a genuinely local browser's request often
+carries `Host: 0.0.0.0:<port>` (or the operator configured it that way) even though the connection is
+via loopback — rejecting that Host would have made the endpoint unusable for a common, otherwise-safe
+deployment shape. This does not widen what the endpoint accepts from the network: the `RemoteAddr`
+loopback check and the `isProxiedRequest` check above still gate every request the same way regardless
+of which loopback-equivalent Host string it presents.
+
 **This is a narrower fix than the broader DNS-rebinding exposure across this codebase.** Every other
 pre-existing unauthenticated `/api/*` route and `/ws/{sessionID}` (see below) still has no Host-header
 validation of its own — `checkOrigin` in `internal/ws/handler.go` allows any request with no `Origin`

--- a/docs/security.md
+++ b/docs/security.md
@@ -128,14 +128,39 @@ variables, or anything else CodeQL would treat as tainted. The arguments after i
 literal flags (`-p`, `--output-format=stream-json`, `--verbose`), a `--resume <session-id>` pulled
 from `SessionState` (itself only ever written by `Runner` from a value `claude` itself reported in an
 earlier run — never client-supplied), a `--mcp-config <path>` pointing at a temp file `Runner` itself
-created, an `--allowedTools` list `commandcenter.AllowedTools()` computes from fixed string literals,
-and finally the user's free-text prompt as the last argument. None of this goes through a shell —
-`exec.CommandContext` passes each argument as a discrete argv element — so there is no shell-injection
-risk from the prompt regardless of its content, matching this document's existing rule that
-"[a]rguments after the command may be user-supplied only when the target binary cannot reinterpret
-them as commands": the `claude` CLI's own argument parser is the only thing that ever sees the prompt
-as anything other than an opaque string, and it is always the final positional argument, after every
-flag this call ever passes.
+created, an `--allowedTools=<list>` value `commandcenter.AllowedTools()` computes from fixed string
+literals, and finally the user's free-text prompt as the last argument. None of this goes through a
+shell — `exec.CommandContext` passes each argument as a discrete argv element — so there is no
+shell-injection risk from the prompt regardless of its content.
+
+**Being the final positional argument does not, by itself, make the prompt safe — this document's
+own first draft of this section claimed exactly that, and the claim was wrong.** `buildArgs` in
+`internal/commandcenter/runner.go` was verified live against a real installed `claude` CLI (v2.1.226)
+to have two distinct, independently-reproduced bugs before the fix now in place:
+
+1. **Argument injection into the `claude` CLI's own parser.** A prompt beginning with `-` (e.g. a
+   user typing `--help`, or something far more consequential like a `--settings=<json>` payload
+   defining a malicious hook) was not treated as opaque prompt text — the CLI's own option parser
+   scans for flags anywhere in argv, not only before the first positional, so a `-`-prefixed prompt
+   was parsed as a flag. This was reproduced directly: passing `"--help"` as the trailing argument
+   printed the CLI's own help output instead of being sent as a prompt, and a `--settings` payload
+   defining a `SessionStart` hook reached and ran that hook. **The fix**: `buildArgs` now inserts a
+   literal `"--"` end-of-options marker immediately before the prompt, which the CLI's parser was
+   confirmed (live) to honor — everything after it is treated as a positional argument, never a flag,
+   regardless of its content.
+2. **`--allowedTools` is declared variadic** (`<tools...>`) by the CLI's own `--help` output, so
+   passing it and its value as two separate argv elements (`"--allowedTools", "a,b,c"`) let it
+   swallow the very next argv element too — which was the prompt, silently breaking every ordinary
+   query with `Input must be provided either through stdin or as a prompt argument when using
+   --print`, confirmed live. **The fix**: `buildArgs` now uses the `=` form
+   (`"--allowedTools=a,b,c"`) as a single argv element, which cannot be extended by a following one.
+
+Both fixes were verified together, live, end-to-end through the real `Runner`/WS/browser stack (not
+just the CLI in isolation) before being considered closed. `internal/commandcenter/runner_test.go`'s
+`TestRunnerBuildArgsShapeIsSafeAgainstArgumentInjection` pins the exact argv shape as a regression,
+since a fake `cmdRunner` cannot reproduce the real CLI's own argument-parsing behavior — it can only
+assert what argv panemux itself constructs, which is why this was caught by an adversarial review
+verifying claims against the real binary, not by the original test suite.
 
 The `PANEMUX_BOARD_TOKEN`/`PANEMUX_BOARD_BASE_URL` values the `claude -p` subprocess's own MCP-server
 child process reads never reach `Runner`'s own `exec.Command` argv at all — they are set in the MCP
@@ -187,11 +212,53 @@ unauthenticated probe to even find.
 
 **`GET /api/session-token` is the one deliberate, unauthenticated exception**, and exists specifically
 to let the browser dashboard learn the token it needs for every route above — there is no other way
-for client-side JavaScript to learn a value that may have been randomly generated on first run. It
-relies on the same protection every other pre-existing unauthenticated `/api/*` route already relies
-on: `corsMiddleware`'s `isLocalhostOrigin` check only lets a loopback origin read a cross-origin
-response body at all, and the operator's own host is already the trust boundary for those routes. It
-is deliberately registered at `/api/session-token`, **not** `/api/board/session-token`: chi routes any
+for client-side JavaScript to learn a value that may have been randomly generated on first run.
+
+**This endpoint does NOT rely on `corsMiddleware`/CORS for protection, despite an earlier revision of
+this document claiming exactly that.** That claim was wrong and was caught by an adversarial review,
+not by any test: CORS only controls whether a cross-origin *script* can read a response body — it
+never rejects the request from reaching the handler, and a non-browser client (`curl`, any process on
+the LAN) ignores CORS entirely. Since this token is the only thing gating every other
+`/api/board/*` route (see above) and `internal/config/validate.go`'s own non-loopback-requires-token
+rule explicitly permits `server.host` to be a non-loopback address as long as a token is set, a CORS-only
+guard would have handed the token to any LAN client that simply asked, in exactly the deployment shape
+the token exists to protect.
+
+`GetBoardSessionToken` (`internal/api/board.go`) instead checks two things directly against the
+request, neither of which a client fully controls the way it controls the `Origin` header CORS reads:
+
+1. **`r.RemoteAddr`'s IP must be loopback.** This is the check that actually restricts the endpoint to
+   the local machine — it rejects any client that genuinely isn't the box panemux runs on, including a
+   LAN client reaching a non-loopback `server.host`. Checked with `net.ParseIP(...).IsLoopback()`
+   against the net/http-reported socket peer address, not a header.
+2. **`r.Host` must also resolve to a loopback authority.** RemoteAddr alone is not enough: DNS
+   rebinding (a domain whose DNS answer changes to `127.0.0.1` after a browser's same-origin check
+   already passed) makes an attacker page's requests arrive with a genuinely loopback RemoteAddr — the
+   TCP connection really is local — while the Host header still carries the attacker's own domain,
+   since browsers send the navigation URL's original host, not the resolved IP. Only the Host check
+   catches that case; this was verified with a dedicated test
+   (`TestGetBoardSessionToken_DNSRebindingHost_Forbidden`) simulating exactly that header combination.
+
+**Accepted limitation, stated explicitly: a dashboard served from a genuinely non-loopback
+`server.host` can no longer bootstrap its own token through this endpoint at all**, since no real
+remote client can ever satisfy the loopback-RemoteAddr check. This is intentional, not an oversight —
+the alternative (allowing the endpoint to answer non-loopback requests) is exactly the exposure this
+whole guard exists to close, and the token's own purpose in that deployment shape is to gate
+network-reachable access, not to be handed out to it. An operator running panemux non-loopback must
+provision the frontend's token some other way (e.g. a reverse proxy that injects it); that mechanism
+does not exist yet and is tracked as a follow-up, not solved by this endpoint.
+
+**This is a narrower fix than the broader DNS-rebinding exposure across this codebase.** Every other
+pre-existing unauthenticated `/api/*` route and `/ws/{sessionID}` (see below) still has no Host-header
+validation of its own — `checkOrigin` in `internal/ws/handler.go` allows any request with no `Origin`
+header at all, and permits `u.Host == r.Host`, which is exactly the tautology DNS rebinding defeats,
+since the attacker's page and the rebound request both send the same (attacker-controlled) Host. The
+session-token endpoint's guard was added specifically because it is the single highest-value target
+(it hands out the credential to everything else), not because the broader gap across other routes has
+been closed — it has not. Extending Host-header validation to every route is tracked as a separate,
+larger follow-up, out of scope for the command center feature this guard was added alongside.
+
+It is deliberately registered at `/api/session-token`, **not** `/api/board/session-token`: chi routes any
 path starting with `/api/board/` into the `bearerAuthMiddleware`-wrapped sub-router regardless of
 where else a handler for that literal path is registered — an earlier revision of this endpoint lived
 at that path and was silently caught by the very middleware it exists to bypass, discovered only by

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,9 +99,10 @@ resolved to an absolute path by the `~` expansion step, itself derived from oper
 runtime request data. panemux only ever detects an existing agmsg installation — it never installs,
 updates, or otherwise manages agmsg on the operator's behalf, locally or remotely. The relay
 goroutine that drives this on a schedule (`internal/board/relay.go`), the bootstrap watcher
-(`bootstrapWatcher` in `bootstrap.go`, `package main`), and the `/api/board/*` REST surface
-(`GET /status`, `GET /messages`, `POST /broadcast`) are implemented — see
-[agent-board.md](agent-board.md)'s status note. The command center is not yet implemented.
+(`bootstrapWatcher` in `bootstrap.go`, `package main`), the `/api/board/*` REST surface
+(`GET /status`, `GET /messages`, `POST /broadcast`), and the command center (`internal/commandcenter`,
+`internal/boardmcp` — see "Command center subprocess execution" below) are all implemented — see
+[agent-board.md](agent-board.md)'s status note.
 
 **The bootstrap watcher's PTY write is not a command-execution sink and is out of scope for this
 document's `exec.Command`-focused rules above.** `bootstrapWatcher` writes a synthesized onboarding

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -245,27 +245,44 @@ Using separate colors avoids mixing "this needs your attention" with "you can dr
 
 ## Agent Board UI (planned)
 
-> **Status: design, not yet implemented.** This section only cross-links the UI-facing pieces of a
-> larger design; it does not add new interaction principles of its own. Full design lives in
-> [agent-board.md](agent-board.md); do not treat any of this as current behavior until that
-> document's status note says so.
+> **Status: the command center palette and history panel are implemented; the status dashboard is
+> still design-only.** Full design lives in [agent-board.md](agent-board.md). The section heading
+> keeps its historical "(planned)" suffix since the dashboard bullet below is still unimplemented —
+> update it once that lands too.
 
 Agent Board (see [agent-board.md](agent-board.md)) introduces two new UI surfaces, both layered on
 top of the principles above rather than replacing them:
 
 - A **dashboard** view of per-pane self-reported status (state, branch, PR, summary — see
-  [agent-board.md's Status self-report](agent-board.md#status-self-report-and-message-flow)),
-  intended to extend the existing workspace-bar/pane-card status vocabulary (**Integrated workspace
-  summaries** and **Workspace pane groups**, above) rather than introduce a competing status
-  language — connection-state dots, attention framing, and repo/branch/PR chrome should read the
-  same way in Agent Board's dashboard as they already do in the pane header and workspace bar.
-- A **Spotlight-style command palette** and **history panel** for the [command
-  center](agent-board.md#command-center), following this document's existing **Modal Dialogs**
-  pattern for the palette itself (a higher-friction, focused interaction that shouldn't be
-  compressed into inline chrome) and the existing overlay-panel pattern already used for the
-  workspace-summary overlay for the persistent history view.
+  [agent-board.md's Status self-report](agent-board.md#status-self-report-and-message-flow)) —
+  **still design-only.** It's intended to extend the existing workspace-bar/pane-card status
+  vocabulary (**Integrated workspace summaries** and **Workspace pane groups**, above) rather than
+  introduce a competing status language — connection-state dots, attention framing, and
+  repo/branch/PR chrome should read the same way in Agent Board's dashboard as they already do in
+  the pane header and workspace bar.
+- A **Spotlight-style command palette** (`CommandPalette.tsx`) and **history panel**
+  (`CommandHistoryPanel.tsx`) for the [command center](agent-board.md#command-center) —
+  **implemented.** The palette follows this document's existing **Modal Dialogs** pattern (a
+  higher-friction, focused interaction, not compressed into inline chrome): dark `#252526` panel,
+  `#444` border, backdrop click and `Escape` to dismiss, matching `AddSSHHostDialog`'s own styling
+  tokens rather than introducing new ones. The history panel follows the same overlay pattern as a
+  right-anchored sliding panel rather than a centered modal, since it's meant to stay open alongside
+  other work rather than demand focus the way the palette does.
 
-Concrete visual decisions (palette keybinding, color treatment, streaming-response layout, error
-presentation) are deferred to implementation time and belong in this document once they're made —
-this section exists so that work doesn't start from a blank page on cross-cutting concerns
-(status-language consistency, dialog/overlay pattern reuse) that are already settled here.
+Concrete decisions this section originally deferred to implementation time:
+
+- **Palette keybinding**: `Cmd/Ctrl+Shift+K`, not plain `Cmd/Ctrl+K` — the latter is already bound in
+  many shells/readline setups a terminal pane might be running, and would be captured as literal pane
+  input rather than reaching the browser as a global shortcut. Registered on the keydown capture
+  phase specifically so it still fires while a terminal pane has focus.
+  See [agent-board.md's UI subsection](agent-board.md#ui) for the full rationale.
+- **Color treatment**: reuses this document's existing dark palette exactly (`#252526` panels, `#444`
+  borders, `#d4d4d4` body text, `#4ec9b0` for the user's own prompt echo, `#f44747` for errors) — no
+  new colors were introduced for Agent Board.
+- **Streaming-response layout**: turn-based, not a single scrolling log — each submitted prompt opens
+  a new turn block showing the prompt followed by its streamed `stream-json` lines as they arrive,
+  an ellipsis while still in flight, and either nothing further (success) or a red error/busy line at
+  the end.
+- **Error presentation**: inline within the turn that failed (red text, same treatment as this
+  document's existing form-validation error styling), not a separate banner or toast — an error is
+  scoped to the one query that produced it, and the palette stays open and usable for the next prompt.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -89,6 +89,10 @@ vi.mock('./hooks/useGitInfo', () => ({
   useGitInfoSnapshotMap: mockUseGitInfoSnapshotMap,
 }))
 
+vi.mock('./hooks/useBoardSessionToken', () => ({
+  useBoardSessionToken: () => ({ token: '', commandCenterEnabled: false }),
+}))
+
 vi.mock('./hooks/usePaneSettings', () => ({
   usePaneSettings: () => ({
     isOpen: false,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,15 @@ import { SplitContainer, LayoutActionsContext } from './components/SplitContaine
 import { PaneSettingsDialog } from './components/PaneSettingsDialog'
 import { AddSSHHostDialog } from './components/AddSSHHostDialog'
 import { WorkspaceTabs } from './components/WorkspaceTabs'
+import { CommandPalette } from './components/CommandPalette'
+import { CommandHistoryPanel } from './components/CommandHistoryPanel'
 import { useLayout } from './hooks/useLayout'
 import { usePaneSettings } from './hooks/usePaneSettings'
 import { useWorkspaceAttentionMonitor } from './hooks/useWorkspaceAttentionMonitor'
 import { useBrowserNotificationPermission } from './hooks/useBrowserNotificationPermission'
 import { useSessionsOverview } from './hooks/useSessionsOverview'
 import { useGitInfoSnapshotMap } from './hooks/useGitInfo'
+import { useBoardSessionToken } from './hooks/useBoardSessionToken'
 import { DisplayConfig } from './types'
 import { TERMINAL_FONT_FAMILY } from './utils/fonts'
 import { findPaneById, generatePaneId, layoutContainsPane } from './utils/layoutTree'
@@ -51,6 +54,9 @@ export const App: React.FC = () => {
   const [movePaneError, setMovePaneError] = useState<string | null>(null)
   const [pendingFocusedPaneId, setPendingFocusedPaneId] = useState<string | null>(null)
   const sessionsById = useSessionsOverview(Boolean(workspaces))
+  const { token: boardToken, commandCenterEnabled } = useBoardSessionToken()
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false)
+  const [isCommandHistoryOpen, setIsCommandHistoryOpen] = useState(false)
 
   const paneMetadataByID = useMemo(() => {
     const metadata = new Map<string, { paneTitle: string; workspaceId: string; workspaceTitle: string }>()
@@ -190,6 +196,25 @@ export const App: React.FC = () => {
 
   useWorkspaceAttentionMonitor({ workspaces, maximizedPaneId, onAttention: notifyAttention })
   useBrowserNotificationPermission()
+
+  // Global command center palette shortcut: Cmd/Ctrl+Shift+K, deliberately
+  // not plain Cmd/Ctrl+K (already bound in many shells/readline setups and
+  // would collide with pane-local terminal input) — see docs/ui-design.md's
+  // Agent Board UI section. Registered on the capture phase so it reaches
+  // this handler even when a terminal pane (which owns its own keydown
+  // handling) currently has focus.
+  useEffect(() => {
+    if (!commandCenterEnabled) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const modifier = event.metaKey || event.ctrlKey
+      if (modifier && event.shiftKey && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        setIsCommandPaletteOpen((open) => !open)
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [commandCenterEnabled])
 
   const handleAddSSHHost = useCallback(async (host: SSHConfigHost) => {
     setIsAddSSHHostSaving(true)
@@ -477,6 +502,40 @@ export const App: React.FC = () => {
           saveError={addSSHHostError}
           onSave={handleAddSSHHost}
           onClose={() => setIsAddSSHHostOpen(false)}
+        />
+        {commandCenterEnabled && (
+          <button
+            type="button"
+            aria-label="Open command center history"
+            onClick={() => setIsCommandHistoryOpen(true)}
+            title="Command center history"
+            style={{
+              position: 'absolute',
+              bottom: 12,
+              right: 12,
+              zIndex: 20,
+              padding: '6px 10px',
+              backgroundColor: '#252526',
+              color: '#888',
+              border: '1px solid #444',
+              borderRadius: '4px',
+              fontFamily: TERMINAL_FONT_FAMILY,
+              fontSize: '11px',
+              cursor: 'pointer',
+            }}
+          >
+            Command History
+          </button>
+        )}
+        <CommandPalette
+          isOpen={isCommandPaletteOpen && commandCenterEnabled}
+          token={boardToken}
+          onClose={() => setIsCommandPaletteOpen(false)}
+        />
+        <CommandHistoryPanel
+          isOpen={isCommandHistoryOpen && commandCenterEnabled}
+          token={boardToken}
+          onClose={() => setIsCommandHistoryOpen(false)}
         />
       </div>
     </LayoutActionsContext.Provider>

--- a/frontend/src/components/CommandHistoryPanel.test.tsx
+++ b/frontend/src/components/CommandHistoryPanel.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CommandHistoryPanel } from './CommandHistoryPanel'
+
+describe('CommandHistoryPanel', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not render when closed', () => {
+    render(<CommandHistoryPanel isOpen={false} token="tok" onClose={vi.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('fetches history with the bearer token on open', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) } as Response)
+
+    render(<CommandHistoryPanel isOpen token="sekret" onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/board/command/history', {
+        headers: { Authorization: 'Bearer sekret' },
+      })
+    })
+  })
+
+  it('shows the empty state when there are no entries', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) } as Response)
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={vi.fn()} />)
+
+    expect(await screen.findByText('No history yet.')).toBeDefined()
+  })
+
+  it('renders each history entry', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        entries: [
+          { at: '2026-08-10T12:00:00Z', raw: { type: 'result', result: 'done' } },
+        ],
+      }),
+    } as Response)
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={vi.fn()} />)
+
+    expect(await screen.findByText(/"result":"done"/)).toBeDefined()
+  })
+
+  it('shows an error message when the request fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, status: 500, json: async () => ({}) } as Response)
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={vi.fn()} />)
+
+    expect(await screen.findByText('Failed to load history (500).')).toBeDefined()
+  })
+
+  it('closes on Escape', () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) } as Response)
+    const onClose = vi.fn()
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={onClose} />)
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes when clicking the close button', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) } as Response)
+    const onClose = vi.fn()
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={onClose} />)
+    fireEvent.click(await screen.findByLabelText('Close history panel'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes when clicking the overlay backdrop', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: async () => ({ entries: [] }) } as Response)
+    const onClose = vi.fn()
+
+    render(<CommandHistoryPanel isOpen token="tok" onClose={onClose} />)
+    fireEvent.click(await screen.findByRole('dialog'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/CommandHistoryPanel.tsx
+++ b/frontend/src/components/CommandHistoryPanel.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react'
+import { BoardCommandHistoryResponseSchema } from '../schemas'
+import type { BoardCommandHistoryEntry } from '../schemas'
+import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+
+interface CommandHistoryPanelProps {
+  isOpen: boolean
+  token: string
+  onClose: () => void
+}
+
+// CommandHistoryPanel is the persistently accessible history view for the
+// Agent Board command center — the same captured turn-by-turn record the
+// palette shows inline, but reachable outside the quick-palette flow for
+// scrolling back further. See docs/agent-board.md's Command center section
+// and docs/ui-design.md's Agent Board UI section (existing overlay-panel
+// pattern reused here, not a new visual language).
+export const CommandHistoryPanel: React.FC<CommandHistoryPanelProps> = ({ isOpen, token, onClose }) => {
+  const [entries, setEntries] = useState<BoardCommandHistoryEntry[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+    let cancelled = false
+    setError(null)
+    void (async () => {
+      try {
+        const res = await fetch('/api/board/command/history', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) {
+          if (!cancelled) setError(`Failed to load history (${res.status}).`)
+          return
+        }
+        const data = BoardCommandHistoryResponseSchema.parse(await res.json())
+        if (!cancelled) setEntries(data.entries)
+      } catch {
+        if (!cancelled) setError('Failed to load history.')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, token])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command center history"
+      style={overlayStyle}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div style={panelStyle}>
+        <div style={headerRowStyle}>
+          <span style={titleStyle}>Command Center History</span>
+          <button onClick={onClose} style={closeButtonStyle} aria-label="Close history panel">×</button>
+        </div>
+
+        <div style={bodyStyle}>
+          {error && <div style={errorStyle}>{error}</div>}
+          {!error && entries.length === 0 && <div style={emptyStyle}>No history yet.</div>}
+          {entries.map((entry, i) => (
+            <div key={i} style={entryStyle}>
+              <div style={timestampStyle}>{formatTimestamp(entry.at)}</div>
+              <div style={rawStyle}>{JSON.stringify(entry.raw)}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatTimestamp(at: string): string {
+  const date = new Date(at)
+  return Number.isNaN(date.getTime()) ? at : date.toLocaleString()
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  display: 'flex',
+  justifyContent: 'flex-end',
+  zIndex: 1150,
+}
+
+const panelStyle: React.CSSProperties = {
+  backgroundColor: '#252526',
+  borderLeft: '1px solid #444',
+  width: '420px',
+  maxWidth: 'calc(100vw - 32px)',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  boxSizing: 'border-box',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  color: '#d4d4d4',
+}
+
+const headerRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '12px 16px',
+  borderBottom: '1px solid #333',
+}
+
+const titleStyle: React.CSSProperties = { fontSize: '13px', fontWeight: 600, color: '#e0e0e0' }
+
+const closeButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: '#888',
+  fontSize: '18px',
+  lineHeight: 1,
+  cursor: 'pointer',
+}
+
+const bodyStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '12px 16px',
+  fontSize: '12px',
+}
+
+const emptyStyle: React.CSSProperties = { color: '#666' }
+
+const errorStyle: React.CSSProperties = { color: '#f44747' }
+
+const entryStyle: React.CSSProperties = { marginBottom: '10px' }
+
+const timestampStyle: React.CSSProperties = { color: '#666', fontSize: '11px', marginBottom: '2px' }
+
+const rawStyle: React.CSSProperties = { color: '#ccc', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }

--- a/frontend/src/components/CommandPalette.test.tsx
+++ b/frontend/src/components/CommandPalette.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { CommandPalette } from './CommandPalette'
+
+class MockWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  static instances: MockWebSocket[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  readyState = MockWebSocket.OPEN
+  url: string
+  protocols: string | string[] | undefined
+  sent: unknown[] = []
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url
+    this.protocols = protocols
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: unknown) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+}
+
+describe('CommandPalette', () => {
+  let originalWebSocket: typeof WebSocket
+
+  beforeEach(() => {
+    originalWebSocket = window.WebSocket
+    MockWebSocket.instances = []
+    window.WebSocket = MockWebSocket as unknown as typeof WebSocket
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries: [] }),
+    }))
+  })
+
+  afterEach(() => {
+    window.WebSocket = originalWebSocket
+    vi.unstubAllGlobals()
+  })
+
+  it('does not render when closed', () => {
+    render(<CommandPalette isOpen={false} token="tok" onClose={vi.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders the prompt input and header when open', () => {
+    render(<CommandPalette isOpen token="tok" onClose={vi.fn()} />)
+    expect(screen.getByRole('dialog')).toBeDefined()
+    expect(screen.getByLabelText('Command center prompt')).toBeDefined()
+  })
+
+  it('fetches recent history with the bearer token on open', async () => {
+    render(<CommandPalette isOpen token="sekret" onClose={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/board/command/history', {
+        headers: { Authorization: 'Bearer sekret' },
+      })
+    })
+  })
+
+  it('shows the empty state when there is no history or turns', async () => {
+    render(<CommandPalette isOpen token="tok" onClose={vi.fn()} />)
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    expect(screen.getByText('No recent activity.')).toBeDefined()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette isOpen token="tok" onClose={onClose} />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('closes when clicking the overlay backdrop', () => {
+    const onClose = vi.fn()
+    render(<CommandPalette isOpen token="tok" onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole('dialog'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('connects the WS with the token as subprotocol while open', () => {
+    render(<CommandPalette isOpen token="sekret" onClose={vi.fn()} />)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].protocols).toEqual(['sekret'])
+  })
+
+  it('submits a prompt over WS and clears the input', async () => {
+    render(<CommandPalette isOpen token="tok" onClose={vi.fn()} />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+
+    const input = screen.getByLabelText('Command center prompt') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'status please' } })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(ws.sent).toEqual([JSON.stringify({ prompt: 'status please' })])
+    expect(input.value).toBe('')
+    expect(await screen.findByText('> status please')).toBeDefined()
+  })
+
+  it('does not submit an empty prompt', () => {
+    render(<CommandPalette isOpen token="tok" onClose={vi.fn()} />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+
+    expect(ws.sent).toHaveLength(0)
+  })
+
+  it('renders a streamed error frame on the active turn', async () => {
+    render(<CommandPalette isOpen token="tok" onClose={vi.fn()} />)
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+
+    fireEvent.change(screen.getByLabelText('Command center prompt'), { target: { value: 'hi' } })
+    fireEvent.click(screen.getByRole('button', { name: /send/i }))
+    act(() => ws.simulateMessage({ type: 'error', message: 'claude exited with error: exit status 1' }))
+
+    expect(await screen.findByText('claude exited with error: exit status 1')).toBeDefined()
+  })
+})

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useBoardCommand } from '../hooks/useBoardCommand'
+import { BoardCommandHistoryResponseSchema } from '../schemas'
+import type { BoardCommandHistoryEntry } from '../schemas'
+import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
+
+interface CommandPaletteProps {
+  isOpen: boolean
+  token: string
+  onClose: () => void
+}
+
+const RECENT_HISTORY_LIMIT = 20
+
+// CommandPalette is the Spotlight-style modal for the Agent Board command
+// center, per docs/agent-board.md's Command center section and
+// docs/ui-design.md's Agent Board UI section (Modal Dialogs pattern reused
+// for the palette itself). It owns its own WS connection, open only while
+// the palette itself is open, and seeds itself with recent history on open
+// so a reopened palette isn't blank.
+export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, token, onClose }) => {
+  const { connected, turns, pending, sendPrompt } = useBoardCommand({ enabled: isOpen, token })
+  const [prompt, setPrompt] = useState('')
+  const [recentHistory, setRecentHistory] = useState<BoardCommandHistoryEntry[]>([])
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setPrompt('')
+      setRecentHistory([])
+      return
+    }
+    inputRef.current?.focus()
+
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/board/command/history', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) return
+        const data = BoardCommandHistoryResponseSchema.parse(await res.json())
+        if (!cancelled) setRecentHistory(data.entries.slice(-RECENT_HISTORY_LIMIT))
+      } catch {
+        // Best-effort inline history — the palette still works without it.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, token])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    const trimmed = prompt.trim()
+    if (!trimmed || pending || !connected) return
+    sendPrompt(trimmed)
+    setPrompt('')
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command center"
+      style={overlayStyle}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div style={paletteStyle}>
+        <div style={headerStyle}>Command Center{connected ? '' : ' (connecting…)'}</div>
+
+        <div style={historyStyle}>
+          {recentHistory.length === 0 && turns.length === 0 && (
+            <div style={emptyStyle}>No recent activity.</div>
+          )}
+          {recentHistory.map((entry, i) => (
+            <div key={`recent-${i}`} style={lineStyle}>{summarizeRaw(entry.raw)}</div>
+          ))}
+          {turns.map((turn) => (
+            <div key={turn.id} style={turnStyle}>
+              <div style={promptLineStyle}>&gt; {turn.prompt}</div>
+              {turn.lines.map((line, i) => (
+                <div key={i} style={lineStyle}>{summarizeRaw(line)}</div>
+              ))}
+              {turn.error && <div style={errorLineStyle}>{turn.error}</div>}
+              {turn.busy && <div style={errorLineStyle}>Command center is busy — try again shortly.</div>}
+              {!turn.done && <div style={lineStyle}>…</div>}
+            </div>
+          ))}
+        </div>
+
+        <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '8px' }}>
+          <input
+            ref={inputRef}
+            type="text"
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Ask the command center…"
+            style={inputStyle}
+            aria-label="Command center prompt"
+          />
+          <button type="submit" style={submitStyle} disabled={pending || !connected}>
+            {pending ? 'Sending…' : 'Send'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+// summarizeRaw renders one stream-json line as a single readable string.
+// This is deliberately simple — a small preview, not a full JSON viewer —
+// since the palette's own inline history is a "recent context" glance, and
+// the persistent history panel is where a user reviews the full record.
+function summarizeRaw(raw: unknown): string {
+  if (raw && typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.result === 'string') return obj.result
+    if (typeof obj.type === 'string') return `[${obj.type}]`
+  }
+  return JSON.stringify(raw)
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  paddingTop: '10vh',
+  zIndex: 1200,
+}
+
+const paletteStyle: React.CSSProperties = {
+  backgroundColor: '#252526',
+  border: '1px solid #444',
+  borderRadius: '6px',
+  padding: '16px 20px',
+  width: '560px',
+  maxWidth: 'calc(100vw - 32px)',
+  maxHeight: 'calc(80vh)',
+  display: 'flex',
+  flexDirection: 'column',
+  boxSizing: 'border-box',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  color: '#d4d4d4',
+}
+
+const headerStyle: React.CSSProperties = {
+  fontSize: '13px',
+  fontWeight: 600,
+  color: '#e0e0e0',
+  marginBottom: '10px',
+}
+
+const historyStyle: React.CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  marginBottom: '12px',
+  fontSize: '12px',
+  lineHeight: 1.5,
+  minHeight: '120px',
+  maxHeight: '50vh',
+}
+
+const emptyStyle: React.CSSProperties = { color: '#666' }
+
+const turnStyle: React.CSSProperties = { marginBottom: '10px' }
+
+const promptLineStyle: React.CSSProperties = { color: '#4ec9b0' }
+
+const lineStyle: React.CSSProperties = { color: '#ccc', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }
+
+const errorLineStyle: React.CSSProperties = { color: '#f44747' }
+
+const inputStyle: React.CSSProperties = {
+  flex: 1,
+  padding: '6px 10px',
+  backgroundColor: '#3c3c3c',
+  color: '#d4d4d4',
+  border: '1px solid #555',
+  borderRadius: '3px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '13px',
+  boxSizing: 'border-box',
+}
+
+const submitStyle: React.CSSProperties = {
+  padding: '6px 14px',
+  backgroundColor: '#0e639c',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '3px',
+  fontFamily: TERMINAL_FONT_FAMILY,
+  fontSize: '13px',
+  cursor: 'pointer',
+}

--- a/frontend/src/hooks/useBoardCommand.test.ts
+++ b/frontend/src/hooks/useBoardCommand.test.ts
@@ -1,0 +1,207 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useBoardCommand } from './useBoardCommand'
+
+class MockWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  static instances: MockWebSocket[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  readyState = MockWebSocket.OPEN
+  url: string
+  protocols: string | string[] | undefined
+  sent: unknown[] = []
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url
+    this.protocols = protocols
+    MockWebSocket.instances.push(this)
+  }
+
+  send(data: unknown) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+}
+
+describe('useBoardCommand', () => {
+  let originalWebSocket: typeof WebSocket
+
+  beforeEach(() => {
+    originalWebSocket = window.WebSocket
+    MockWebSocket.instances = []
+    window.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    window.WebSocket = originalWebSocket
+  })
+
+  it('does not connect when disabled', () => {
+    renderHook(() => useBoardCommand({ enabled: false, token: 'tok' }))
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('does not connect without a token', () => {
+    renderHook(() => useBoardCommand({ enabled: true, token: '' }))
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  it('connects with the token as a WS subprotocol', () => {
+    renderHook(() => useBoardCommand({ enabled: true, token: 'sekret' }))
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].protocols).toEqual(['sekret'])
+    expect(MockWebSocket.instances[0].url).toContain('/ws/board-command')
+  })
+
+  it('reflects connected state from ws open/close', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+
+    expect(result.current.connected).toBe(false)
+    act(() => ws.simulateOpen())
+    expect(result.current.connected).toBe(true)
+    act(() => ws.close())
+    expect(result.current.connected).toBe(false)
+  })
+
+  it('sendPrompt appends a pending turn and sends the prompt as JSON', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+
+    act(() => result.current.sendPrompt('hello'))
+
+    expect(result.current.turns).toHaveLength(1)
+    expect(result.current.turns[0]).toMatchObject({ prompt: 'hello', lines: [], done: false })
+    expect(result.current.pending).toBe(true)
+    expect(ws.sent).toEqual([JSON.stringify({ prompt: 'hello' })])
+  })
+
+  it('sendPrompt is a no-op when the socket is not open', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    ws.readyState = MockWebSocket.CONNECTING
+
+    act(() => result.current.sendPrompt('hello'))
+
+    expect(result.current.turns).toHaveLength(0)
+    expect(ws.sent).toHaveLength(0)
+  })
+
+  it('appends line frames to the last turn', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    act(() => ws.simulateMessage({ type: 'line', raw: { type: 'result' } }))
+
+    expect(result.current.turns[0].lines).toEqual([{ type: 'result' }])
+    expect(result.current.pending).toBe(true) // still pending after a line
+  })
+
+  it('marks the turn done and clears pending on a done frame', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    act(() => ws.simulateMessage({ type: 'done' }))
+
+    expect(result.current.turns[0].done).toBe(true)
+    expect(result.current.pending).toBe(false)
+  })
+
+  it('records an error frame on the turn and clears pending', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    act(() => ws.simulateMessage({ type: 'error', message: 'claude exited with error: exit status 1' }))
+
+    expect(result.current.turns[0]).toMatchObject({
+      error: 'claude exited with error: exit status 1',
+      done: true,
+    })
+    expect(result.current.pending).toBe(false)
+  })
+
+  it('records a busy frame on the turn and clears pending', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    act(() => ws.simulateMessage({ type: 'busy' }))
+
+    expect(result.current.turns[0]).toMatchObject({ busy: true, done: true })
+    expect(result.current.pending).toBe(false)
+  })
+
+  it('ignores a message frame when there is no turn to attach it to', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+
+    act(() => ws.simulateMessage({ type: 'done' }))
+
+    expect(result.current.turns).toHaveLength(0)
+  })
+
+  it('ignores malformed / schema-invalid messages', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    act(() => ws.onmessage?.({ data: 'not json' }))
+    act(() => ws.onmessage?.({ data: JSON.stringify({ type: 'unknown-type' }) }))
+
+    expect(result.current.turns[0].done).toBe(false)
+  })
+
+  it('closes the socket on unmount', () => {
+    const { unmount } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    const closeSpy = vi.spyOn(ws, 'close')
+
+    unmount()
+
+    expect(closeSpy).toHaveBeenCalled()
+  })
+
+  it('reconnects a new socket when re-enabled after being disabled', () => {
+    const { rerender } = renderHook(
+      ({ enabled }) => useBoardCommand({ enabled, token: 'tok' }),
+      { initialProps: { enabled: true } }
+    )
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+})

--- a/frontend/src/hooks/useBoardCommand.test.ts
+++ b/frontend/src/hooks/useBoardCommand.test.ts
@@ -204,4 +204,52 @@ describe('useBoardCommand', () => {
 
     expect(MockWebSocket.instances).toHaveLength(2)
   })
+
+  it('resets pending and turns when disabled mid-query (e.g. the palette closes)', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useBoardCommand({ enabled, token: 'tok' }),
+      { initialProps: { enabled: true } }
+    )
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    expect(result.current.pending).toBe(true)
+    expect(result.current.turns).toHaveLength(1)
+
+    rerender({ enabled: false })
+
+    expect(result.current.pending).toBe(false)
+    expect(result.current.turns).toHaveLength(0)
+  })
+
+  it('clears pending when the socket closes mid-query without an explicit disable', () => {
+    const { result } = renderHook(() => useBoardCommand({ enabled: true, token: 'tok' }))
+    const ws = MockWebSocket.instances[0]
+    act(() => ws.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+
+    expect(result.current.pending).toBe(true)
+
+    act(() => ws.close())
+
+    expect(result.current.pending).toBe(false)
+  })
+
+  it('reopening after a mid-query close does not resend a stale pending state', () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useBoardCommand({ enabled, token: 'tok' }),
+      { initialProps: { enabled: true } }
+    )
+    const firstWs = MockWebSocket.instances[0]
+    act(() => firstWs.simulateOpen())
+    act(() => result.current.sendPrompt('hello'))
+    expect(result.current.pending).toBe(true)
+
+    rerender({ enabled: false })
+    rerender({ enabled: true })
+
+    expect(result.current.pending).toBe(false)
+    expect(result.current.turns).toHaveLength(0)
+  })
 })

--- a/frontend/src/hooks/useBoardCommand.ts
+++ b/frontend/src/hooks/useBoardCommand.ts
@@ -46,7 +46,17 @@ export function useBoardCommand({ enabled, token }: UseBoardCommandOptions): Use
     wsRef.current = ws
 
     ws.onopen = () => setConnected(true)
-    ws.onclose = () => setConnected(false)
+    ws.onclose = () => {
+      setConnected(false)
+      // A close can arrive mid-query (server restart, network drop) with no
+      // terminal done/error/busy frame ever received. Without this, pending
+      // would stay stuck true forever, permanently disabling the palette's
+      // Send button until a full page reload — see handlePrompt/Query on the
+      // server side for why the query itself is not left running: the
+      // client side must not stay stuck waiting for a reply that will never
+      // arrive on a connection that's gone.
+      setPending(false)
+    }
     ws.onerror = () => ws.close()
     ws.onmessage = (event) => {
       if (typeof event.data !== 'string') return
@@ -62,6 +72,14 @@ export function useBoardCommand({ enabled, token }: UseBoardCommandOptions): Use
       ws.close()
       wsRef.current = null
       setConnected(false)
+      // Reset per-connection state on every teardown (palette closing mid-
+      // query, or the enabled/token deps changing), not just on ws.onclose:
+      // without this, closing the palette mid-query left pending stuck true
+      // (Send permanently disabled on reopen) and left stale turns to
+      // duplicate against the freshly refetched history the palette shows
+      // on its next open.
+      setPending(false)
+      setTurns([])
     }
   }, [enabled, token])
 

--- a/frontend/src/hooks/useBoardCommand.ts
+++ b/frontend/src/hooks/useBoardCommand.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { BoardCommandFrameSchema } from '../schemas'
+import type { BoardCommandFrame } from '../schemas'
+
+export interface BoardCommandTurn {
+  id: number
+  prompt: string
+  lines: unknown[]
+  error: string | null
+  busy: boolean
+  done: boolean
+}
+
+interface UseBoardCommandOptions {
+  enabled: boolean
+  token: string
+}
+
+export interface UseBoardCommandResult {
+  connected: boolean
+  turns: BoardCommandTurn[]
+  pending: boolean
+  sendPrompt: (prompt: string) => void
+}
+
+let nextTurnId = 1
+
+// useBoardCommand drives the command center chat used by the Spotlight
+// palette: one WS /ws/board-command connection per mount, open only while
+// enabled (the palette is expected to pass its own open/closed state), the
+// bearer token as a WebSocket subprotocol per BoardCommandHandler's own
+// contract (internal/ws/board_command.go) since browsers cannot set an
+// Authorization header on a WebSocket upgrade. See docs/agent-board.md's
+// "API and streaming" section for the line/error/done/busy frame protocol.
+export function useBoardCommand({ enabled, token }: UseBoardCommandOptions): UseBoardCommandResult {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [connected, setConnected] = useState(false)
+  const [turns, setTurns] = useState<BoardCommandTurn[]>([])
+  const [pending, setPending] = useState(false)
+
+  useEffect(() => {
+    if (!enabled || !token) return
+
+    const ws = new WebSocket(buildBoardCommandWSURL(), [token])
+    wsRef.current = ws
+
+    ws.onopen = () => setConnected(true)
+    ws.onclose = () => setConnected(false)
+    ws.onerror = () => ws.close()
+    ws.onmessage = (event) => {
+      if (typeof event.data !== 'string') return
+      const frame = parseFrame(event.data)
+      if (!frame) return
+      applyFrame(setTurns, frame)
+      if (frame.type !== 'line') setPending(false)
+    }
+
+    return () => {
+      ws.onclose = null
+      ws.onerror = null
+      ws.close()
+      wsRef.current = null
+      setConnected(false)
+    }
+  }, [enabled, token])
+
+  const sendPrompt = useCallback((prompt: string) => {
+    const ws = wsRef.current
+    if (!ws || ws.readyState !== WebSocket.OPEN) return
+    setTurns((prev) => [...prev, { id: nextTurnId++, prompt, lines: [], error: null, busy: false, done: false }])
+    setPending(true)
+    ws.send(JSON.stringify({ prompt }))
+  }, [])
+
+  return { connected, turns, pending, sendPrompt }
+}
+
+function parseFrame(data: string): BoardCommandFrame | null {
+  try {
+    const parsed = BoardCommandFrameSchema.safeParse(JSON.parse(data))
+    return parsed.success ? parsed.data : null
+  } catch {
+    return null
+  }
+}
+
+function applyFrame(setTurns: Dispatch<SetStateAction<BoardCommandTurn[]>>, frame: BoardCommandFrame) {
+  setTurns((prev) => {
+    if (prev.length === 0) return prev
+    const last = prev[prev.length - 1]
+    const updated: BoardCommandTurn = { ...last }
+    switch (frame.type) {
+      case 'line':
+        updated.lines = [...updated.lines, frame.raw]
+        break
+      case 'error':
+        updated.error = frame.message
+        updated.done = true
+        break
+      case 'done':
+        updated.done = true
+        break
+      case 'busy':
+        updated.busy = true
+        updated.done = true
+        break
+    }
+    return [...prev.slice(0, -1), updated]
+  })
+}
+
+function buildBoardCommandWSURL(): string {
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${location.host}/ws/board-command`
+}

--- a/frontend/src/hooks/useBoardSessionToken.test.ts
+++ b/frontend/src/hooks/useBoardSessionToken.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useBoardSessionToken } from './useBoardSessionToken'
+
+describe('useBoardSessionToken', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns default (empty token, disabled) before the fetch resolves', () => {
+    vi.mocked(fetch).mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useBoardSessionToken())
+
+    expect(result.current).toEqual({ token: '', commandCenterEnabled: false })
+  })
+
+  it('populates token and commandCenterEnabled from a successful response', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'sekret', command_center_enabled: true }),
+    } as Response)
+
+    const { result } = renderHook(() => useBoardSessionToken())
+
+    await waitFor(() => {
+      expect(result.current).toEqual({ token: 'sekret', commandCenterEnabled: true })
+    })
+  })
+
+  it('stays at defaults when the request fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false, json: async () => ({}) } as Response)
+
+    const { result } = renderHook(() => useBoardSessionToken())
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/session-token')
+    })
+    expect(result.current).toEqual({ token: '', commandCenterEnabled: false })
+  })
+
+  it('stays at defaults when the response fails schema validation', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ token: 'sekret' }), // missing command_center_enabled
+    } as Response)
+
+    const { result } = renderHook(() => useBoardSessionToken())
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled()
+    })
+    expect(result.current).toEqual({ token: '', commandCenterEnabled: false })
+  })
+})

--- a/frontend/src/hooks/useBoardSessionToken.ts
+++ b/frontend/src/hooks/useBoardSessionToken.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { BoardSessionTokenResponseSchema } from '../schemas'
+
+export interface BoardSession {
+  token: string
+  commandCenterEnabled: boolean
+}
+
+const DEFAULT_BOARD_SESSION: BoardSession = { token: '', commandCenterEnabled: false }
+
+// useBoardSessionToken fetches the bearer token panemux generated or was
+// configured with, so the dashboard can authenticate its own
+// /api/board/* requests and the /ws/board-command connection. See
+// GetBoardSessionToken's own doc comment (internal/api/board.go) for why
+// this endpoint exists and is deliberately unauthenticated itself.
+export function useBoardSessionToken(): BoardSession {
+  const [session, setSession] = useState<BoardSession>(DEFAULT_BOARD_SESSION)
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/session-token')
+        if (!res.ok) return
+        const data = BoardSessionTokenResponseSchema.parse(await res.json())
+        if (!cancelled) {
+          setSession({ token: data.token, commandCenterEnabled: data.command_center_enabled })
+        }
+      } catch {
+        // Best-effort: the command center simply stays unavailable.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return session
+}

--- a/frontend/src/schemas/index.ts
+++ b/frontend/src/schemas/index.ts
@@ -177,3 +177,32 @@ export const DirectoryBrowserResponseSchema = z.object({
 })
 
 export type DirectoryBrowserResponse = z.infer<typeof DirectoryBrowserResponseSchema>
+
+export const BoardSessionTokenResponseSchema = z.object({
+  token: z.string(),
+  command_center_enabled: z.boolean(),
+})
+
+export type BoardSessionTokenResponse = z.infer<typeof BoardSessionTokenResponseSchema>
+
+export const BoardCommandFrameSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('line'), raw: z.unknown() }),
+  z.object({ type: z.literal('error'), message: z.string() }),
+  z.object({ type: z.literal('done') }),
+  z.object({ type: z.literal('busy') }),
+])
+
+export type BoardCommandFrame = z.infer<typeof BoardCommandFrameSchema>
+
+export const BoardCommandHistoryEntrySchema = z.object({
+  at: z.string(),
+  raw: z.unknown(),
+})
+
+export type BoardCommandHistoryEntry = z.infer<typeof BoardCommandHistoryEntrySchema>
+
+export const BoardCommandHistoryResponseSchema = z.object({
+  entries: z.array(BoardCommandHistoryEntrySchema),
+})
+
+export type BoardCommandHistoryResponse = z.infer<typeof BoardCommandHistoryResponseSchema>

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -13,6 +13,10 @@ import (
 	"panemux/internal/commandcenter"
 )
 
+// loopbackIPv4 is the literal IPv4 loopback host string, as it appears in a
+// Host header or server.host config value (as opposed to a parsed net.IP).
+const loopbackIPv4 = "127.0.0.1"
+
 type boardStatusEntry struct {
 	UpdatedAt time.Time `json:"updated_at"`
 	State     string    `json:"state,omitempty"`
@@ -271,7 +275,7 @@ func isLoopbackAuthority(authority string) bool {
 	if err != nil {
 		host = authority
 	}
-	return host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "0.0.0.0"
+	return host == "localhost" || host == loopbackIPv4 || host == "::1" || host == "0.0.0.0"
 }
 
 // isLoopbackRemoteAddr reports whether remoteAddr (an http.Request's own

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -189,18 +190,73 @@ type boardSessionTokenResponse struct {
 //
 // This endpoint is deliberately NOT behind bearerAuthMiddleware itself —
 // nothing could ever bootstrap the token without already knowing it
-// otherwise — and instead relies on the same protection every other
-// pre-existing, unauthenticated /api/* route already relies on: the
-// server's CORS policy only allows a loopback origin to read a cross-origin
-// response body at all (see corsMiddleware/isLocalhostOrigin in
-// internal/server), and the operator's own host is already the trust
-// boundary for those routes. See docs/security.md's "Auth token and
-// transport encryption" section.
+// otherwise. An earlier revision of this doc comment claimed the server's
+// CORS policy protects it; that claim was wrong and has been corrected —
+// CORS only controls whether a cross-origin script can *read* a response
+// body, it never rejects the request from reaching the handler at all, and
+// a non-browser client (curl, another process on the LAN) ignores CORS
+// entirely. The real guard is below, checked directly against the request
+// rather than delegated to a header a client fully controls:
+//
+//  1. r.RemoteAddr's IP must be loopback. This is what actually restricts
+//     this endpoint to the local machine — it rejects any client that
+//     genuinely isn't the box panemux is running on, including a client on
+//     a LAN that reaches a `server.host` bound to a non-loopback address
+//     (a configuration internal/config/validate.go's own
+//     non-loopback-requires-token rule explicitly allows). Handing the
+//     token to any such client would defeat the entire reason that rule
+//     requires a token in the first place.
+//  2. r.Host must also resolve to a loopback authority. RemoteAddr alone is
+//     not enough: DNS rebinding (a domain whose DNS answer changes to
+//     127.0.0.1 after the browser's same-origin check already passed) makes
+//     an attacker-controlled page's requests arrive with a genuinely
+//     loopback RemoteAddr — the TCP connection really is local — while the
+//     Host header still carries the attacker's own domain, since browsers
+//     send the navigation URL's original host, not the resolved IP. Only
+//     the Host check catches that case.
+//
+// See docs/security.md's "Auth token and transport encryption" section for
+// the full rationale, including the accepted limitation this creates: a
+// dashboard served from a genuinely non-loopback `server.host` can no
+// longer bootstrap its own token through this endpoint at all, by design.
 func (h *Handler) GetBoardSessionToken(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRemoteAddr(r.RemoteAddr) || !isLoopbackAuthority(r.Host) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
 	writeJSON(w, boardSessionTokenResponse{
 		Token:                h.cfg.Server.AuthToken,
-		CommandCenterEnabled: h.cfg.CommandCenter.Enabled,
+		CommandCenterEnabled: h.commandCenterAvailable,
 	})
+}
+
+// isLoopbackAuthority reports whether authority (a Host-header-shaped
+// "host" or "host:port" string) names a loopback address, regardless of
+// port — matching internal/server's own isLocalhostOrigin/isLoopbackHost
+// port-agnostic allowance for the Vite dev server's proxied port.
+func isLoopbackAuthority(authority string) bool {
+	host, _, err := net.SplitHostPort(authority)
+	if err != nil {
+		host = authority
+	}
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// isLoopbackRemoteAddr reports whether remoteAddr (an http.Request's own
+// RemoteAddr, always "IP:port" for a real TCP connection) is a loopback IP.
+// Unlike isLoopbackAuthority, this is checked against net.IP.IsLoopback
+// rather than string equality, since RemoteAddr is the net/http-reported
+// address of the actual socket peer, not attacker-controlled request
+// content — it can carry any valid loopback representation (including
+// IPv4-mapped IPv6 forms), not just the literal strings a Host header
+// realistically contains.
+func isLoopbackRemoteAddr(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // defaultCommandHistoryFn reads the command center's history file from its

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -218,9 +218,13 @@ type boardSessionTokenResponse struct {
 // See docs/security.md's "Auth token and transport encryption" section for
 // the full rationale, including the accepted limitation this creates: a
 // dashboard served from a genuinely non-loopback `server.host` can no
-// longer bootstrap its own token through this endpoint at all, by design.
+// longer bootstrap its own token through this endpoint at all, by design —
+// and the narrower, NOT fully closed gap a same-host reverse proxy still
+// opens, which the forwarding-header check below only partially mitigates.
+// See that same security.md section for why a complete fix needs an
+// operator-configured trusted-proxy allowlist this endpoint does not have.
 func (h *Handler) GetBoardSessionToken(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemoteAddr(r.RemoteAddr) || !isLoopbackAuthority(r.Host) {
+	if isProxiedRequest(r) || !isLoopbackRemoteAddr(r.RemoteAddr) || !isLoopbackAuthority(r.Host) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
@@ -230,16 +234,44 @@ func (h *Handler) GetBoardSessionToken(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// isProxiedRequest reports whether r carries any of the standard
+// client-address forwarding headers (X-Forwarded-For, X-Real-IP, the RFC
+// 7239 Forwarded header). A genuine direct request from a local browser
+// never carries these — only a request that passed through a reverse proxy
+// does — so their mere presence is treated as proof the RemoteAddr/Host
+// pair below can no longer be trusted to mean "this really is the local
+// machine": a same-host reverse proxy (the exact mitigation this
+// repository's own docs recommend for exposing panemux beyond loopback)
+// makes every proxied request's RemoteAddr loopback and, under common
+// proxy defaults, its Host loopback-looking too, for a client that may be
+// anywhere on the internet. This is a partial mitigation, not a complete
+// one: a proxy configured not to set any of these headers is not caught by
+// it. See docs/security.md's "Auth token and transport encryption" section
+// for the accepted residual gap.
+func isProxiedRequest(r *http.Request) bool {
+	return r.Header.Get("X-Forwarded-For") != "" ||
+		r.Header.Get("X-Real-IP") != "" ||
+		r.Header.Get("Forwarded") != ""
+}
+
 // isLoopbackAuthority reports whether authority (a Host-header-shaped
 // "host" or "host:port" string) names a loopback address, regardless of
 // port — matching internal/server's own isLocalhostOrigin/isLoopbackHost
-// port-agnostic allowance for the Vite dev server's proxied port.
+// port-agnostic allowance for the Vite dev server's proxied port. "0.0.0.0"
+// is accepted too: a wildcard-bound server.host reached via `--open`
+// launches the browser at exactly http://0.0.0.0:<port>/, so the
+// dashboard's own same-origin request legitimately carries that literal
+// Host value — this does not weaken the DNS-rebinding defense, since an
+// attacker would need a victim to navigate to a URL whose hostname is
+// literally "0.0.0.0", which a DNS answer for an attacker-chosen domain
+// cannot produce (Host reflects the URL's original hostname, never the
+// resolved IP).
 func isLoopbackAuthority(authority string) bool {
 	host, _, err := net.SplitHostPort(authority)
 	if err != nil {
 		host = authority
 	}
-	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+	return host == "localhost" || host == "127.0.0.1" || host == "::1" || host == "0.0.0.0"
 }
 
 // isLoopbackRemoteAddr reports whether remoteAddr (an http.Request's own

--- a/internal/api/board.go
+++ b/internal/api/board.go
@@ -3,11 +3,13 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"panemux/internal/board"
+	"panemux/internal/commandcenter"
 )
 
 type boardStatusEntry struct {
@@ -141,4 +143,79 @@ func (h *Handler) PostBoardBroadcast(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, boardBroadcastResponse{Delivered: delivered})
+}
+
+type commandHistoryEntryResponse struct {
+	At  time.Time       `json:"at"`
+	Raw json.RawMessage `json:"raw"`
+}
+
+type commandHistoryResponse struct {
+	Entries []commandHistoryEntryResponse `json:"entries"`
+}
+
+// GetBoardCommandHistory returns the command center's own captured
+// turn-by-turn conversation history — read directly from the local history
+// file the Runner appends to while streaming a query's output, never
+// re-derived from Claude Code's transcript after the fact. See
+// docs/agent-board.md's "API and streaming" section. An empty or missing
+// history file (the command center has never run, or is not enabled) is
+// not an error; it returns an empty list.
+func (h *Handler) GetBoardCommandHistory(w http.ResponseWriter, r *http.Request) {
+	entries, err := h.commandHistoryFn()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to load command center history: %v", err), http.StatusInternalServerError)
+		return
+	}
+	resp := commandHistoryResponse{Entries: make([]commandHistoryEntryResponse, 0, len(entries))}
+	for _, e := range entries {
+		resp.Entries = append(resp.Entries, commandHistoryEntryResponse{At: e.At, Raw: e.Raw})
+	}
+	writeJSON(w, resp)
+}
+
+type boardSessionTokenResponse struct {
+	Token                string `json:"token"`
+	CommandCenterEnabled bool   `json:"command_center_enabled"`
+}
+
+// GetBoardSessionToken lets the same-origin dashboard learn the bearer
+// token panemux generated or was configured with, so its own JavaScript can
+// authenticate the /api/board/* requests and the /ws/board-command
+// WebSocket connection it makes on the user's behalf. There is no other way
+// for the frontend to learn a token that may have been randomly generated
+// on first run (see config.Config.EnsureAuthToken) and is never sent to the
+// browser any other way.
+//
+// This endpoint is deliberately NOT behind bearerAuthMiddleware itself —
+// nothing could ever bootstrap the token without already knowing it
+// otherwise — and instead relies on the same protection every other
+// pre-existing, unauthenticated /api/* route already relies on: the
+// server's CORS policy only allows a loopback origin to read a cross-origin
+// response body at all (see corsMiddleware/isLocalhostOrigin in
+// internal/server), and the operator's own host is already the trust
+// boundary for those routes. See docs/security.md's "Auth token and
+// transport encryption" section.
+func (h *Handler) GetBoardSessionToken(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, boardSessionTokenResponse{
+		Token:                h.cfg.Server.AuthToken,
+		CommandCenterEnabled: h.cfg.CommandCenter.Enabled,
+	})
+}
+
+// defaultCommandHistoryFn reads the command center's history file from its
+// default location. Resolving the path lazily on every call (rather than
+// once at Handler construction) matches commandcenter.LoadHistory's own
+// tolerance of a not-yet-existing file — nothing needs to exist before the
+// command center's first successful query.
+func defaultCommandHistoryFn() ([]commandcenter.HistoryEntry, error) {
+	path, err := commandcenter.DefaultHistoryFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("resolving command center history path: %w", err)
+	}
+	entries, err := commandcenter.LoadHistory(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading command center history: %w", err)
+	}
+	return entries, nil
 }

--- a/internal/api/board_command_history_test.go
+++ b/internal/api/board_command_history_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/board"
+	"panemux/internal/commandcenter"
+)
+
+func setupCommandHistoryRouter(fn func() ([]commandcenter.HistoryEntry, error)) *Handler {
+	h := setupBoardRouter(board.NewBoardCache(), nil)
+	if fn != nil {
+		h.commandHistoryFn = fn
+	}
+	return h
+}
+
+func TestGetBoardCommandHistory_Empty_ReturnsEmptyArray(t *testing.T) {
+	h := setupCommandHistoryRouter(func() ([]commandcenter.HistoryEntry, error) { return nil, nil })
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/command/history", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp commandHistoryResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.NotNil(t, resp.Entries)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGetBoardCommandHistory_Populated_ReturnsEntriesInOrder(t *testing.T) {
+	at := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	h := setupCommandHistoryRouter(func() ([]commandcenter.HistoryEntry, error) {
+		return []commandcenter.HistoryEntry{
+			{At: at, Raw: json.RawMessage(`{"type":"system","subtype":"init"}`)},
+			{At: at.Add(time.Second), Raw: json.RawMessage(`{"type":"result","result":"done"}`)},
+		}, nil
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/command/history", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp commandHistoryResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	require.Len(t, resp.Entries, 2)
+	assert.Equal(t, at, resp.Entries[0].At.UTC())
+	assert.JSONEq(t, `{"type":"system","subtype":"init"}`, string(resp.Entries[0].Raw))
+	assert.JSONEq(t, `{"type":"result","result":"done"}`, string(resp.Entries[1].Raw))
+}
+
+func TestGetBoardCommandHistory_LoadError_500(t *testing.T) {
+	h := setupCommandHistoryRouter(func() ([]commandcenter.HistoryEntry, error) {
+		return nil, errors.New("disk read failed")
+	})
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/board/command/history", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -27,15 +27,29 @@ func setupBoardRouter(cache *board.BoardCache, broadcastFn broadcastFunc) *Handl
 	return h
 }
 
+// loopbackSessionTokenRequest builds a GET /api/session-token request that
+// looks like it came from the local machine over a loopback interface with
+// no DNS-rebinding trickery: both the TCP peer (RemoteAddr) and the Host
+// header claim a loopback authority. GetBoardSessionToken requires both —
+// see its own doc comment for why RemoteAddr alone can't distinguish a
+// legitimate local dashboard from a DNS-rebound attacker page that also
+// genuinely connects to 127.0.0.1.
+func loopbackSessionTokenRequest() *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "127.0.0.1:8080"
+	return req
+}
+
 func TestGetBoardSessionToken_ReturnsConfiguredTokenAndCommandCenterState(t *testing.T) {
 	cfg := defaultTestConfig()
 	cfg.Server.AuthToken = "sekret"
-	cfg.CommandCenter.Enabled = true
 	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	h.SetCommandCenterAvailable(true)
 	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req := loopbackSessionTokenRequest()
 	r.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -43,6 +57,86 @@ func TestGetBoardSessionToken_ReturnsConfiguredTokenAndCommandCenterState(t *tes
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
 	assert.Equal(t, "sekret", resp.Token)
 	assert.True(t, resp.CommandCenterEnabled)
+}
+
+func TestGetBoardSessionToken_CommandCenterUnavailable_ReportsFalse(t *testing.T) {
+	// cfg.CommandCenter.Enabled alone must not drive this response field:
+	// setup can fail after the config check (e.g. no auth token, or a path
+	// resolution error in setupCommandCenter), leaving /ws/board-command
+	// unregistered even though the operator's config says "enabled". The
+	// frontend must be told the route doesn't actually exist, not shown a
+	// working-looking palette that 404s on every request.
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	cfg.CommandCenter.Enabled = true // config says enabled...
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	// ...but SetCommandCenterAvailable is never called, matching a Runner
+	// that setupCommandCenter decided not to build.
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := loopbackSessionTokenRequest()
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardSessionTokenResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.False(t, resp.CommandCenterEnabled)
+}
+
+func TestGetBoardSessionToken_NonLoopbackRemoteAddr_Forbidden(t *testing.T) {
+	// A real remote client — even one that sends a Host header matching the
+	// server's own configured non-loopback address — must never receive the
+	// token: the token's entire purpose is to gate exactly this kind of
+	// network-reachable access (see internal/config/validate.go's
+	// non-loopback-requires-token rule), so handing it out to any TCP peer
+	// that isn't the local machine defeats it regardless of what Host claims.
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "203.0.113.7:54321"
+	req.Host = "127.0.0.1:8080" // even a "trusted-looking" Host must not help
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetBoardSessionToken_DNSRebindingHost_Forbidden(t *testing.T) {
+	// DNS rebinding: attacker.example resolves to 127.0.0.1, so the TCP
+	// connection genuinely is loopback (RemoteAddr can't tell this apart
+	// from a legitimate local dashboard), but the browser still sends the
+	// original navigation Host header, which this must reject.
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "attacker.example:8080"
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetBoardSessionToken_LocalhostHostname_Allowed(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "localhost:5173" // Vite dev server port, matching corsMiddleware's own allowance
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestGetBoardStatus_EmptyCache_ReturnsEmptyObject(t *testing.T) {

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -139,6 +139,77 @@ func TestGetBoardSessionToken_LocalhostHostname_Allowed(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestGetBoardSessionToken_WildcardBindHost_Allowed(t *testing.T) {
+	// A wildcard-bound server (server.host: "0.0.0.0") reached via `--open`
+	// launches the browser at exactly http://0.0.0.0:<port>/, so the
+	// dashboard's own same-origin request carries a literal "0.0.0.0" Host
+	// header — a legitimate case, not an attacker-supplied one (an attacker
+	// would need a victim to specifically navigate to a URL naming
+	// "0.0.0.0", which DNS rebinding does not produce).
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "0.0.0.0:8080"
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestGetBoardSessionToken_XForwardedForHeader_Forbidden(t *testing.T) {
+	// A same-host reverse proxy (the exact mitigation docs/security.md
+	// itself recommends for exposing panemux beyond loopback) makes every
+	// proxied request arrive with a loopback RemoteAddr and, under common
+	// proxy defaults (nginx's $proxy_host, Apache's ProxyPreserveHost Off),
+	// a loopback-looking Host too — defeating both checks above for a
+	// genuinely remote client. A forwarding header is the one signal a
+	// direct local browser request never carries, so its mere presence is
+	// treated as proof this request was proxied and must be rejected.
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := loopbackSessionTokenRequest()
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetBoardSessionToken_XRealIPHeader_Forbidden(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := loopbackSessionTokenRequest()
+	req.Header.Set("X-Real-IP", "203.0.113.7")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestGetBoardSessionToken_ForwardedHeader_Forbidden(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := loopbackSessionTokenRequest()
+	req.Header.Set("Forwarded", "for=203.0.113.7")
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
 func TestGetBoardStatus_EmptyCache_ReturnsEmptyObject(t *testing.T) {
 	h := setupBoardRouter(board.NewBoardCache(), nil)
 	r := setupRouterWithHandler(h)

--- a/internal/api/board_test.go
+++ b/internal/api/board_test.go
@@ -27,6 +27,24 @@ func setupBoardRouter(cache *board.BoardCache, broadcastFn broadcastFunc) *Handl
 	return h
 }
 
+func TestGetBoardSessionToken_ReturnsConfiguredTokenAndCommandCenterState(t *testing.T) {
+	cfg := defaultTestConfig()
+	cfg.Server.AuthToken = "sekret"
+	cfg.CommandCenter.Enabled = true
+	h := NewHandler(cfg, session.NewManager(), board.NewBoardCache(), nil)
+	r := setupRouterWithHandler(h)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp boardSessionTokenResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "sekret", resp.Token)
+	assert.True(t, resp.CommandCenterEnabled)
+}
+
 func TestGetBoardStatus_EmptyCache_ReturnsEmptyObject(t *testing.T) {
 	h := setupBoardRouter(board.NewBoardCache(), nil)
 	r := setupRouterWithHandler(h)

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"panemux/internal/board"
+	"panemux/internal/commandcenter"
 	"panemux/internal/config"
 	"panemux/internal/session"
 	"panemux/internal/sshconfig"
@@ -37,6 +38,7 @@ type Handler struct {
 	readDirFn               func(name string) ([]os.DirEntry, error)
 	manager                 *session.Manager
 	boardBroadcastFn        func(ctx context.Context, to []string, body string) ([]string, error)
+	commandHistoryFn        func() ([]commandcenter.HistoryEntry, error)
 	boardCache              *board.BoardCache
 	gitInfoCacheBySession   map[string]gitInfoCacheEntry
 	createSession           func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
@@ -174,6 +176,7 @@ func NewHandler(
 	h.boardBroadcastFn = func(ctx context.Context, to []string, body string) ([]string, error) {
 		return boardRelay.Broadcast(ctx, board.SystemID, to, body)
 	}
+	h.commandHistoryFn = defaultCommandHistoryFn
 	return h
 }
 

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -39,6 +39,7 @@ type Handler struct {
 	manager                 *session.Manager
 	boardBroadcastFn        func(ctx context.Context, to []string, body string) ([]string, error)
 	commandHistoryFn        func() ([]commandcenter.HistoryEntry, error)
+	commandCenterAvailable  bool
 	boardCache              *board.BoardCache
 	gitInfoCacheBySession   map[string]gitInfoCacheEntry
 	createSession           func(*config.PaneConfig, map[string]config.SSHConnection) (session.Session, error)
@@ -178,6 +179,18 @@ func NewHandler(
 	}
 	h.commandHistoryFn = defaultCommandHistoryFn
 	return h
+}
+
+// SetCommandCenterAvailable records whether /ws/board-command is actually
+// registered, for GetBoardSessionToken to report. This is a separate,
+// later-set field rather than a NewHandler parameter deliberately: the
+// caller (internal/server.New) only knows whether setupCommandCenter
+// actually produced a Runner — which can differ from cfg.CommandCenter.Enabled
+// (e.g. enabled but no server.auth_token configured) — and threading that
+// decision through NewHandler's existing four-argument, ~90-call-site
+// signature was judged not worth the churn for one boolean.
+func (h *Handler) SetCommandCenterAvailable(available bool) {
+	h.commandCenterAvailable = available
 }
 
 // GetLayout returns the current layout configuration.

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -120,7 +120,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 
 func defaultTestConfig() *config.Config {
 	return &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -132,7 +132,7 @@ func defaultTestConfig() *config.Config {
 
 func workspaceTestConfig() *config.Config {
 	return &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Workspaces: config.WorkspacesConfig{
 			Active:           "one",
 			TabPosition:      "top",
@@ -864,7 +864,7 @@ func TestPostSession_DuplicateID_409(t *testing.T) {
 
 func TestRestartSession_Found_200(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -893,7 +893,7 @@ func TestRestartSession_Found_200(t *testing.T) {
 
 func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -926,7 +926,7 @@ func TestRestartSession_ClearsPreferredCWD(t *testing.T) {
 
 func TestRestartSession_ClearsGitInfoCache(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -966,7 +966,7 @@ func TestRestartSession_NotFound_404(t *testing.T) {
 
 func TestRestartSession_CreateFails_OldSessionStaysRegistered(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -998,7 +998,7 @@ func TestRestartSession_CreateFails_OldSessionStaysRegistered(t *testing.T) {
 
 func TestRestartSession_CreateFails_PreservesPreferredCWD(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -1031,7 +1031,7 @@ func TestRestartSession_CreateFails_PreservesPreferredCWD(t *testing.T) {
 
 func TestRestartSession_CreateFails_500Body(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -1058,7 +1058,7 @@ func TestRestartSession_CreateFails_500Body(t *testing.T) {
 
 func TestRestartSession_CreateFails_NoPanicWhenNoPriorSession(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -1094,7 +1094,7 @@ func TestRestartSession_CreateFails_NoPanicWhenNoPriorSession(t *testing.T) {
 // concurrent call instead.
 func TestRestartSession_ConcurrentRequests_SecondReturns409(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{
@@ -1153,7 +1153,7 @@ func TestRestartSession_ConcurrentRequests_SecondReturns409(t *testing.T) {
 // so it never permanently locks a pane out of future restarts.
 func TestRestartSession_GuardReleasedAfterCompletion(t *testing.T) {
 	cfg := &config.Config{
-		Server: config.ServerConfig{Port: 8080, Host: "127.0.0.1"},
+		Server: config.ServerConfig{Port: 8080, Host: loopbackIPv4},
 		Layout: config.LayoutNode{
 			Direction: "horizontal",
 			Children: []config.LayoutChild{

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -110,9 +110,11 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r.Post("/api/ssh-config/hosts", h.PostSSHConfigHost)
 	r.Get("/api/detect-shell", h.GetDetectShell)
 	r.Get("/api/directories", h.GetDirectories)
+	r.Get("/api/session-token", h.GetBoardSessionToken)
 	r.Get("/api/board/status", h.GetBoardStatus)
 	r.Get("/api/board/messages", h.GetBoardMessages)
 	r.Post("/api/board/broadcast", h.PostBoardBroadcast)
+	r.Get("/api/board/command/history", h.GetBoardCommandHistory)
 	return r
 }
 

--- a/internal/boardmcp/client.go
+++ b/internal/boardmcp/client.go
@@ -67,7 +67,7 @@ func (c *HTTPBoardAPIClient) Messages(ctx context.Context, since int64) (json.Ra
 
 // Broadcast calls POST /api/board/broadcast with {"to": to, "body": body}.
 func (c *HTTPBoardAPIClient) Broadcast(ctx context.Context, to []string, body string) (json.RawMessage, error) {
-	reqBody, err := json.Marshal(map[string]any{"to": to, "body": body})
+	reqBody, err := json.Marshal(map[string]any{"to": to, broadcastBodyField: body})
 	if err != nil {
 		return nil, fmt.Errorf("encoding broadcast request: %w", err)
 	}

--- a/internal/boardmcp/client.go
+++ b/internal/boardmcp/client.go
@@ -1,0 +1,101 @@
+// Package boardmcp implements the command center's narrow MCP server: three
+// tools (board_status, board_messages, board_broadcast) that are thin
+// wrappers around panemux's own authenticated REST API. See
+// docs/agent-board.md's Command center section — this is deliberately the
+// only code that talks to that REST API on the command center subprocess's
+// behalf, so the LLM itself never composes an HTTP call or a shell
+// invocation.
+package boardmcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// BoardAPIClient is what the MCP server's tool handlers call. Returning raw
+// JSON response bodies (rather than decoding into typed DTOs) keeps this
+// package decoupled from internal/api's response shapes — the LLM sees
+// exactly what a human dashboard request would see.
+type BoardAPIClient interface {
+	Status(ctx context.Context) (json.RawMessage, error)
+	Messages(ctx context.Context, since int64) (json.RawMessage, error)
+	Broadcast(ctx context.Context, to []string, body string) (json.RawMessage, error)
+}
+
+const httpClientTimeout = 30 * time.Second
+
+// HTTPBoardAPIClient calls panemux's own /api/board/* REST endpoints over
+// loopback with a bearer token, the same endpoints the browser dashboard
+// uses.
+type HTTPBoardAPIClient struct {
+	httpClient *http.Client
+	baseURL    string
+	token      string
+}
+
+// NewHTTPBoardAPIClient constructs a client against baseURL (e.g.
+// "http://127.0.0.1:8080") using token as the bearer credential.
+func NewHTTPBoardAPIClient(baseURL, token string) *HTTPBoardAPIClient {
+	return &HTTPBoardAPIClient{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		token:      token,
+		httpClient: &http.Client{Timeout: httpClientTimeout},
+	}
+}
+
+// Status calls GET /api/board/status.
+func (c *HTTPBoardAPIClient) Status(ctx context.Context) (json.RawMessage, error) {
+	return c.do(ctx, http.MethodGet, "/api/board/status", nil)
+}
+
+// Messages calls GET /api/board/messages, including ?since=<since> only
+// when since is non-zero (0 is the REST API's own "from the start" default).
+func (c *HTTPBoardAPIClient) Messages(ctx context.Context, since int64) (json.RawMessage, error) {
+	path := "/api/board/messages"
+	if since != 0 {
+		path += "?since=" + strconv.FormatInt(since, 10)
+	}
+	return c.do(ctx, http.MethodGet, path, nil)
+}
+
+// Broadcast calls POST /api/board/broadcast with {"to": to, "body": body}.
+func (c *HTTPBoardAPIClient) Broadcast(ctx context.Context, to []string, body string) (json.RawMessage, error) {
+	reqBody, err := json.Marshal(map[string]any{"to": to, "body": body})
+	if err != nil {
+		return nil, fmt.Errorf("encoding broadcast request: %w", err)
+	}
+	return c.do(ctx, http.MethodPost, "/api/board/broadcast", bytes.NewReader(reqBody))
+}
+
+func (c *HTTPBoardAPIClient) do(ctx context.Context, method, path string, body io.Reader) (json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling panemux board api: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading panemux board api response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("panemux board api returned %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return json.RawMessage(data), nil
+}

--- a/internal/boardmcp/client_test.go
+++ b/internal/boardmcp/client_test.go
@@ -1,0 +1,98 @@
+package boardmcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPBoardAPIClientStatusSendsBearerTokenAndReturnsBody(t *testing.T) {
+	var gotAuth, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"statuses":{}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPBoardAPIClient(srv.URL, "sekret")
+	raw, err := client.Status(context.Background())
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"statuses":{}}`, string(raw))
+	assert.Equal(t, "Bearer sekret", gotAuth)
+	assert.Equal(t, "/api/board/status", gotPath)
+	assert.Equal(t, http.MethodGet, gotMethod)
+}
+
+func TestHTTPBoardAPIClientMessagesSetsSinceQueryParam(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPBoardAPIClient(srv.URL, "tok")
+	_, err := client.Messages(context.Background(), 42)
+
+	require.NoError(t, err)
+	assert.Equal(t, "since=42", gotQuery)
+}
+
+func TestHTTPBoardAPIClientMessagesOmitsSinceWhenZero(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPBoardAPIClient(srv.URL, "tok")
+	_, err := client.Messages(context.Background(), 0)
+
+	require.NoError(t, err)
+	assert.Empty(t, gotQuery)
+}
+
+func TestHTTPBoardAPIClientBroadcastSendsJSONBody(t *testing.T) {
+	var gotMethod, gotContentType, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		_, _ = w.Write([]byte(`{"delivered":["pane-a"]}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPBoardAPIClient(srv.URL, "tok")
+	raw, err := client.Broadcast(context.Background(), []string{"pane-a"}, "hello")
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"delivered":["pane-a"]}`, string(raw))
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.JSONEq(t, `{"to":["pane-a"],"body":"hello"}`, gotBody)
+}
+
+func TestHTTPBoardAPIClientNon2xxReturnsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unauthorized"))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPBoardAPIClient(srv.URL, "wrong-token")
+	_, err := client.Status(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}

--- a/internal/boardmcp/server.go
+++ b/internal/boardmcp/server.go
@@ -103,7 +103,12 @@ func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
 
 // handleLine returns nil for a notification (no id, or a JSON-null id) —
 // per the JSON-RPC 2.0 spec, notifications never receive a response, even
-// an error one, since there is no id to correlate it with.
+// an error one, since there is no id to correlate it with. A notification
+// is never dispatched at all, not just left unanswered: nothing here would
+// ever see the result of a state-changing call like board_broadcast if it
+// ran as a notification, so — unlike a plain request whose caller is
+// choosing to ignore the response — there would be no way to tell the
+// difference between "didn't run" and "ran and nobody found out."
 func (s *Server) handleLine(ctx context.Context, line []byte) *jsonrpcResponse {
 	var req jsonrpcRequest
 	if err := json.Unmarshal(line, &req); err != nil {
@@ -112,12 +117,11 @@ func (s *Server) handleLine(ctx context.Context, line []byte) *jsonrpcResponse {
 			Error:   &jsonrpcError{Code: jsonrpcParseError, Message: "parse error: " + err.Error()},
 		}
 	}
-	isNotification := len(req.ID) == 0 || string(req.ID) == "null"
-
-	result, rpcErr := s.dispatch(ctx, req.Method, req.Params)
-	if isNotification {
+	if len(req.ID) == 0 || string(req.ID) == "null" {
 		return nil
 	}
+
+	result, rpcErr := s.dispatch(ctx, req.Method, req.Params)
 	resp := &jsonrpcResponse{JSONRPC: "2.0", ID: req.ID}
 	if rpcErr != nil {
 		resp.Error = rpcErr

--- a/internal/boardmcp/server.go
+++ b/internal/boardmcp/server.go
@@ -24,6 +24,11 @@ const (
 	toolBoardBroadcast = "board_broadcast"
 )
 
+// broadcastBodyField is the board_broadcast tool's "body" argument/schema
+// field name — shared between this file's tool schema, callBroadcast's
+// argument struct, and client.go's outgoing request body.
+const broadcastBodyField = "body"
+
 const (
 	jsonrpcParseError     = -32700
 	jsonrpcMethodNotFound = -32601
@@ -175,41 +180,59 @@ type toolsListResult struct {
 	Tools []toolDef `json:"tools"`
 }
 
+// jsonSchemaFieldType is the JSON Schema "type" keyword, shared by every
+// helper below so it's a single literal rather than one per call site.
+const jsonSchemaFieldType = "type"
+
+// objectSchema builds a JSON Schema "object" InputSchema, optionally
+// requiring the given property names. These helpers exist so the hand-built
+// schemas below don't each repeat JSON Schema keyword string literals
+// ("type", "properties", "description", ...) at every call site.
+func objectSchema(properties map[string]any, required ...string) map[string]any {
+	schema := map[string]any{jsonSchemaFieldType: "object", "properties": properties}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// typedProperty builds a JSON Schema property of the given primitive kind
+// ("integer", "string", ...) with a human-readable description.
+func typedProperty(kind, description string) map[string]any {
+	return map[string]any{jsonSchemaFieldType: kind, "description": description}
+}
+
+// arrayProperty builds a JSON Schema "array" property whose items are all
+// of itemKind, with a human-readable description.
+func arrayProperty(itemKind, description string) map[string]any {
+	return map[string]any{
+		jsonSchemaFieldType: "array",
+		"items":             map[string]any{jsonSchemaFieldType: itemKind},
+		"description":       description,
+	}
+}
+
 func (s *Server) handleToolsList() toolsListResult {
 	return toolsListResult{Tools: []toolDef{
 		{
 			Name:        toolBoardStatus,
 			Description: "Get the current self-reported status of every board-enabled pane " + statusToolFieldsHint,
-			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+			InputSchema: objectSchema(map[string]any{}),
 		},
 		{
 			Name:        toolBoardMessages,
 			Description: "Get recent board message history. Optional 'since' returns only newer messages.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"since": map[string]any{
-						"type":        "integer",
-						"description": "Only return messages newer than this sequence number",
-					},
-				},
-			},
+			InputSchema: objectSchema(map[string]any{
+				"since": typedProperty("integer", "Only return messages newer than this sequence number"),
+			}),
 		},
 		{
 			Name:        toolBoardBroadcast,
 			Description: "Send a message to one or more board-enabled panes.",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"to": map[string]any{
-						"type":        "array",
-						"items":       map[string]any{"type": "string"},
-						"description": "Pane IDs to send to",
-					},
-					"body": map[string]any{"type": "string", "description": "Message text"},
-				},
-				"required": []string{"to", "body"},
-			},
+			InputSchema: objectSchema(map[string]any{
+				"to":               arrayProperty("string", "Pane IDs to send to"),
+				broadcastBodyField: typedProperty("string", "Message text"),
+			}, "to", broadcastBodyField),
 		},
 	}}
 }

--- a/internal/boardmcp/server.go
+++ b/internal/boardmcp/server.go
@@ -1,0 +1,314 @@
+package boardmcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// protocolVersion is the MCP protocol date this server implements.
+const protocolVersion = "2024-11-05"
+
+// serverName/serverVersion identify this server in the initialize handshake.
+const serverName = "panemux-board"
+
+//nolint:gochecknoglobals // overridable by main.go at build/link time, mirrors main.go's own `version` var
+var serverVersion = "dev"
+
+const (
+	toolBoardStatus    = "board_status"
+	toolBoardMessages  = "board_messages"
+	toolBoardBroadcast = "board_broadcast"
+)
+
+const (
+	jsonrpcParseError     = -32700
+	jsonrpcMethodNotFound = -32601
+	jsonrpcInvalidParams  = -32602
+)
+
+//nolint:govet // fieldalignment: field order kept grouped by meaning, padding cost is negligible
+type jsonrpcRequest struct {
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+}
+
+//nolint:govet // fieldalignment: field order kept grouped by meaning, padding cost is negligible
+type jsonrpcResponse struct {
+	Result  any             `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+}
+
+type jsonrpcError struct {
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}
+
+// Error implements the error interface so a *jsonrpcError can also be
+// returned as callTool's ordinary error result — see handleToolsCall.
+func (e *jsonrpcError) Error() string { return e.Message }
+
+// Server is the command center's narrow MCP server: three tools
+// (board_status, board_messages, board_broadcast), each a thin wrapper
+// around a BoardAPIClient call. It never calls agmsg or anything else
+// directly — see docs/agent-board.md's Command center section.
+type Server struct {
+	client BoardAPIClient
+}
+
+// NewServer constructs a Server backed by client.
+func NewServer(client BoardAPIClient) *Server {
+	return &Server{client: client}
+}
+
+// Serve reads newline-delimited JSON-RPC 2.0 requests from r and writes
+// newline-delimited responses to w, per MCP's stdio transport. It processes
+// one line at a time, in order; a notification (a request with no id)
+// produces no output line. Serve returns when r is exhausted or a
+// read/write error occurs — a malformed request line is reported back to
+// the client as a JSON-RPC error response, not treated as fatal to the
+// connection.
+func (s *Server) Serve(ctx context.Context, r io.Reader, w io.Writer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		resp := s.handleLine(ctx, line)
+		if resp == nil {
+			continue
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return fmt.Errorf("encoding mcp response: %w", err)
+		}
+		if _, err := w.Write(append(data, '\n')); err != nil {
+			return fmt.Errorf("writing mcp response: %w", err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading mcp request: %w", err)
+	}
+	return nil
+}
+
+// handleLine returns nil for a notification (no id, or a JSON-null id) —
+// per the JSON-RPC 2.0 spec, notifications never receive a response, even
+// an error one, since there is no id to correlate it with.
+func (s *Server) handleLine(ctx context.Context, line []byte) *jsonrpcResponse {
+	var req jsonrpcRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return &jsonrpcResponse{
+			JSONRPC: "2.0",
+			Error:   &jsonrpcError{Code: jsonrpcParseError, Message: "parse error: " + err.Error()},
+		}
+	}
+	isNotification := len(req.ID) == 0 || string(req.ID) == "null"
+
+	result, rpcErr := s.dispatch(ctx, req.Method, req.Params)
+	if isNotification {
+		return nil
+	}
+	resp := &jsonrpcResponse{JSONRPC: "2.0", ID: req.ID}
+	if rpcErr != nil {
+		resp.Error = rpcErr
+	} else {
+		resp.Result = result
+	}
+	return resp
+}
+
+func (s *Server) dispatch(ctx context.Context, method string, params json.RawMessage) (any, *jsonrpcError) {
+	switch method {
+	case "initialize":
+		return s.handleInitialize(), nil
+	case "notifications/initialized":
+		return nil, nil
+	case "tools/list":
+		return s.handleToolsList(), nil
+	case "tools/call":
+		return s.handleToolsCall(ctx, params)
+	default:
+		return nil, &jsonrpcError{Code: jsonrpcMethodNotFound, Message: "method not found: " + method}
+	}
+}
+
+type initializeResult struct {
+	Capabilities    map[string]any `json:"capabilities"`
+	ProtocolVersion string         `json:"protocolVersion"`
+	ServerInfo      serverInfo     `json:"serverInfo"`
+}
+
+type serverInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (s *Server) handleInitialize() initializeResult {
+	return initializeResult{
+		ProtocolVersion: protocolVersion,
+		Capabilities:    map[string]any{"tools": map[string]any{}},
+		ServerInfo:      serverInfo{Name: serverName, Version: serverVersion},
+	}
+}
+
+type toolDef struct {
+	InputSchema map[string]any `json:"inputSchema"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+}
+
+type toolsListResult struct {
+	Tools []toolDef `json:"tools"`
+}
+
+func (s *Server) handleToolsList() toolsListResult {
+	return toolsListResult{Tools: []toolDef{
+		{
+			Name:        toolBoardStatus,
+			Description: "Get the current self-reported status of every board-enabled pane " + statusToolFieldsHint,
+			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		},
+		{
+			Name:        toolBoardMessages,
+			Description: "Get recent board message history. Optional 'since' returns only newer messages.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"since": map[string]any{
+						"type":        "integer",
+						"description": "Only return messages newer than this sequence number",
+					},
+				},
+			},
+		},
+		{
+			Name:        toolBoardBroadcast,
+			Description: "Send a message to one or more board-enabled panes.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"to": map[string]any{
+						"type":        "array",
+						"items":       map[string]any{"type": "string"},
+						"description": "Pane IDs to send to",
+					},
+					"body": map[string]any{"type": "string", "description": "Message text"},
+				},
+				"required": []string{"to", "body"},
+			},
+		},
+	}}
+}
+
+const statusToolFieldsHint = "(working directory, branch, PR, idle/working/waiting state)."
+
+//nolint:govet // fieldalignment: padding cost is negligible for a two-field struct
+type toolCallParams struct {
+	Arguments json.RawMessage `json:"arguments"`
+	Name      string          `json:"name"`
+}
+
+type toolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type toolCallResult struct {
+	Content []toolContent `json:"content"`
+	IsError bool          `json:"isError"`
+}
+
+func (s *Server) handleToolsCall(ctx context.Context, params json.RawMessage) (any, *jsonrpcError) {
+	var p toolCallParams
+	if err := json.Unmarshal(params, &p); err != nil {
+		return nil, &jsonrpcError{Code: jsonrpcInvalidParams, Message: "invalid params: " + err.Error()}
+	}
+
+	raw, err := s.callTool(ctx, p)
+	if err != nil {
+		var rpcErr *jsonrpcError
+		if asJSONRPCError(err, &rpcErr) {
+			return nil, rpcErr
+		}
+		return toolCallResult{Content: []toolContent{{Type: "text", Text: err.Error()}}, IsError: true}, nil
+	}
+	return toolCallResult{Content: []toolContent{{Type: "text", Text: string(raw)}}, IsError: false}, nil
+}
+
+// asJSONRPCError reports whether err is a *jsonrpcError produced by
+// callTool's own argument validation (never one returned by BoardAPIClient,
+// which only ever returns ordinary errors) and, if so, sets *out to it.
+// A plain type assertion is intentionally not used here (errorlint would
+// flag it): this checks for exactly one concrete internal sentinel type,
+// not an arbitrary wrapped error chain.
+func asJSONRPCError(err error, out **jsonrpcError) bool {
+	//nolint:errorlint // see doc comment above: exact internal sentinel type, not a wrapped chain
+	rpcErr, ok := err.(*jsonrpcError)
+	if ok {
+		*out = rpcErr
+	}
+	return ok
+}
+
+func (s *Server) callTool(ctx context.Context, p toolCallParams) (json.RawMessage, error) {
+	switch p.Name {
+	case toolBoardStatus:
+		return s.callStatus(ctx)
+	case toolBoardMessages:
+		return s.callMessages(ctx, p.Arguments)
+	case toolBoardBroadcast:
+		return s.callBroadcast(ctx, p.Arguments)
+	default:
+		return nil, &jsonrpcError{Code: jsonrpcMethodNotFound, Message: "unknown tool: " + p.Name}
+	}
+}
+
+func (s *Server) callStatus(ctx context.Context) (json.RawMessage, error) {
+	raw, err := s.client.Status(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("board_status: %w", err)
+	}
+	return raw, nil
+}
+
+func (s *Server) callMessages(ctx context.Context, rawArgs json.RawMessage) (json.RawMessage, error) {
+	var args struct {
+		Since int64 `json:"since"`
+	}
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return nil, &jsonrpcError{Code: jsonrpcInvalidParams, Message: "invalid arguments: " + err.Error()}
+		}
+	}
+	raw, err := s.client.Messages(ctx, args.Since)
+	if err != nil {
+		return nil, fmt.Errorf("board_messages: %w", err)
+	}
+	return raw, nil
+}
+
+func (s *Server) callBroadcast(ctx context.Context, rawArgs json.RawMessage) (json.RawMessage, error) {
+	//nolint:govet // fieldalignment: local decode struct, padding cost is negligible
+	var args struct {
+		To   []string `json:"to"`
+		Body string   `json:"body"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return nil, &jsonrpcError{Code: jsonrpcInvalidParams, Message: "invalid arguments: " + err.Error()}
+	}
+	raw, err := s.client.Broadcast(ctx, args.To, args.Body)
+	if err != nil {
+		return nil, fmt.Errorf("board_broadcast: %w", err)
+	}
+	return raw, nil
+}

--- a/internal/boardmcp/server_test.go
+++ b/internal/boardmcp/server_test.go
@@ -1,0 +1,178 @@
+package boardmcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//nolint:govet // fieldalignment: test fixture, padding cost is negligible
+type fakeBoardAPIClient struct {
+	statusRaw    json.RawMessage
+	statusErr    error
+	messagesRaw  json.RawMessage
+	messagesErr  error
+	broadcastRaw json.RawMessage
+	broadcastErr error
+
+	gotSince        int64
+	gotBroadcastTo  []string
+	gotBroadcastMsg string
+}
+
+func (f *fakeBoardAPIClient) Status(_ context.Context) (json.RawMessage, error) {
+	return f.statusRaw, f.statusErr
+}
+
+func (f *fakeBoardAPIClient) Messages(_ context.Context, since int64) (json.RawMessage, error) {
+	f.gotSince = since
+	return f.messagesRaw, f.messagesErr
+}
+
+func (f *fakeBoardAPIClient) Broadcast(_ context.Context, to []string, body string) (json.RawMessage, error) {
+	f.gotBroadcastTo = to
+	f.gotBroadcastMsg = body
+	return f.broadcastRaw, f.broadcastErr
+}
+
+// serveLines runs Server.Serve against the given request lines and returns
+// the parsed response lines in order.
+func serveLines(t *testing.T, client BoardAPIClient, lines ...string) []map[string]any {
+	t.Helper()
+	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
+	var out bytes.Buffer
+
+	err := NewServer(client).Serve(context.Background(), in, &out)
+	require.NoError(t, err)
+
+	var responses []map[string]any
+	scanner := bufio.NewScanner(&out)
+	for scanner.Scan() {
+		if scanner.Text() == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(scanner.Bytes(), &m))
+		responses = append(responses, m)
+	}
+	return responses
+}
+
+func TestServerInitializeReturnsProtocolVersionAndServerInfo(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{}, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+
+	require.Len(t, resp, 1)
+	result, ok := resp[0]["result"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, protocolVersion, result["protocolVersion"])
+	serverInfo, ok := result["serverInfo"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, serverName, serverInfo["name"])
+}
+
+func TestServerNotificationsInitializedProducesNoResponse(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{}, `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+
+	assert.Empty(t, resp)
+}
+
+func TestServerToolsListReturnsThreeBoardTools(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{}, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+
+	require.Len(t, resp, 1)
+	result := resp[0]["result"].(map[string]any) //nolint:errcheck
+	tools := result["tools"].([]any)             //nolint:errcheck
+	require.Len(t, tools, 3)
+	var names []string
+	for _, tool := range tools {
+		names = append(names, tool.(map[string]any)["name"].(string)) //nolint:errcheck
+	}
+	assert.ElementsMatch(t, []string{"board_status", "board_messages", "board_broadcast"}, names)
+}
+
+func TestServerToolsCallBoardStatusRelaysClientResponse(t *testing.T) {
+	client := &fakeBoardAPIClient{statusRaw: json.RawMessage(`{"statuses":{"pane-a":{"state":"working"}}}`)}
+	resp := serveLines(t, client,
+		`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"board_status","arguments":{}}}`)
+
+	require.Len(t, resp, 1)
+	result := resp[0]["result"].(map[string]any) //nolint:errcheck
+	assert.Equal(t, false, result["isError"])
+	content := result["content"].([]any)                 //nolint:errcheck
+	text := content[0].(map[string]any)["text"].(string) //nolint:errcheck
+	assert.JSONEq(t, `{"statuses":{"pane-a":{"state":"working"}}}`, text)
+}
+
+func TestServerToolsCallBoardMessagesParsesSinceArgument(t *testing.T) {
+	client := &fakeBoardAPIClient{messagesRaw: json.RawMessage(`{"messages":[]}`)}
+	serveLines(t, client,
+		`{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"board_messages","arguments":{"since":17}}}`)
+
+	assert.Equal(t, int64(17), client.gotSince)
+}
+
+func TestServerToolsCallBoardBroadcastParsesToAndBody(t *testing.T) {
+	client := &fakeBoardAPIClient{broadcastRaw: json.RawMessage(`{"delivered":["pane-a"]}`)}
+	resp := serveLines(t, client,
+		`{"jsonrpc":"2.0","id":5,"method":"tools/call","params":`+
+			`{"name":"board_broadcast","arguments":{"to":["pane-a"],"body":"hi"}}}`)
+
+	assert.Equal(t, []string{"pane-a"}, client.gotBroadcastTo)
+	assert.Equal(t, "hi", client.gotBroadcastMsg)
+	result := resp[0]["result"].(map[string]any) //nolint:errcheck
+	assert.Equal(t, false, result["isError"])
+}
+
+func TestServerToolsCallClientErrorReturnsIsErrorResult(t *testing.T) {
+	client := &fakeBoardAPIClient{statusErr: errors.New("connection refused")}
+	resp := serveLines(t, client,
+		`{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"board_status","arguments":{}}}`)
+
+	require.Len(t, resp, 1)
+	result := resp[0]["result"].(map[string]any) //nolint:errcheck
+	assert.Equal(t, true, result["isError"])
+	content := result["content"].([]any)                 //nolint:errcheck
+	text := content[0].(map[string]any)["text"].(string) //nolint:errcheck
+	assert.Contains(t, text, "connection refused")
+}
+
+func TestServerToolsCallUnknownToolReturnsJSONRPCError(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{},
+		`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"nonexistent","arguments":{}}}`)
+
+	require.Len(t, resp, 1)
+	require.NotNil(t, resp[0]["error"])
+}
+
+func TestServerUnknownMethodReturnsJSONRPCError(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{}, `{"jsonrpc":"2.0","id":8,"method":"nonexistent/method"}`)
+
+	require.Len(t, resp, 1)
+	errObj := resp[0]["error"].(map[string]any) //nolint:errcheck
+	assert.Contains(t, errObj["message"], "nonexistent/method")
+}
+
+func TestServerMalformedLineReturnsParseError(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{}, `not json at all`)
+
+	require.Len(t, resp, 1)
+	require.NotNil(t, resp[0]["error"])
+}
+
+func TestServerProcessesMultipleLinesInOrder(t *testing.T) {
+	resp := serveLines(t, &fakeBoardAPIClient{},
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`,
+	)
+
+	require.Len(t, resp, 2)
+	assert.InDelta(t, 1, resp[0]["id"], 0)
+	assert.InDelta(t, 2, resp[1]["id"], 0)
+}

--- a/internal/boardmcp/server_test.go
+++ b/internal/boardmcp/server_test.go
@@ -83,6 +83,21 @@ func TestServerNotificationsInitializedProducesNoResponse(t *testing.T) {
 	assert.Empty(t, resp)
 }
 
+func TestServerToolsCallSentAsNotificationNeverExecutesSideEffect(t *testing.T) {
+	// A tools/call with no "id" is a JSON-RPC notification: the server must
+	// not reply (already covered above) — but it must also never dispatch
+	// the underlying tool call at all, since a state-changing call like
+	// board_broadcast would otherwise fire with no response ever
+	// acknowledging (or reporting a failure for) whatever it did.
+	client := &fakeBoardAPIClient{broadcastRaw: json.RawMessage(`{"delivered":["pane-a"]}`)}
+	resp := serveLines(t, client,
+		`{"jsonrpc":"2.0","method":"tools/call","params":`+
+			`{"name":"board_broadcast","arguments":{"to":["pane-a"],"body":"hi"}}}`)
+
+	assert.Empty(t, resp)
+	assert.Nil(t, client.gotBroadcastTo, "board_broadcast must never be dispatched for a notification-shaped request")
+}
+
 func TestServerToolsListReturnsThreeBoardTools(t *testing.T) {
 	resp := serveLines(t, &fakeBoardAPIClient{}, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
 

--- a/internal/commandcenter/atomic_write.go
+++ b/internal/commandcenter/atomic_write.go
@@ -1,0 +1,47 @@
+// Package commandcenter implements the Agent Board command center: a
+// headless, per-query `claude -p --resume` subprocess that reads and writes
+// the board only through panemux's own authenticated REST API (see
+// docs/agent-board.md's Command center section).
+package commandcenter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to path via a temp file plus rename, creating
+// the parent directory if needed, so a crash or power loss mid-write can
+// never leave a truncated or half-written file on disk — a rename onto an
+// existing path is atomic on the platforms panemux targets, unlike a direct
+// write. This mirrors internal/board's own atomicWriteFile helper; it is
+// duplicated here rather than shared because internal/board's copy is
+// unexported and this package's persisted files (command-center session id,
+// history) are otherwise unrelated to anything internal/board owns.
+func atomicWriteFile(path string, data []byte, mode os.FileMode, label string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("creating %s directory: %w", label, err)
+	}
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("creating temp %s: %w", label, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing temp %s: %w", label, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing temp %s: %w", label, err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return fmt.Errorf("setting %s mode: %w", label, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replacing %s: %w", label, err)
+	}
+	return nil
+}

--- a/internal/commandcenter/atomic_write_test.go
+++ b/internal/commandcenter/atomic_write_test.go
@@ -1,0 +1,51 @@
+package commandcenter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicWriteFileCreatesParentDirAndWritesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "file.json")
+
+	err := atomicWriteFile(path, []byte(`{"a":1}`), 0600, "test file")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":1}`, string(data))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestAtomicWriteFileOverwritesExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.json")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0600))
+
+	err := atomicWriteFile(path, []byte("new"), 0600, "test file")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(data))
+}
+
+func TestAtomicWriteFileLeavesNoTempFileBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.json")
+
+	require.NoError(t, atomicWriteFile(path, []byte("x"), 0600, "test file"))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "file.json", entries[0].Name())
+}

--- a/internal/commandcenter/history_store.go
+++ b/internal/commandcenter/history_store.go
@@ -1,0 +1,117 @@
+package commandcenter
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const historyFileName = "command-center-history.jsonl"
+const historyFileMode os.FileMode = 0600
+
+// HistoryEntry is one line of the command center's own captured
+// conversation history: a raw --output-format=stream-json line, exactly as
+// captured while relaying it to the WS client — never re-derived from
+// Claude Code's transcript file after the fact. See docs/agent-board.md's
+// "API and streaming" section.
+type HistoryEntry struct {
+	At  time.Time       `json:"at"`
+	Raw json.RawMessage `json:"raw"`
+}
+
+// AppendHistory appends entries to path, one JSON object per line, creating
+// the parent directory and file if needed. A crash mid-write can leave at
+// most one truncated trailing line, which LoadHistory tolerates by design —
+// see its own doc comment. Empty entries is a no-op and never creates the
+// file, so a command center that has never run leaves no history file
+// behind.
+func AppendHistory(path string, entries []HistoryEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return fmt.Errorf("creating command center history directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, historyFileMode)
+	if err != nil {
+		return fmt.Errorf("opening command center history file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	var buf bytes.Buffer
+	for _, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return fmt.Errorf("encoding command center history entry: %w", err)
+		}
+		buf.Write(data)
+		buf.WriteByte('\n')
+	}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("writing command center history file: %w", err)
+	}
+	return nil
+}
+
+// LoadHistory reads every persisted HistoryEntry. A missing file is the
+// normal state before the command center's first query and returns an empty
+// slice, not an error.
+//
+// A malformed final line — the tail of a write interrupted mid-append by a
+// crash or power loss — is silently dropped rather than treated as an
+// error, since AppendHistory's own write pattern can produce exactly that
+// shape and it represents no genuinely lost history (the interrupted append
+// call itself never returned success). A malformed line anywhere else in
+// the file is a real corruption, not an expected truncation, and is
+// reported as an error instead of silently skipped.
+func LoadHistory(path string) ([]HistoryEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("opening command center history file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading command center history file: %w", err)
+	}
+
+	entries := make([]HistoryEntry, 0, len(lines))
+	for i, line := range lines {
+		var entry HistoryEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			if i == len(lines)-1 {
+				break // tolerate a truncated trailing line, see doc comment
+			}
+			return nil, fmt.Errorf("parsing command center history file: %w", err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// DefaultHistoryFilePath returns ~/.config/panemux/command-center-history.jsonl.
+func DefaultHistoryFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", historyFileName), nil
+}

--- a/internal/commandcenter/history_store.go
+++ b/internal/commandcenter/history_store.go
@@ -25,11 +25,15 @@ type HistoryEntry struct {
 }
 
 // AppendHistory appends entries to path, one JSON object per line, creating
-// the parent directory and file if needed. A crash mid-write can leave at
-// most one truncated trailing line, which LoadHistory tolerates by design —
-// see its own doc comment. Empty entries is a no-op and never creates the
-// file, so a command center that has never run leaves no history file
-// behind.
+// the parent directory and file if needed. A crash mid-write can leave a
+// truncated final line with no trailing newline; if the file is already in
+// that state, a leading newline is written first so this call's own entries
+// land on their own lines rather than concatenating onto the truncated
+// tail — see TestAppendHistoryAddsSeparatingNewlineAfterUnterminatedPriorWrite
+// for the corruption this avoids, and LoadHistory's own doc comment for why
+// a bad line further in the file is tolerated either way. Empty entries is
+// a no-op and never creates the file, so a command center that has never
+// run leaves no history file behind.
 func AppendHistory(path string, entries []HistoryEntry) error {
 	if len(entries) == 0 {
 		return nil
@@ -37,13 +41,21 @@ func AppendHistory(path string, entries []HistoryEntry) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return fmt.Errorf("creating command center history directory: %w", err)
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, historyFileMode)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_APPEND, historyFileMode)
 	if err != nil {
 		return fmt.Errorf("opening command center history file: %w", err)
 	}
 	defer f.Close() //nolint:errcheck
 
+	needsLeadingNewline, err := fileEndsWithoutTrailingNewline(f)
+	if err != nil {
+		return fmt.Errorf("checking command center history file: %w", err)
+	}
+
 	var buf bytes.Buffer
+	if needsLeadingNewline {
+		buf.WriteByte('\n')
+	}
 	for _, entry := range entries {
 		data, err := json.Marshal(entry)
 		if err != nil {
@@ -58,17 +70,44 @@ func AppendHistory(path string, entries []HistoryEntry) error {
 	return nil
 }
 
+// fileEndsWithoutTrailingNewline reports whether f is non-empty and its
+// last byte is not '\n'. Uses ReadAt at an explicit offset rather than
+// Read, so it doesn't disturb the file's O_APPEND write position (every
+// Write on an O_APPEND-opened file always targets end-of-file regardless of
+// the current offset, but ReadAt avoids relying on that rather than
+// assuming it).
+func fileEndsWithoutTrailingNewline(f *os.File) (bool, error) {
+	info, err := f.Stat()
+	if err != nil {
+		return false, fmt.Errorf("stat: %w", err)
+	}
+	if info.Size() == 0 {
+		return false, nil
+	}
+	last := make([]byte, 1)
+	if _, err := f.ReadAt(last, info.Size()-1); err != nil {
+		return false, fmt.Errorf("reading last byte: %w", err)
+	}
+	return last[0] != '\n', nil
+}
+
 // LoadHistory reads every persisted HistoryEntry. A missing file is the
 // normal state before the command center's first query and returns an empty
 // slice, not an error.
 //
-// A malformed final line — the tail of a write interrupted mid-append by a
-// crash or power loss — is silently dropped rather than treated as an
-// error, since AppendHistory's own write pattern can produce exactly that
-// shape and it represents no genuinely lost history (the interrupted append
-// call itself never returned success). A malformed line anywhere else in
-// the file is a real corruption, not an expected truncation, and is
-// reported as an error instead of silently skipped.
+// A line that fails to parse is skipped, wherever it falls in the file, not
+// treated as a fatal error for the whole read. This is deliberately more
+// lenient than a typical parser: history is best-effort conversation
+// record, not authoritative state, and one bad line — the tail of a write
+// interrupted mid-append by a crash or power loss, which AppendHistory's
+// own newline-separation guard (see its doc comment) keeps isolated to
+// exactly one line rather than merged into a neighbor — permanently 500-ing
+// every future read, including every good line around it, is a worse
+// failure mode than silently omitting that one line. An earlier revision of
+// this function only tolerated a malformed *trailing* line and hard-failed
+// on any other position; that was wrong in practice, since a truncated line
+// stops being trailing the moment the process restarts and appends again,
+// which is the normal recovery path, not an exceptional one.
 func LoadHistory(path string) ([]HistoryEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -79,7 +118,7 @@ func LoadHistory(path string) ([]HistoryEntry, error) {
 	}
 	defer f.Close() //nolint:errcheck
 
-	var lines []string
+	var entries []HistoryEntry
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	for scanner.Scan() {
@@ -87,22 +126,14 @@ func LoadHistory(path string) ([]HistoryEntry, error) {
 		if line == "" {
 			continue
 		}
-		lines = append(lines, line)
+		var entry HistoryEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		entries = append(entries, entry)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("reading command center history file: %w", err)
-	}
-
-	entries := make([]HistoryEntry, 0, len(lines))
-	for i, line := range lines {
-		var entry HistoryEntry
-		if err := json.Unmarshal([]byte(line), &entry); err != nil {
-			if i == len(lines)-1 {
-				break // tolerate a truncated trailing line, see doc comment
-			}
-			return nil, fmt.Errorf("parsing command center history file: %w", err)
-		}
-		entries = append(entries, entry)
 	}
 	return entries, nil
 }

--- a/internal/commandcenter/history_store_test.go
+++ b/internal/commandcenter/history_store_test.go
@@ -1,0 +1,97 @@
+package commandcenter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadHistoryMissingFileReturnsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.jsonl")
+
+	entries, err := LoadHistory(path)
+
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestAppendThenLoadHistoryRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "command-center-history.jsonl")
+	at := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	err := AppendHistory(path, []HistoryEntry{
+		{At: at, Raw: json.RawMessage(`{"type":"system","subtype":"init","session_id":"abc"}`)},
+		{At: at.Add(time.Second), Raw: json.RawMessage(`{"type":"result","result":"done"}`)},
+	})
+	require.NoError(t, err)
+
+	entries, err := LoadHistory(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, at, entries[0].At.UTC())
+	assert.JSONEq(t, `{"type":"system","subtype":"init","session_id":"abc"}`, string(entries[0].Raw))
+	assert.JSONEq(t, `{"type":"result","result":"done"}`, string(entries[1].Raw))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestAppendHistoryAppendsAcrossMultipleCalls(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+
+	require.NoError(t, AppendHistory(path, []HistoryEntry{{Raw: json.RawMessage(`{"n":1}`)}}))
+	require.NoError(t, AppendHistory(path, []HistoryEntry{{Raw: json.RawMessage(`{"n":2}`)}}))
+
+	entries, err := LoadHistory(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.JSONEq(t, `{"n":1}`, string(entries[0].Raw))
+	assert.JSONEq(t, `{"n":2}`, string(entries[1].Raw))
+}
+
+func TestAppendHistoryEmptyEntriesIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+
+	require.NoError(t, AppendHistory(path, nil))
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestLoadHistorySkipsTruncatedTrailingLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	line := `{"at":"2026-08-10T12:00:00Z","raw":{"n":1}}` + "\n"
+	truncated := `{"at":"2026-08-10T12:00:01Z","raw":{"n":2` // crash mid-write, no trailing newline
+	require.NoError(t, os.WriteFile(path, []byte(line+truncated), 0600))
+
+	entries, err := LoadHistory(path)
+
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.JSONEq(t, `{"n":1}`, string(entries[0].Raw))
+}
+
+func TestLoadHistoryMalformedMiddleLineReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	content := `{"at":"2026-08-10T12:00:00Z","raw":{"n":1}}` + "\n" +
+		`not json at all` + "\n" +
+		`{"at":"2026-08-10T12:00:02Z","raw":{"n":3}}` + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+
+	_, err := LoadHistory(path)
+
+	assert.Error(t, err)
+}
+
+func TestDefaultHistoryFilePath(t *testing.T) {
+	path, err := DefaultHistoryFilePath()
+
+	require.NoError(t, err)
+	assert.Contains(t, path, filepath.Join(".config", "panemux", "command-center-history.jsonl"))
+}

--- a/internal/commandcenter/history_store_test.go
+++ b/internal/commandcenter/history_store_test.go
@@ -77,16 +77,49 @@ func TestLoadHistorySkipsTruncatedTrailingLine(t *testing.T) {
 	assert.JSONEq(t, `{"n":1}`, string(entries[0].Raw))
 }
 
-func TestLoadHistoryMalformedMiddleLineReturnsError(t *testing.T) {
+func TestLoadHistorySkipsMalformedMiddleLine(t *testing.T) {
+	// A malformed line is skipped wherever it appears in the file, not just
+	// at the end: history is best-effort, not authoritative state, so one
+	// bad line (e.g. a truncated write later followed by more appends, at
+	// which point it's no longer the trailing line — see
+	// TestAppendHistoryAddsSeparatingNewlineAfterUnterminatedPriorWrite)
+	// must not permanently break every read of the file, including the
+	// good lines around it.
 	path := filepath.Join(t.TempDir(), "history.jsonl")
 	content := `{"at":"2026-08-10T12:00:00Z","raw":{"n":1}}` + "\n" +
 		`not json at all` + "\n" +
 		`{"at":"2026-08-10T12:00:02Z","raw":{"n":3}}` + "\n"
 	require.NoError(t, os.WriteFile(path, []byte(content), 0600))
 
-	_, err := LoadHistory(path)
+	entries, err := LoadHistory(path)
 
-	assert.Error(t, err)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.JSONEq(t, `{"n":1}`, string(entries[0].Raw))
+	assert.JSONEq(t, `{"n":3}`, string(entries[1].Raw))
+}
+
+func TestAppendHistoryAddsSeparatingNewlineAfterUnterminatedPriorWrite(t *testing.T) {
+	// Simulates AppendHistory being interrupted mid-write (crash, power
+	// loss) leaving a truncated final line with no trailing newline, then
+	// called again normally after the process restarts. Without a
+	// separating newline, the next entry's bytes would concatenate directly
+	// onto the truncated line, producing one new, unrecoverable garbled
+	// line instead of one isolated bad line plus one good one.
+	path := filepath.Join(t.TempDir(), "history.jsonl")
+	truncated := `{"at":"2026-08-10T12:00:00Z","raw":{"n":1` // no trailing newline
+	require.NoError(t, os.WriteFile(path, []byte(truncated), 0600))
+
+	require.NoError(t, AppendHistory(path, []HistoryEntry{{Raw: json.RawMessage(`{"n":2}`)}}))
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, truncated+"\n"+`{"at":"0001-01-01T00:00:00Z","raw":{"n":2}}`+"\n", string(raw))
+
+	entries, err := LoadHistory(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the new, well-formed entry should be readable back")
+	assert.JSONEq(t, `{"n":2}`, string(entries[0].Raw))
 }
 
 func TestDefaultHistoryFilePath(t *testing.T) {

--- a/internal/commandcenter/mcp_config.go
+++ b/internal/commandcenter/mcp_config.go
@@ -1,0 +1,107 @@
+package commandcenter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// BoardMCPServerSubcommand is the hidden panemux subcommand
+// (`panemux __board-mcp-server`) that main.go recognizes before ordinary
+// flag parsing. Re-invoking the panemux binary itself as the MCP server's
+// command means no second listening process is ever started — the
+// subprocess speaks MCP over stdio to the claude -p process that spawned
+// it, exits with it, and is never itself reachable over the network. See
+// docs/agent-board.md's "No new daemon, no new listening port" design
+// principle.
+const BoardMCPServerSubcommand = "__board-mcp-server"
+
+// mcpServerName is this MCP server's name as it appears in the mcp-config
+// file's "mcpServers" map and, per Claude Code's own naming convention, as
+// the middle segment of every mcp__<server>__<tool> allowed-tool name.
+const mcpServerName = "panemux-board"
+
+// The three tool names the board MCP server exposes — thin wrappers around
+// GET /api/board/status, GET /api/board/messages, and POST
+// /api/board/broadcast respectively. See docs/agent-board.md's Command
+// center section.
+const (
+	MCPToolBoardStatus    = "board_status"
+	MCPToolBoardMessages  = "board_messages"
+	MCPToolBoardBroadcast = "board_broadcast"
+)
+
+type mcpServerConfig struct {
+	Env     map[string]string `json:"env"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+}
+
+type mcpConfigFile struct {
+	MCPServers map[string]mcpServerConfig `json:"mcpServers"`
+}
+
+// BuildMCPConfig writes a temporary MCP config file (mode 0600, since its
+// env block embeds a bearer token in plaintext) wiring the command center's
+// `claude -p` subprocess to panemux's own narrow MCP server: a
+// re-invocation of execPath with BoardMCPServerSubcommand, reading baseURL
+// and token from its environment. The returned cleanup func removes the
+// file; callers must call it once the `claude -p` subprocess this config
+// was built for has exited, never before — the subprocess reads the file
+// path only at MCP server startup, but that startup can happen any time
+// during the subprocess's life.
+func BuildMCPConfig(execPath, baseURL, token string) (path string, cleanup func(), err error) {
+	cfg := mcpConfigFile{
+		MCPServers: map[string]mcpServerConfig{
+			mcpServerName: {
+				Command: execPath,
+				Args:    []string{BoardMCPServerSubcommand},
+				Env: map[string]string{
+					"PANEMUX_BOARD_BASE_URL": baseURL,
+					"PANEMUX_BOARD_TOKEN":    token,
+				},
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", nil, fmt.Errorf("encoding mcp config: %w", err)
+	}
+
+	f, err := os.CreateTemp("", "panemux-board-mcp-*.json")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temp mcp config: %w", err)
+	}
+	tmpPath := f.Name()
+	cleanup = func() { _ = os.Remove(tmpPath) }
+
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("writing temp mcp config: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("closing temp mcp config: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("setting mcp config mode: %w", err)
+	}
+	return tmpPath, cleanup, nil
+}
+
+// AllowedTools returns the --allowedTools value scoping the command
+// center's `claude -p` subprocess to exactly the three board MCP tools —
+// no Bash, no filesystem tools, no other MCP server. See
+// docs/agent-board.md's "Permissions" subsection: the subprocess never
+// receives --dangerously-skip-permissions, and this narrow allowlist is
+// what stands in for the interactive approval prompt it has no PTY to
+// surface.
+func AllowedTools() []string {
+	return []string{
+		"mcp__" + mcpServerName + "__" + MCPToolBoardStatus,
+		"mcp__" + mcpServerName + "__" + MCPToolBoardMessages,
+		"mcp__" + mcpServerName + "__" + MCPToolBoardBroadcast,
+	}
+}

--- a/internal/commandcenter/mcp_config_test.go
+++ b/internal/commandcenter/mcp_config_test.go
@@ -1,0 +1,65 @@
+package commandcenter
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMCPConfigWritesExpectedShape(t *testing.T) {
+	path, cleanup, err := BuildMCPConfig("/usr/local/bin/panemux", "http://127.0.0.1:8080", "sekret-token")
+	require.NoError(t, err)
+	defer cleanup()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var parsed mcpConfigFile
+	require.NoError(t, json.Unmarshal(data, &parsed))
+
+	server, ok := parsed.MCPServers["panemux-board"]
+	require.True(t, ok, "expected a panemux-board mcp server entry")
+	assert.Equal(t, "/usr/local/bin/panemux", server.Command)
+	assert.Equal(t, []string{BoardMCPServerSubcommand}, server.Args)
+	assert.Equal(t, "http://127.0.0.1:8080", server.Env["PANEMUX_BOARD_BASE_URL"])
+	assert.Equal(t, "sekret-token", server.Env["PANEMUX_BOARD_TOKEN"])
+}
+
+func TestBuildMCPConfigCleanupRemovesFile(t *testing.T) {
+	path, cleanup, err := BuildMCPConfig("/usr/local/bin/panemux", "http://127.0.0.1:8080", "tok")
+	require.NoError(t, err)
+
+	cleanup()
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestBuildMCPConfigEachCallGetsDistinctPath(t *testing.T) {
+	path1, cleanup1, err := BuildMCPConfig("/bin/panemux", "http://127.0.0.1:8080", "a")
+	require.NoError(t, err)
+	defer cleanup1()
+
+	path2, cleanup2, err := BuildMCPConfig("/bin/panemux", "http://127.0.0.1:8080", "b")
+	require.NoError(t, err)
+	defer cleanup2()
+
+	assert.NotEqual(t, path1, path2)
+}
+
+func TestAllowedToolsScopedToBoardToolsOnly(t *testing.T) {
+	tools := AllowedTools()
+
+	assert.Equal(t, []string{
+		"mcp__panemux-board__board_status",
+		"mcp__panemux-board__board_messages",
+		"mcp__panemux-board__board_broadcast",
+	}, tools)
+}

--- a/internal/commandcenter/runner.go
+++ b/internal/commandcenter/runner.go
@@ -9,10 +9,24 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 )
+
+// validSessionID matches the shape of a session id claude itself would ever
+// emit — an alphanumeric token, optionally with internal "." "_" "-"
+// separators (a UUID fits this), and critically never starting with "-".
+// --resume's value is optional in the claude CLI's own parser, so a
+// persisted session id beginning with "-" would be parsed as a new CLI flag
+// rather than a --resume value — the same class of argument-injection
+// buildArgs's own "--" end-of-options marker defends the prompt against,
+// except --resume's value sits before that marker and needs its own guard.
+// A regex-allowlist branch gating a value before it reaches exec.Command
+// argv is this repository's established pattern for exactly this problem
+// (see docs/security.md's validateShell/validTmuxSessionName/validRemotePath).
+var validSessionID = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // ErrBusy is returned by Query when a previous query against this Runner's
 // single command-center session is still in flight. See
@@ -172,12 +186,11 @@ func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
 	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
 	defer cancel()
 
-	state, err := LoadSessionFile(r.sessionPath)
+	state, firstRun, err := r.loadValidatedSessionState()
 	if err != nil {
 		events <- errorEvent("loading command center session state: %v", err)
 		return
 	}
-	firstRun := state.SessionID == ""
 
 	mcpPath, cleanup, err := r.buildMCPConfig()
 	if err != nil {
@@ -199,34 +212,94 @@ func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
 
 	historyEntries, capturedSessionID, scanFailed := r.streamOutput(stdout, events)
 
+	if scanFailed {
+		// The client has already been told the query failed (streamOutput
+		// sent the EventError). Cancel now, before Wait(), rather than
+		// relying on the deferred cancel() at the top of this function:
+		// that one only fires once run() itself returns, which can't
+		// happen until Wait() returns — so without this, a subprocess that
+		// doesn't exit on its own after a malformed line would hold the
+		// busy flag (and this goroutine) for up to the full query timeout
+		// instead of being killed immediately.
+		cancel()
+	}
+
+	r.finishAfterStream(ctx, cmd, finishParams{
+		firstRun:          firstRun,
+		capturedSessionID: capturedSessionID,
+		historyEntries:    historyEntries,
+		scanFailed:        scanFailed,
+	}, events)
+}
+
+// loadValidatedSessionState loads the persisted session state and, if its
+// session id doesn't match validSessionID's shape, treats that exactly like
+// no persisted id at all (see validSessionID's doc comment) rather than
+// letting an unsafe value reach buildArgs.
+func (r *Runner) loadValidatedSessionState() (state SessionState, firstRun bool, err error) {
+	state, err = LoadSessionFile(r.sessionPath)
+	if err != nil {
+		return SessionState{}, false, err
+	}
+	if state.SessionID != "" && !validSessionID.MatchString(state.SessionID) {
+		// Best-effort clear so a future query doesn't keep re-tripping this
+		// same fallback.
+		_ = SaveSessionFile(r.sessionPath, SessionState{})
+		state.SessionID = ""
+	}
+	return state, state.SessionID == "", nil
+}
+
+// finishParams bundles what finishAfterStream needs to know about the
+// streamOutput phase that already ran before cmd.Wait().
+type finishParams struct {
+	capturedSessionID string
+	historyEntries    []HistoryEntry
+	firstRun          bool
+	scanFailed        bool
+}
+
+// finishAfterStream waits for the subprocess to exit, persists any captured
+// history, and emits the query's final event. Split out of run so run stays
+// under this repository's function-length lint limit.
+func (r *Runner) finishAfterStream(ctx context.Context, cmd cmdRunner, p finishParams, events chan<- Event) {
 	waitErr := cmd.Wait()
 
-	if len(historyEntries) > 0 {
-		if err := AppendHistory(r.historyPath, historyEntries); err != nil {
+	if len(p.historyEntries) > 0 {
+		if err := AppendHistory(r.historyPath, p.historyEntries); err != nil {
 			events <- errorEvent("persisting command center history: %v", err)
 		}
 	}
 
-	if scanFailed {
+	if p.scanFailed {
 		return // an EventError for the malformed line was already sent
 	}
 	if waitErr != nil {
-		if !firstRun {
-			// A resume failure is the CLI's own signal that --resume
-			// continuity is already broken (e.g. the user cleared
-			// ~/.claude, or the session was garbage collected) — clear the
-			// persisted id so the next query starts a fresh first-run
-			// instead of retrying the same doomed id forever. Best-effort:
-			// a failure to clear it doesn't need its own separate event: the
-			// query's own error below is still the actionable one, and the
-			// next query will simply hit the same resume failure again.
+		// A query killed by this Runner's own timeout is not evidence the
+		// --resume id itself is bad — it's evidence the query took too
+		// long, which says nothing about whether claude would still
+		// recognize the id on a fresh attempt. Only a genuine resume
+		// rejection (the CLI's own signal that --resume continuity is
+		// already broken — e.g. the user cleared ~/.claude, or the session
+		// was garbage collected) should clear the persisted id; conflating
+		// the two would silently drop a perfectly good, still-resumable
+		// conversation just because one turn happened to run long.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			events <- Event{Type: EventError, Err: fmt.Sprintf("claude query timed out after %s", r.queryTimeout)}
+			return
+		}
+		if !p.firstRun {
+			// Best-effort: a failure to clear it doesn't need its own
+			// separate event — the query's own error below is still the
+			// actionable one, and the next query will simply hit the same
+			// resume failure again.
 			_ = SaveSessionFile(r.sessionPath, SessionState{})
 		}
 		events <- errorEvent("claude exited with error: %v", waitErr)
 		return
 	}
-	if firstRun && capturedSessionID != "" {
-		if err := SaveSessionFile(r.sessionPath, SessionState{SessionID: capturedSessionID}); err != nil {
+	if p.firstRun && p.capturedSessionID != "" {
+		if err := SaveSessionFile(r.sessionPath, SessionState{SessionID: p.capturedSessionID}); err != nil {
 			events <- errorEvent("persisting command center session id: %v", err)
 			return
 		}

--- a/internal/commandcenter/runner.go
+++ b/internal/commandcenter/runner.go
@@ -1,0 +1,260 @@
+package commandcenter
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrBusy is returned by Query when a previous query against this Runner's
+// single command-center session is still in flight. See
+// docs/agent-board.md's "Concurrency" subsection: two concurrent
+// `claude -p --resume <same-id>` invocations have no ordering guarantee
+// from the CLI itself, so a second request is rejected immediately rather
+// than queued.
+var ErrBusy = errors.New("command center busy")
+
+// EventType discriminates the kind of Event a Query emits.
+type EventType string
+
+const (
+	// EventLine carries one raw --output-format=stream-json line, exactly
+	// as emitted by the subprocess.
+	EventLine EventType = "line"
+	// EventError reports a subprocess failure — non-zero exit, malformed
+	// stream-json output, or a context cancellation/timeout — as an
+	// explicit frame rather than a silently empty response. It is always
+	// the last event on a channel that received one.
+	EventError EventType = "error"
+	// EventDone marks a successful query's end. It is never sent after an
+	// EventError on the same channel.
+	EventDone EventType = "done"
+)
+
+// Event is one item streamed back from Query's channel.
+//
+//nolint:govet // fieldalignment: Type/Raw/Err order kept for readability, padding cost is negligible
+type Event struct {
+	Type EventType
+	Raw  json.RawMessage
+	Err  string
+}
+
+// cmdRunner abstracts the subset of *exec.Cmd Query needs, so tests can
+// substitute a fake subprocess without a real `claude` binary on PATH — see
+// DEVELOPMENT.md's testability rule. *exec.Cmd already satisfies this
+// interface directly.
+type cmdRunner interface {
+	StdoutPipe() (io.ReadCloser, error)
+	Start() error
+	Wait() error
+}
+
+// commandFactory constructs the subprocess for one query. The production
+// default wraps exec.CommandContext; tests inject a fake.
+type commandFactory func(ctx context.Context, name string, args ...string) cmdRunner
+
+const defaultClaudeBin = "claude"
+
+// RunnerConfig configures a Runner. NewCommand and Now default to
+// production behavior (a real subprocess, time.Now) when left zero.
+type RunnerConfig struct {
+	BuildMCPConfig func() (path string, cleanup func(), err error)
+	NewCommand     commandFactory
+	Now            func() time.Time
+	ClaudeBin      string
+	SessionPath    string
+	HistoryPath    string
+	AllowedTools   []string
+}
+
+// Runner drives the command center's per-query `claude -p [--resume]`
+// subprocess lifecycle: at most one query in flight at a time, streaming
+// parsed stream-json lines as Events, persisting captured history, and
+// persisting a freshly captured session id only after a successful first
+// run. See docs/agent-board.md's Command center section.
+type Runner struct {
+	buildMCPConfig func() (path string, cleanup func(), err error)
+	newCommand     commandFactory
+	now            func() time.Time
+	claudeBin      string
+	sessionPath    string
+	historyPath    string
+	allowedTools   []string
+	mu             sync.Mutex
+	busy           bool
+}
+
+// NewRunner constructs a Runner from cfg.
+func NewRunner(cfg RunnerConfig) *Runner {
+	r := &Runner{
+		buildMCPConfig: cfg.BuildMCPConfig,
+		newCommand:     cfg.NewCommand,
+		now:            cfg.Now,
+		claudeBin:      cfg.ClaudeBin,
+		sessionPath:    cfg.SessionPath,
+		historyPath:    cfg.HistoryPath,
+		allowedTools:   cfg.AllowedTools,
+	}
+	if r.claudeBin == "" {
+		r.claudeBin = defaultClaudeBin
+	}
+	if r.newCommand == nil {
+		r.newCommand = realCommandFactory
+	}
+	if r.now == nil {
+		r.now = time.Now
+	}
+	return r
+}
+
+// realCommandFactory wraps exec.CommandContext. name is a hardcoded literal
+// ("claude") unless operator-overridden, and args are passed as discrete
+// argv elements with no intermediate shell, so no argument here can be
+// reinterpreted as a command.
+func realCommandFactory(ctx context.Context, name string, args ...string) cmdRunner {
+	return exec.CommandContext(ctx, name, args...) //nolint:gosec // G204: see doc comment above
+}
+
+// Query starts one command-center turn if none is currently in flight,
+// returning ErrBusy immediately otherwise. The returned channel is closed
+// once the query finishes (successfully or not); the caller must drain it.
+func (r *Runner) Query(ctx context.Context, prompt string) (<-chan Event, error) {
+	r.mu.Lock()
+	if r.busy {
+		r.mu.Unlock()
+		return nil, ErrBusy
+	}
+	r.busy = true
+	r.mu.Unlock()
+
+	events := make(chan Event, 64)
+	go func() {
+		defer close(events)
+		defer func() {
+			r.mu.Lock()
+			r.busy = false
+			r.mu.Unlock()
+		}()
+		r.run(ctx, prompt, events)
+	}()
+	return events, nil
+}
+
+func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
+	state, err := LoadSessionFile(r.sessionPath)
+	if err != nil {
+		events <- errorEvent("loading command center session state: %v", err)
+		return
+	}
+	firstRun := state.SessionID == ""
+
+	mcpPath, cleanup, err := r.buildMCPConfig()
+	if err != nil {
+		events <- errorEvent("building mcp config: %v", err)
+		return
+	}
+	defer cleanup()
+
+	cmd := r.newCommand(ctx, r.claudeBin, r.buildArgs(state.SessionID, firstRun, mcpPath, prompt)...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		events <- errorEvent("creating stdout pipe: %v", err)
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		events <- errorEvent("starting claude: %v", err)
+		return
+	}
+
+	historyEntries, capturedSessionID, scanFailed := r.streamOutput(stdout, events)
+
+	waitErr := cmd.Wait()
+
+	if len(historyEntries) > 0 {
+		if err := AppendHistory(r.historyPath, historyEntries); err != nil {
+			events <- errorEvent("persisting command center history: %v", err)
+		}
+	}
+
+	if scanFailed {
+		return // an EventError for the malformed line was already sent
+	}
+	if waitErr != nil {
+		events <- errorEvent("claude exited with error: %v", waitErr)
+		return
+	}
+	if firstRun && capturedSessionID != "" {
+		if err := SaveSessionFile(r.sessionPath, SessionState{SessionID: capturedSessionID}); err != nil {
+			events <- errorEvent("persisting command center session id: %v", err)
+			return
+		}
+	}
+	events <- Event{Type: EventDone}
+}
+
+func (r *Runner) buildArgs(sessionID string, firstRun bool, mcpPath, prompt string) []string {
+	args := []string{"-p"}
+	if !firstRun {
+		args = append(args, "--resume", sessionID)
+	}
+	args = append(args,
+		"--output-format=stream-json",
+		"--verbose",
+		"--mcp-config", mcpPath,
+		"--allowedTools", strings.Join(r.allowedTools, ","),
+		prompt,
+	)
+	return args
+}
+
+// streamOutput reads stdout line by line, emitting an EventLine per parsed
+// stream-json line and collecting HistoryEntry copies for persistence. It
+// stops at the first line that fails to parse as a JSON object, having
+// already sent the corresponding EventError, and drains any remaining
+// output so the subprocess is never left blocked writing into a pipe no one
+// is reading — Wait() must still be safe to call after this returns.
+func (r *Runner) streamOutput(
+	stdout io.ReadCloser, events chan<- Event,
+) (entries []HistoryEntry, sessionID string, failed bool) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		lineCopy := append([]byte(nil), line...)
+
+		var probe struct {
+			SessionID string `json:"session_id"`
+		}
+		if err := json.Unmarshal(lineCopy, &probe); err != nil {
+			events <- errorEvent("malformed stream-json output: %v", err)
+			_, _ = io.Copy(io.Discard, stdout)
+			return entries, sessionID, true
+		}
+		if probe.SessionID != "" {
+			sessionID = probe.SessionID
+		}
+		entries = append(entries, HistoryEntry{At: r.now(), Raw: json.RawMessage(lineCopy)})
+		events <- Event{Type: EventLine, Raw: json.RawMessage(lineCopy)}
+	}
+	if err := scanner.Err(); err != nil {
+		events <- errorEvent("reading claude output: %v", err)
+		return entries, sessionID, true
+	}
+	return entries, sessionID, false
+}
+
+func errorEvent(format string, err error) Event {
+	return Event{Type: EventError, Err: fmt.Sprintf(format, err)}
+}

--- a/internal/commandcenter/runner.go
+++ b/internal/commandcenter/runner.go
@@ -64,8 +64,21 @@ type commandFactory func(ctx context.Context, name string, args ...string) cmdRu
 
 const defaultClaudeBin = "claude"
 
-// RunnerConfig configures a Runner. NewCommand and Now default to
-// production behavior (a real subprocess, time.Now) when left zero.
+// defaultQueryTimeout bounds how long a single query's subprocess may run.
+// Without this, a hung or very slow `claude` invocation would keep the
+// Runner's single-query busy flag set indefinitely — worse, the context
+// Query receives from the WS handler is the request context of an already
+// http.Hijack'd connection (see internal/ws/board_command.go), which the
+// standard library never cancels on client disconnect, so relying on the
+// caller's own context alone is not sufficient. A generous but finite
+// default keeps an abandoned or wedged query from blocking the command
+// center forever, while still allowing a genuinely long agent turn to
+// finish.
+const defaultQueryTimeout = 5 * time.Minute
+
+// RunnerConfig configures a Runner. NewCommand, Now, and QueryTimeout
+// default to production behavior (a real subprocess, time.Now,
+// defaultQueryTimeout) when left zero.
 type RunnerConfig struct {
 	BuildMCPConfig func() (path string, cleanup func(), err error)
 	NewCommand     commandFactory
@@ -74,6 +87,7 @@ type RunnerConfig struct {
 	SessionPath    string
 	HistoryPath    string
 	AllowedTools   []string
+	QueryTimeout   time.Duration
 }
 
 // Runner drives the command center's per-query `claude -p [--resume]`
@@ -89,6 +103,7 @@ type Runner struct {
 	sessionPath    string
 	historyPath    string
 	allowedTools   []string
+	queryTimeout   time.Duration
 	mu             sync.Mutex
 	busy           bool
 }
@@ -103,6 +118,7 @@ func NewRunner(cfg RunnerConfig) *Runner {
 		sessionPath:    cfg.SessionPath,
 		historyPath:    cfg.HistoryPath,
 		allowedTools:   cfg.AllowedTools,
+		queryTimeout:   cfg.QueryTimeout,
 	}
 	if r.claudeBin == "" {
 		r.claudeBin = defaultClaudeBin
@@ -112,6 +128,9 @@ func NewRunner(cfg RunnerConfig) *Runner {
 	}
 	if r.now == nil {
 		r.now = time.Now
+	}
+	if r.queryTimeout <= 0 {
+		r.queryTimeout = defaultQueryTimeout
 	}
 	return r
 }
@@ -150,6 +169,9 @@ func (r *Runner) Query(ctx context.Context, prompt string) (<-chan Event, error)
 }
 
 func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
 	state, err := LoadSessionFile(r.sessionPath)
 	if err != nil {
 		events <- errorEvent("loading command center session state: %v", err)
@@ -189,6 +211,17 @@ func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
 		return // an EventError for the malformed line was already sent
 	}
 	if waitErr != nil {
+		if !firstRun {
+			// A resume failure is the CLI's own signal that --resume
+			// continuity is already broken (e.g. the user cleared
+			// ~/.claude, or the session was garbage collected) — clear the
+			// persisted id so the next query starts a fresh first-run
+			// instead of retrying the same doomed id forever. Best-effort:
+			// a failure to clear it doesn't need its own separate event: the
+			// query's own error below is still the actionable one, and the
+			// next query will simply hit the same resume failure again.
+			_ = SaveSessionFile(r.sessionPath, SessionState{})
+		}
 		events <- errorEvent("claude exited with error: %v", waitErr)
 		return
 	}
@@ -201,6 +234,23 @@ func (r *Runner) run(ctx context.Context, prompt string, events chan<- Event) {
 	events <- Event{Type: EventDone}
 }
 
+// buildArgs constructs the claude CLI argv. Two details here are load-bearing
+// for safety, both verified live against the real CLI (v2.1.226), not just
+// inferred from --help text:
+//
+//   - "--allowedTools" is declared variadic (`<tools...>`) by the CLI's own
+//     parser, so passing it and its value as two separate argv elements lets
+//     it swallow the very next element too — which would be the prompt,
+//     silently breaking every query ("Input must be provided either through
+//     stdin or as a prompt argument"). The "=" form
+//     ("--allowedTools=a,b,c") is a single argv element and cannot be
+//     extended by a following element.
+//   - The prompt is preceded by a literal "--" end-of-options marker.
+//     Without it, a prompt beginning with "-" (e.g. a user typing
+//     "--help" into the palette) is parsed as a CLI flag instead of being
+//     passed through as prompt text — argument injection into the claude
+//     CLI's own option parser, up to and including flags that alter its
+//     permission model.
 func (r *Runner) buildArgs(sessionID string, firstRun bool, mcpPath, prompt string) []string {
 	args := []string{"-p"}
 	if !firstRun {
@@ -210,7 +260,8 @@ func (r *Runner) buildArgs(sessionID string, firstRun bool, mcpPath, prompt stri
 		"--output-format=stream-json",
 		"--verbose",
 		"--mcp-config", mcpPath,
-		"--allowedTools", strings.Join(r.allowedTools, ","),
+		"--allowedTools="+strings.Join(r.allowedTools, ","),
+		"--",
 		prompt,
 	)
 	return args
@@ -218,13 +269,17 @@ func (r *Runner) buildArgs(sessionID string, firstRun bool, mcpPath, prompt stri
 
 // streamOutput reads stdout line by line, emitting an EventLine per parsed
 // stream-json line and collecting HistoryEntry copies for persistence. It
-// stops at the first line that fails to parse as a JSON object, having
-// already sent the corresponding EventError, and drains any remaining
-// output so the subprocess is never left blocked writing into a pipe no one
-// is reading — Wait() must still be safe to call after this returns.
+// stops at the first line that fails to parse as a JSON object or the first
+// underlying read error, having already sent the corresponding EventError,
+// and — via the deferred drain below, covering every exit path uniformly —
+// always drains any remaining output so the subprocess is never left
+// blocked writing into a pipe no one is reading. Wait() must still be safe
+// to call after this returns.
 func (r *Runner) streamOutput(
 	stdout io.ReadCloser, events chan<- Event,
 ) (entries []HistoryEntry, sessionID string, failed bool) {
+	defer func() { _, _ = io.Copy(io.Discard, stdout) }()
+
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	for scanner.Scan() {
@@ -239,7 +294,6 @@ func (r *Runner) streamOutput(
 		}
 		if err := json.Unmarshal(lineCopy, &probe); err != nil {
 			events <- errorEvent("malformed stream-json output: %v", err)
-			_, _ = io.Copy(io.Discard, stdout)
 			return entries, sessionID, true
 		}
 		if probe.SessionID != "" {

--- a/internal/commandcenter/runner_test.go
+++ b/internal/commandcenter/runner_test.go
@@ -1,0 +1,283 @@
+package commandcenter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCmd struct {
+	stdout   io.ReadCloser
+	startErr error
+	waitErr  error
+}
+
+func (f *fakeCmd) StdoutPipe() (io.ReadCloser, error) { return f.stdout, nil }
+func (f *fakeCmd) Start() error                       { return f.startErr }
+func (f *fakeCmd) Wait() error                        { return f.waitErr }
+
+type capturedInvocation struct {
+	Name string
+	Args []string
+}
+
+func newTestRunner(t *testing.T, factory commandFactory) (*Runner, string, string) {
+	t.Helper()
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	cleanupCalls := 0
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake-mcp-config.json", func() { cleanupCalls++ }, nil
+		},
+		AllowedTools: []string{"mcp__panemux-board__board_status"},
+		NewCommand:   factory,
+		Now:          func() time.Time { return time.Unix(0, 0).UTC() },
+	})
+	return r, sessionPath, historyPath
+}
+
+func drain(t *testing.T, events <-chan Event) []Event {
+	t.Helper()
+	var got []Event
+	for ev := range events {
+		got = append(got, ev)
+	}
+	return got
+}
+
+func TestRunnerFirstRunCapturesAndPersistsSessionID(t *testing.T) {
+	output := `{"type":"system","subtype":"init","session_id":"sess-1"}` + "\n" +
+		`{"type":"result","session_id":"sess-1","result":"done"}` + "\n"
+	var captured capturedInvocation
+	factory := func(_ context.Context, name string, args ...string) cmdRunner {
+		captured = capturedInvocation{Name: name, Args: args}
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(output))}
+	}
+	r, sessionPath, historyPath := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "hello there")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 3)
+	assert.Equal(t, EventLine, got[0].Type)
+	assert.Equal(t, EventLine, got[1].Type)
+	assert.Equal(t, EventDone, got[2].Type)
+
+	assert.Equal(t, "claude", captured.Name)
+	assert.NotContains(t, captured.Args, "--resume")
+	assert.Equal(t, "hello there", captured.Args[len(captured.Args)-1])
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "sess-1", state.SessionID)
+
+	entries, err := LoadHistory(historyPath)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestRunnerResumeUsesPersistedSessionIDAndNeverOverwritesIt(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	require.NoError(t, SaveSessionFile(sessionPath, SessionState{SessionID: "existing-session"}))
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+
+	output := `{"type":"result","session_id":"existing-session","result":"ok"}` + "\n"
+	var captured capturedInvocation
+	factory := func(_ context.Context, name string, args ...string) cmdRunner {
+		captured = capturedInvocation{Name: name, Args: args}
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(output))}
+	}
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake-mcp-config.json", func() {}, nil
+		},
+		AllowedTools: []string{"mcp__panemux-board__board_status"},
+		NewCommand:   factory,
+	})
+
+	events, err := r.Query(context.Background(), "follow up")
+	require.NoError(t, err)
+	drain(t, events)
+
+	require.Contains(t, captured.Args, "--resume")
+	idx := indexOf(captured.Args, "--resume")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Equal(t, "existing-session", captured.Args[idx+1])
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-session", state.SessionID)
+}
+
+func TestRunnerRejectsSecondQueryWhileBusy(t *testing.T) {
+	pr, pw := io.Pipe()
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: pr}
+	}
+	r, _, _ := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "first")
+	require.NoError(t, err)
+
+	_, err = r.Query(context.Background(), "second")
+	assert.ErrorIs(t, err, ErrBusy)
+
+	_, _ = pw.Write([]byte(`{"type":"result","session_id":"s"}` + "\n"))
+	require.NoError(t, pw.Close())
+	drain(t, events)
+
+	// Busy is released once the first query's goroutine finishes.
+	events2, err := r.Query(context.Background(), "third")
+	require.NoError(t, err)
+	drain(t, events2)
+}
+
+func TestRunnerMalformedStreamJSONEmitsErrorAndStops(t *testing.T) {
+	output := `{"type":"system","subtype":"init","session_id":"sess-1"}` + "\n" +
+		`not json` + "\n" +
+		`{"type":"result","session_id":"sess-1"}` + "\n"
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(output))}
+	}
+	r, sessionPath, historyPath := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, EventLine, got[0].Type)
+	assert.Equal(t, EventError, got[1].Type)
+	assert.Contains(t, got[1].Err, "malformed")
+
+	// A failed query must never persist a session id.
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, state.SessionID)
+
+	// What was captured before the failure is still persisted to history.
+	entries, err := LoadHistory(historyPath)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestRunnerNonZeroExitEmitsErrorEventAndSkipsSessionPersist(t *testing.T) {
+	output := `{"type":"system","subtype":"init","session_id":"sess-1"}` + "\n"
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(output)), waitErr: errors.New("exit status 1")}
+	}
+	r, sessionPath, historyPath := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, EventLine, got[0].Type)
+	assert.Equal(t, EventError, got[1].Type)
+	assert.Contains(t, got[1].Err, "exit status 1")
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, state.SessionID, "a failed query must never persist a session id")
+
+	entries, err := LoadHistory(historyPath)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "output captured before the failing exit is still persisted")
+}
+
+func TestRunnerStartErrorEmitsErrorEventAndReleasesBusy(t *testing.T) {
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader("")), startErr: errors.New("claude: command not found")}
+	}
+	r, _, _ := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, EventError, got[0].Type)
+	assert.Contains(t, got[0].Err, "command not found")
+
+	// Busy must be released even though this query failed to start.
+	events2, err := r.Query(context.Background(), "second")
+	require.NoError(t, err)
+	drain(t, events2)
+}
+
+func TestRunnerBuildMCPConfigFailureEmitsErrorAndNeverStartsProcess(t *testing.T) {
+	started := false
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		started = true
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(""))}
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "", nil, errors.New("disk full")
+		},
+		NewCommand: factory,
+	})
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, EventError, got[0].Type)
+	assert.Contains(t, got[0].Err, "disk full")
+	assert.False(t, started, "must never spawn claude when mcp config setup fails")
+}
+
+func TestRunnerAlwaysCallsMCPConfigCleanup(t *testing.T) {
+	cleanupCalled := false
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader("")), waitErr: errors.New("boom")}
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake.json", func() { cleanupCalled = true }, nil
+		},
+		NewCommand: factory,
+	})
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	drain(t, events)
+
+	assert.True(t, cleanupCalled)
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, v := range haystack {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/commandcenter/runner_test.go
+++ b/internal/commandcenter/runner_test.go
@@ -197,6 +197,170 @@ func TestRunnerResumeFailureClearsStaleSessionID(t *testing.T) {
 	assert.Empty(t, state.SessionID, "a failed --resume must clear the stale session id, not repeat it forever")
 }
 
+// TestRunnerMalformedPersistedSessionIDFallsBackToFirstRun covers a
+// persisted session id that doesn't look like anything claude itself would
+// ever emit — in particular one shaped like a CLI flag. --resume's value is
+// optional in the claude CLI's own parser, so passing such a value straight
+// through as the argv element after "--resume" risks the same class of
+// argument-injection buildArgs's own "--" marker defends the prompt
+// against, except --resume's value sits before that marker and has no
+// marker of its own to rely on. The Runner must instead treat this the same
+// as no persisted id at all: query without --resume, and persist whatever
+// fresh session id this successful first-run query captures.
+func TestRunnerMalformedPersistedSessionIDFallsBackToFirstRun(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	require.NoError(t, SaveSessionFile(sessionPath, SessionState{SessionID: "--dangerously-skip-permissions"}))
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+
+	output := `{"type":"system","subtype":"init","session_id":"new-session-1"}` + "\n" +
+		`{"type":"result","session_id":"new-session-1","result":"done"}` + "\n"
+	var captured capturedInvocation
+	factory := func(_ context.Context, name string, args ...string) cmdRunner {
+		captured = capturedInvocation{Name: name, Args: args}
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(output))}
+	}
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake-mcp-config.json", func() {}, nil
+		},
+		NewCommand: factory,
+	})
+
+	events, err := r.Query(context.Background(), "hello there")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.NotEmpty(t, got)
+	assert.Equal(t, EventDone, got[len(got)-1].Type)
+	assert.NotContains(t, captured.Args, "--resume",
+		"a flag-shaped persisted session id must never reach --resume's argv slot")
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "new-session-1", state.SessionID,
+		"the fallback first run's own freshly captured session id must still be persisted")
+}
+
+// sleepingFakeCmd behaves like fakeCmd, but Wait() sleeps first — used to
+// force a query's own context deadline to have already passed by the time
+// Wait() returns, so ctx.Err() reliably reports context.DeadlineExceeded
+// rather than depending on scheduler timing.
+type sleepingFakeCmd struct {
+	stdout          io.ReadCloser
+	waitErr         error
+	sleepBeforeWait time.Duration
+}
+
+func (f *sleepingFakeCmd) StdoutPipe() (io.ReadCloser, error) { return f.stdout, nil }
+func (f *sleepingFakeCmd) Start() error                       { return nil }
+func (f *sleepingFakeCmd) Wait() error {
+	time.Sleep(f.sleepBeforeWait)
+	return f.waitErr
+}
+
+func TestRunnerTimeoutDoesNotClearSessionIdAndReportsTimeoutMessage(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	require.NoError(t, SaveSessionFile(sessionPath, SessionState{SessionID: "existing-session"}))
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &sleepingFakeCmd{
+			stdout:          io.NopCloser(strings.NewReader("")),
+			waitErr:         errors.New("signal: killed"),
+			sleepBeforeWait: 50 * time.Millisecond,
+		}
+	}
+	r := NewRunner(RunnerConfig{
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake.json", func() {}, nil
+		},
+		NewCommand:   factory,
+		QueryTimeout: 10 * time.Millisecond, // well under sleepBeforeWait, so the deadline has already passed
+	})
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, EventError, got[0].Type)
+	assert.Contains(t, got[0].Err, "timed out")
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-session", state.SessionID,
+		"a query-timeout kill must never be mistaken for a genuine --resume rejection")
+}
+
+// ctxAwareFakeCmd's Wait() blocks until ctx is canceled, then returns
+// ctx.Err() — mirroring exec.CommandContext's real behavior, where
+// canceling the context kills the process and is what unblocks a real
+// Wait() call. Used to prove a query context is actually canceled
+// immediately on a malformed line, not merely eventually via the deferred
+// cancel() that only fires after run() itself returns — which can't happen
+// until Wait() returns, an actual deadlock without the fix.
+type ctxAwareFakeCmd struct {
+	stdout io.ReadCloser
+	// Deliberately stored: this fake needs it inside Wait(), mirroring
+	// exec.Cmd's own real ctx-awareness.
+	ctx context.Context //nolint:containedctx
+}
+
+func (f *ctxAwareFakeCmd) StdoutPipe() (io.ReadCloser, error) { return f.stdout, nil }
+func (f *ctxAwareFakeCmd) Start() error                       { return nil }
+func (f *ctxAwareFakeCmd) Wait() error {
+	<-f.ctx.Done()
+	return f.ctx.Err() //nolint:wrapcheck // test fake mirrors exec.Cmd's own unwrapped ctx.Err() propagation
+}
+
+func TestRunnerMalformedStreamJSONCancelsQueryContextImmediately(t *testing.T) {
+	// A malformed line already tells the client the query failed (see
+	// TestRunnerMalformedStreamJSONEmitsErrorAndStops); the subprocess must
+	// not be left running for up to the full query timeout just to exit on
+	// its own afterward, holding the busy flag the whole time.
+	output := `not json` + "\n"
+	factory := func(ctx context.Context, _ string, _ ...string) cmdRunner {
+		return &ctxAwareFakeCmd{stdout: io.NopCloser(strings.NewReader(output)), ctx: ctx}
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	r := NewRunner(RunnerConfig{
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake.json", func() {}, nil
+		},
+		NewCommand: factory,
+		// Deliberately long: if the fix doesn't call cancel() before
+		// cmd.Wait(), this test deadlocks (Wait() can't return until
+		// canceled; run() can't call its deferred cancel() until Wait()
+		// returns) rather than merely running slowly, so the 2s bound below
+		// catches a real regression, not just a slow one.
+		QueryTimeout: time.Minute,
+	})
+
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		drain(t, events)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("query did not complete promptly after a malformed line — " +
+			"the subprocess context was not canceled immediately")
+	}
+}
+
 func TestRunnerRejectsSecondQueryWhileBusy(t *testing.T) {
 	pr, pw := io.Pipe()
 	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {

--- a/internal/commandcenter/runner_test.go
+++ b/internal/commandcenter/runner_test.go
@@ -88,6 +88,42 @@ func TestRunnerFirstRunCapturesAndPersistsSessionID(t *testing.T) {
 	assert.Len(t, entries, 2)
 }
 
+// TestRunnerBuildArgsShapeIsSafeAgainstArgumentInjection locks in the exact
+// argv shape verified live against the real `claude` CLI (v2.1.226):
+//   - --allowedTools must use the "=" form as a single argv element
+//     ("--allowedTools=a,b"), never two separate elements ("--allowedTools",
+//     "a,b") — the flag is declared variadic (`<tools...>`), so a two-element
+//     form lets it swallow the very next argv element (the prompt) as an
+//     additional tool name, and a real query then fails with "Input must be
+//     provided either through stdin or as a prompt argument".
+//   - "--" must immediately precede the prompt — without it, a prompt
+//     beginning with "-" (e.g. "--help") is parsed as a CLI flag instead of
+//     being passed through as prompt text.
+//
+// Both failure modes were reproduced against the real CLI before this fix;
+// this test only pins the argv shape so a regression is caught without
+// needing the CLI installed.
+func TestRunnerBuildArgsShapeIsSafeAgainstArgumentInjection(t *testing.T) {
+	var captured capturedInvocation
+	factory := func(_ context.Context, name string, args ...string) cmdRunner {
+		captured = capturedInvocation{Name: name, Args: args}
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(""))}
+	}
+	r, _, _ := newTestRunner(t, factory)
+
+	events, err := r.Query(context.Background(), "--help")
+	require.NoError(t, err)
+	drain(t, events)
+
+	require.Contains(t, captured.Args, "--allowedTools=mcp__panemux-board__board_status")
+	assert.NotContains(t, captured.Args, "--allowedTools")
+
+	dashDashIdx := indexOf(captured.Args, "--")
+	require.GreaterOrEqual(t, dashDashIdx, 0, "expected a literal -- before the prompt, got %v", captured.Args)
+	require.Equal(t, len(captured.Args)-2, dashDashIdx, "-- must immediately precede the final (prompt) argument")
+	assert.Equal(t, "--help", captured.Args[len(captured.Args)-1])
+}
+
 func TestRunnerResumeUsesPersistedSessionIDAndNeverOverwritesIt(t *testing.T) {
 	sessionPath := filepath.Join(t.TempDir(), "session.json")
 	require.NoError(t, SaveSessionFile(sessionPath, SessionState{SessionID: "existing-session"}))
@@ -122,6 +158,43 @@ func TestRunnerResumeUsesPersistedSessionIDAndNeverOverwritesIt(t *testing.T) {
 	state, err := LoadSessionFile(sessionPath)
 	require.NoError(t, err)
 	assert.Equal(t, "existing-session", state.SessionID)
+}
+
+// TestRunnerResumeFailureClearsStaleSessionID covers the case where claude
+// no longer recognizes a persisted --resume id (e.g. the user cleared
+// ~/.claude, or the session was garbage collected): without this, every
+// future query would keep retrying the same dead id forever, since
+// SaveSessionFile is only ever reached on a *first-run* success (see
+// TestRunnerNonZeroExitEmitsErrorEventAndSkipsSessionPersist) — nothing
+// else would ever clear a bad resume id.
+func TestRunnerResumeFailureClearsStaleSessionID(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	require.NoError(t, SaveSessionFile(sessionPath, SessionState{SessionID: "dead-session"}))
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+
+	factory := func(_ context.Context, _ string, _ ...string) cmdRunner {
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader("")), waitErr: errors.New("exit status 1")}
+	}
+	r := NewRunner(RunnerConfig{
+		ClaudeBin:   "claude",
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake-mcp-config.json", func() {}, nil
+		},
+		NewCommand: factory,
+	})
+
+	events, err := r.Query(context.Background(), "follow up")
+	require.NoError(t, err)
+	got := drain(t, events)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, EventError, got[0].Type)
+
+	state, err := LoadSessionFile(sessionPath)
+	require.NoError(t, err)
+	assert.Empty(t, state.SessionID, "a failed --resume must clear the stale session id, not repeat it forever")
 }
 
 func TestRunnerRejectsSecondQueryWhileBusy(t *testing.T) {
@@ -271,6 +344,109 @@ func TestRunnerAlwaysCallsMCPConfigCleanup(t *testing.T) {
 	drain(t, events)
 
 	assert.True(t, cleanupCalled)
+}
+
+func TestRunnerAppliesConfiguredQueryTimeoutToSubprocessContext(t *testing.T) {
+	var capturedCtx context.Context
+	factory := func(ctx context.Context, _ string, _ ...string) cmdRunner {
+		capturedCtx = ctx
+		return &fakeCmd{stdout: io.NopCloser(strings.NewReader(""))}
+	}
+	sessionPath := filepath.Join(t.TempDir(), "session.json")
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	r := NewRunner(RunnerConfig{
+		SessionPath: sessionPath,
+		HistoryPath: historyPath,
+		BuildMCPConfig: func() (string, func(), error) {
+			return "/tmp/fake.json", func() {}, nil
+		},
+		NewCommand:   factory,
+		QueryTimeout: 30 * time.Second,
+	})
+
+	before := time.Now()
+	events, err := r.Query(context.Background(), "prompt")
+	require.NoError(t, err)
+	drain(t, events)
+
+	require.NotNil(t, capturedCtx, "the subprocess factory must have been called")
+	deadline, ok := capturedCtx.Deadline()
+	require.True(t, ok, "the subprocess context must carry a deadline, or an abandoned/hung "+
+		"query could block the command center's busy flag forever")
+	assert.WithinDuration(t, before.Add(30*time.Second), deadline, 2*time.Second)
+}
+
+func TestRunnerDefaultsQueryTimeoutWhenUnconfigured(t *testing.T) {
+	r := NewRunner(RunnerConfig{})
+
+	assert.Equal(t, defaultQueryTimeout, r.queryTimeout)
+}
+
+// errThenMoreReader emits `before` with nil errors, then `sentinel`, then
+// (only if Read is called again — proving the caller kept draining) `after`
+// followed by io.EOF. Used to test that streamOutput's scanner.Err() path
+// keeps reading stdout to completion rather than abandoning it mid-stream.
+type errThenMoreReader struct {
+	before      []byte
+	sentinel    error
+	after       []byte
+	pos         int
+	stage       int
+	afterServed bool
+}
+
+func (r *errThenMoreReader) Read(p []byte) (int, error) {
+	switch r.stage {
+	case 0:
+		n := copy(p, r.before[r.pos:])
+		r.pos += n
+		if r.pos >= len(r.before) {
+			r.stage = 1
+		}
+		return n, nil
+	case 1:
+		r.stage = 2
+		return 0, r.sentinel
+	default:
+		r.afterServed = true
+		if len(r.after) == 0 {
+			return 0, io.EOF
+		}
+		n := copy(p, r.after)
+		r.after = r.after[n:]
+		return n, io.EOF
+	}
+}
+
+func (r *errThenMoreReader) Close() error { return nil }
+
+func TestRunnerStreamOutputDrainsRemainingOutputAfterScannerError(t *testing.T) {
+	reader := &errThenMoreReader{
+		before:   []byte(`{"type":"system","subtype":"init","session_id":"sess-1"}` + "\n"),
+		sentinel: errors.New("boom"),
+		after:    []byte("leftover buffered subprocess output"),
+	}
+	r := NewRunner(RunnerConfig{})
+	events := make(chan Event, 8)
+
+	entries, sessionID, failed := r.streamOutput(reader, events)
+	close(events)
+
+	assert.True(t, failed)
+	assert.Equal(t, "sess-1", sessionID)
+	require.Len(t, entries, 1)
+	assert.True(t, reader.afterServed,
+		"streamOutput must keep reading stdout after a scanner error (not just a malformed-JSON error), "+
+			"or a subprocess still writing to the pipe could block cmd.Wait() forever")
+
+	var got []Event
+	for ev := range events {
+		got = append(got, ev)
+	}
+	require.Len(t, got, 2)
+	assert.Equal(t, EventLine, got[0].Type)
+	assert.Equal(t, EventError, got[1].Type)
+	assert.Contains(t, got[1].Err, "boom")
 }
 
 func indexOf(haystack []string, needle string) int {

--- a/internal/commandcenter/session_store.go
+++ b/internal/commandcenter/session_store.go
@@ -1,0 +1,57 @@
+package commandcenter
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const sessionFileName = "command-center-session.json"
+const sessionFileMode os.FileMode = 0600
+
+// SessionState is the command center's own persisted --resume continuity: a
+// single fixed Claude session id reused across every later query. See
+// docs/agent-board.md's Process lifecycle section.
+type SessionState struct {
+	SessionID string `json:"session_id"`
+}
+
+// LoadSessionFile reads a previously persisted SessionState. A missing file
+// is the normal state before the first successful query, not an error, and
+// returns the zero value.
+func LoadSessionFile(path string) (SessionState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SessionState{}, nil
+		}
+		return SessionState{}, fmt.Errorf("reading command center session file: %w", err)
+	}
+	var state SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return SessionState{}, fmt.Errorf("parsing command center session file: %w", err)
+	}
+	return state, nil
+}
+
+// SaveSessionFile persists state, creating the parent directory if needed,
+// via a temp file plus rename so a crash mid-write can never leave a
+// truncated file behind.
+func SaveSessionFile(path string, state SessionState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("encoding command center session file: %w", err)
+	}
+	return atomicWriteFile(path, data, sessionFileMode, "command center session file")
+}
+
+// DefaultSessionFilePath returns ~/.config/panemux/command-center-session.json.
+func DefaultSessionFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("getting home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "panemux", sessionFileName), nil
+}

--- a/internal/commandcenter/session_store_test.go
+++ b/internal/commandcenter/session_store_test.go
@@ -1,0 +1,60 @@
+package commandcenter
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadSessionFileMissingReturnsZeroValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+
+	state, err := LoadSessionFile(path)
+
+	require.NoError(t, err)
+	assert.Equal(t, SessionState{}, state)
+}
+
+func TestSaveThenLoadSessionFileRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "command-center-session.json")
+
+	require.NoError(t, SaveSessionFile(path, SessionState{SessionID: "sess-123"}))
+
+	state, err := LoadSessionFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, SessionState{SessionID: "sess-123"}, state)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+func TestSaveSessionFileOverwritesPreviousSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "command-center-session.json")
+
+	require.NoError(t, SaveSessionFile(path, SessionState{SessionID: "first"}))
+	require.NoError(t, SaveSessionFile(path, SessionState{SessionID: "second"}))
+
+	state, err := LoadSessionFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "second", state.SessionID)
+}
+
+func TestLoadSessionFileMalformedJSONReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "command-center-session.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0600))
+
+	_, err := LoadSessionFile(path)
+
+	assert.Error(t, err)
+}
+
+func TestDefaultSessionFilePath(t *testing.T) {
+	path, err := DefaultSessionFilePath()
+
+	require.NoError(t, err)
+	assert.Contains(t, path, filepath.Join(".config", "panemux", "command-center-session.json"))
+}

--- a/internal/server/board_routes_test.go
+++ b/internal/server/board_routes_test.go
@@ -23,9 +23,9 @@ func TestServer_BoardRoutesWired_RequireAuth(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
 	cache := board.NewBoardCache()
-	srv := New(cfg, mgr, cache, nil, emptyFS)
+	srv := New(cfg, mgr, cache, nil, nil, emptyFS)
 
-	paths := []string{"/api/board/status", "/api/board/messages"}
+	paths := []string{"/api/board/status", "/api/board/messages", "/api/board/command/history"}
 	for _, path := range paths {
 		t.Run(path, func(t *testing.T) {
 			rec := httptest.NewRecorder()
@@ -40,7 +40,7 @@ func TestServer_BoardRoutes_WrongToken_Rejected(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
 	cache := board.NewBoardCache()
-	srv := New(cfg, mgr, cache, nil, emptyFS)
+	srv := New(cfg, mgr, cache, nil, nil, emptyFS)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
@@ -53,7 +53,7 @@ func TestServer_BoardRoutes_CorrectToken_Reaches200(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
 	cache := board.NewBoardCache()
-	srv := New(cfg, mgr, cache, nil, emptyFS)
+	srv := New(cfg, mgr, cache, nil, nil, emptyFS)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/board/status", nil)
@@ -62,13 +62,34 @@ func TestServer_BoardRoutes_CorrectToken_Reaches200(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestServer_SessionTokenRoute_RemainsUnauthenticated(t *testing.T) {
+	// Regression test: /api/session-token must stay reachable with no
+	// Authorization header even though every other /api/board/* route
+	// requires one — see GetBoardSessionToken's own doc comment. This is
+	// checked against the real server.New()-constructed router (not just a
+	// handler-level test router) because chi routes any path starting with
+	// /api/board/ into the bearer-gated sub-router regardless of where a
+	// handler for that literal path is registered elsewhere — an earlier
+	// version of this endpoint lived at /api/board/session-token and was
+	// silently caught by that middleware despite never being registered
+	// inside the bearer-gated route group.
+	cfg := testConfigWithToken("secret-token")
+	mgr := session.NewManager()
+	srv := New(cfg, mgr, board.NewBoardCache(), nil, nil, emptyFS)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	srv.httpSrv.Handler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code, "session-token must be reachable with no Authorization header")
+}
+
 func TestServer_ExistingAPIRoutes_RemainUnauthenticated(t *testing.T) {
 	// Regression test: scoping bearerAuthMiddleware to /api/board must not
 	// widen to any pre-existing route — the current frontend sends no
 	// token at all.
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, board.NewBoardCache(), nil, emptyFS)
+	srv := New(cfg, mgr, board.NewBoardCache(), nil, nil, emptyFS)
 
 	paths := []string{"/api/layout", "/api/workspaces", "/api/sessions", "/api/display"}
 	for _, path := range paths {
@@ -85,7 +106,7 @@ func TestServer_ExistingAPIRoutes_RemainUnauthenticated(t *testing.T) {
 func TestServer_WSRoute_RemainsUnauthenticated(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, board.NewBoardCache(), nil, emptyFS)
+	srv := New(cfg, mgr, board.NewBoardCache(), nil, nil, emptyFS)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/ws/nonexistent-session", nil)

--- a/internal/server/board_routes_test.go
+++ b/internal/server/board_routes_test.go
@@ -64,21 +64,26 @@ func TestServer_BoardRoutes_CorrectToken_Reaches200(t *testing.T) {
 
 func TestServer_SessionTokenRoute_RemainsUnauthenticated(t *testing.T) {
 	// Regression test: /api/session-token must stay reachable with no
-	// Authorization header even though every other /api/board/* route
-	// requires one — see GetBoardSessionToken's own doc comment. This is
-	// checked against the real server.New()-constructed router (not just a
-	// handler-level test router) because chi routes any path starting with
-	// /api/board/ into the bearer-gated sub-router regardless of where a
-	// handler for that literal path is registered elsewhere — an earlier
-	// version of this endpoint lived at /api/board/session-token and was
-	// silently caught by that middleware despite never being registered
-	// inside the bearer-gated route group.
+	// Authorization header, from a loopback caller, even though every other
+	// /api/board/* route requires a bearer token — see GetBoardSessionToken's
+	// own doc comment. This is checked against the real
+	// server.New()-constructed router (not just a handler-level test router)
+	// because chi routes any path starting with /api/board/ into the
+	// bearer-gated sub-router regardless of where a handler for that literal
+	// path is registered elsewhere — an earlier version of this endpoint
+	// lived at /api/board/session-token and was silently caught by that
+	// middleware despite never being registered inside the bearer-gated
+	// route group. The request still needs a loopback RemoteAddr/Host: this
+	// route's own separate, non-bearer-token guard (RemoteAddr and Host both
+	// loopback) is exercised directly in internal/api/board_test.go.
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()
 	srv := New(cfg, mgr, board.NewBoardCache(), nil, nil, emptyFS)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/session-token", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	req.Host = "127.0.0.1:8080"
 	srv.httpSrv.Handler.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code, "session-token must be reachable with no Authorization header")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 
 	"panemux/internal/api"
 	"panemux/internal/board"
+	"panemux/internal/commandcenter"
 	"panemux/internal/config"
 	"panemux/internal/session"
 	"panemux/internal/ws"
@@ -29,10 +30,13 @@ type Server struct {
 	httpSrv *http.Server
 }
 
-// New creates a new server instance.
+// New creates a new server instance. commandRunner may be nil when
+// command_center.enabled is false — the /ws/board-command route is simply
+// not registered in that case, so it 404s like any other undefined route
+// rather than panicking on a nil runner.
 func New(
 	cfg *config.Config, manager *session.Manager, boardCache *board.BoardCache, boardRelay *board.Relay,
-	frontendFS embed.FS,
+	commandRunner *commandcenter.Runner, frontendFS embed.FS,
 ) *Server {
 	r := chi.NewRouter()
 	r.Use(middleware.Logger)
@@ -42,7 +46,7 @@ func New(
 
 	apiHandler := api.NewHandler(cfg, manager, boardCache, boardRelay)
 	wsHandler := ws.NewHandler(manager)
-	registerRoutes(r, apiHandler, wsHandler, frontendFS, cfg.Server.AuthToken)
+	registerRoutes(r, apiHandler, wsHandler, commandRunner, frontendFS, cfg.Server.AuthToken)
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	return &Server{
@@ -60,7 +64,8 @@ func New(
 }
 
 func registerRoutes(
-	r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, frontendFS embed.FS, authToken string,
+	r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, commandRunner *commandcenter.Runner,
+	frontendFS embed.FS, authToken string,
 ) {
 	r.Route("/api", func(r chi.Router) {
 		r.Get("/layout", apiHandler.GetLayout)
@@ -85,6 +90,14 @@ func registerRoutes(
 		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
 		r.Get("/detect-shell", apiHandler.GetDetectShell)
 		r.Get("/directories", apiHandler.GetDirectories)
+		// Deliberately NOT placed under /board/ — chi routes any path
+		// starting with /api/board/ into the r.Route("/api/board", ...)
+		// sub-router below regardless of where else a handler for that path
+		// is registered, so a route literally named /api/board/session-token
+		// would always be caught by bearerAuthMiddleware even when defined
+		// here. See GetBoardSessionToken's own doc comment for why this one
+		// route must stay unauthenticated.
+		r.Get("/session-token", apiHandler.GetBoardSessionToken)
 	})
 	// /api/board/* is the only part of the API gated behind bearer-token
 	// auth today: unlike every other /api/* route and /ws/{sessionID},
@@ -97,8 +110,17 @@ func registerRoutes(
 		r.Get("/status", apiHandler.GetBoardStatus)
 		r.Get("/messages", apiHandler.GetBoardMessages)
 		r.Post("/broadcast", apiHandler.PostBoardBroadcast)
+		r.Get("/command/history", apiHandler.GetBoardCommandHistory)
 	})
 	r.Get("/ws/{sessionID}", wsHandler.ServeHTTP)
+	// /ws/board-command is only registered when the command center is
+	// enabled (commandRunner != nil) — see docs/agent-board.md's Command
+	// center section. Unlike /ws/{sessionID}, this route requires the
+	// bearer token, mirroring /api/board/*.
+	if commandRunner != nil {
+		boardCommandHandler := ws.NewBoardCommandHandler(commandRunner, authToken)
+		r.Get("/ws/board-command", boardCommandHandler.ServeHTTP)
+	}
 	registerFrontend(r, frontendFS)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ func New(
 	r.Use(securityHeadersMiddleware)
 
 	apiHandler := api.NewHandler(cfg, manager, boardCache, boardRelay)
+	apiHandler.SetCommandCenterAvailable(commandRunner != nil)
 	wsHandler := ws.NewHandler(manager)
 	registerRoutes(r, apiHandler, wsHandler, commandRunner, frontendFS, cfg.Server.AuthToken)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -46,14 +46,14 @@ func testConfig() *config.Config {
 func TestNew_ReturnsServer(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 }
 
 func TestAddr_ReturnsConfiguredAddress(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	assert.Equal(t, "127.0.0.1:8080", srv.Addr())
 }
 
@@ -154,7 +154,7 @@ func TestIsLocalhostOrigin(t *testing.T) {
 func TestServer_APIRoutesWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()
@@ -166,7 +166,7 @@ func TestServer_APIRoutesWired(t *testing.T) {
 func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()
@@ -181,7 +181,7 @@ func TestServer_WorkspaceRenameRouteWired(t *testing.T) {
 func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/tab-position", `{"tab_position":"right"}`)
@@ -192,7 +192,7 @@ func TestServer_WorkspaceTabPositionRouteWiredBeforeWorkspaceIDRoute(t *testing.
 func TestServer_WorkspaceVerticalBarWidthRouteWiredBeforeWorkspaceIDRoute(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	performWorkspaceSettingUpdate(t, srv, "/api/workspaces/vertical-bar-width", `{"vertical_bar_width":320}`)
@@ -213,7 +213,7 @@ func performWorkspaceSettingUpdate(t *testing.T, srv *Server, path string, body 
 func TestServer_DirectoriesRouteWired(t *testing.T) {
 	cfg := testConfig()
 	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, emptyFS)
+	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
 	require.NotNil(t, srv)
 
 	rec := httptest.NewRecorder()

--- a/internal/ws/board_command.go
+++ b/internal/ws/board_command.go
@@ -1,0 +1,165 @@
+package ws
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+
+	"panemux/internal/commandcenter"
+)
+
+var boardCommandUpgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin:     checkOrigin,
+}
+
+// boardCommandRunner is the subset of *commandcenter.Runner the WS handler
+// needs, so tests can substitute a fake query without a real `claude`
+// subprocess. *commandcenter.Runner satisfies this directly.
+type boardCommandRunner interface {
+	Query(ctx context.Context, prompt string) (<-chan commandcenter.Event, error)
+}
+
+// boardCommandRequest is the client->server WS frame: one command center
+// prompt per message.
+type boardCommandRequest struct {
+	Prompt string `json:"prompt"`
+}
+
+// boardCommandFrame is the server->client WS frame. Type is one of "line",
+// "error", "done", or "busy" — see docs/agent-board.md's "API and
+// streaming" section.
+//
+//nolint:govet // fieldalignment: field order kept as Type/Raw/Message for readability, padding cost is negligible
+type boardCommandFrame struct {
+	Type    string          `json:"type"`
+	Raw     json.RawMessage `json:"raw,omitempty"`
+	Message string          `json:"message,omitempty"`
+}
+
+// BoardCommandHandler serves WS /ws/board-command: the command center chat
+// used by the Spotlight palette. Unlike /ws/{sessionID}, this route
+// requires the bearer token, matching every other /api/board/* endpoint —
+// see docs/security.md. Browsers cannot set an Authorization header on a
+// WebSocket upgrade request, so the token travels as a WebSocket
+// subprotocol (`new WebSocket(url, [token])`) instead of a query string,
+// keeping it out of server access logs, browser history, and same-origin
+// Referer headers.
+type BoardCommandHandler struct {
+	runner boardCommandRunner
+	token  string
+}
+
+// NewBoardCommandHandler constructs a BoardCommandHandler backed by runner,
+// requiring token on every connection.
+func NewBoardCommandHandler(runner boardCommandRunner, token string) *BoardCommandHandler {
+	return &BoardCommandHandler{runner: runner, token: token}
+}
+
+// ServeHTTP handles GET /ws/board-command.
+func (h *BoardCommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	proto := r.Header.Get("Sec-WebSocket-Protocol")
+	if !validSubprotocolToken(proto, h.token) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	responseHeader := http.Header{}
+	responseHeader.Set("Sec-WebSocket-Protocol", proto)
+	conn, err := boardCommandUpgrader.Upgrade(w, r, responseHeader)
+	if err != nil {
+		log.Printf("board command ws upgrade error: %v", err)
+		return
+	}
+	defer conn.Close() //nolint:errcheck
+	conn.SetReadLimit(wsReadLimitBytes)
+
+	for {
+		msgType, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		if msgType != websocket.TextMessage {
+			continue
+		}
+		if !h.handlePrompt(r.Context(), conn, data) {
+			return
+		}
+	}
+}
+
+// handlePrompt processes one client prompt message. It returns false when
+// the underlying connection has failed and the caller should stop reading
+// further messages.
+func (h *BoardCommandHandler) handlePrompt(ctx context.Context, conn *websocket.Conn, data []byte) bool {
+	var req boardCommandRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return writeBoardCommandFrame(conn, boardCommandFrame{Type: "error", Message: "invalid request: " + err.Error()})
+	}
+
+	events, err := h.runner.Query(ctx, req.Prompt)
+	if err != nil {
+		if errors.Is(err, commandcenter.ErrBusy) {
+			return writeBoardCommandFrame(conn, boardCommandFrame{Type: "busy"})
+		}
+		return writeBoardCommandFrame(conn, boardCommandFrame{Type: "error", Message: err.Error()})
+	}
+	return streamBoardCommandEvents(conn, events)
+}
+
+// streamBoardCommandEvents forwards every event to conn, in order. Once a
+// write fails, it keeps ranging over events without writing further — never
+// abandoning the channel — so the Runner's own goroutine (and its busy
+// flag) is never left blocked sending into a channel nobody drains.
+func streamBoardCommandEvents(conn *websocket.Conn, events <-chan commandcenter.Event) bool {
+	ok := true
+	for ev := range events {
+		if !ok {
+			continue
+		}
+		if !writeBoardCommandFrame(conn, eventToBoardCommandFrame(ev)) {
+			ok = false
+		}
+	}
+	return ok
+}
+
+func eventToBoardCommandFrame(ev commandcenter.Event) boardCommandFrame {
+	switch ev.Type {
+	case commandcenter.EventLine:
+		return boardCommandFrame{Type: "line", Raw: ev.Raw}
+	case commandcenter.EventError:
+		return boardCommandFrame{Type: "error", Message: ev.Err}
+	case commandcenter.EventDone:
+		return boardCommandFrame{Type: "done"}
+	default:
+		return boardCommandFrame{Type: "error", Message: "unknown event type: " + string(ev.Type)}
+	}
+}
+
+func writeBoardCommandFrame(conn *websocket.Conn, frame boardCommandFrame) bool {
+	data, err := json.Marshal(frame)
+	if err != nil {
+		return false
+	}
+	return conn.WriteMessage(websocket.TextMessage, data) == nil
+}
+
+// validSubprotocolToken reports whether proto (the client's offered
+// Sec-WebSocket-Protocol value) matches token, using a constant-time
+// comparison so response timing cannot be used to guess the token
+// byte-by-byte — mirrors internal/server/auth.go's bearerAuthMiddleware,
+// duplicated here because that check is header-shaped
+// ("Authorization: Bearer <token>") and this one is not.
+func validSubprotocolToken(proto, token string) bool {
+	if token == "" || proto == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(proto), []byte(token)) == 1
+}

--- a/internal/ws/board_command.go
+++ b/internal/ws/board_command.go
@@ -29,6 +29,15 @@ var boardCommandUpgrader = websocket.Upgrader{
 // Runner's single-query busy flag forever.
 const boardCommandWriteTimeout = 10 * time.Second
 
+// boardCommandFrame.Type wire values — see docs/agent-board.md's "API and
+// streaming" section.
+const (
+	boardCommandFrameTypeLine  = "line"
+	boardCommandFrameTypeError = "error"
+	boardCommandFrameTypeDone  = "done"
+	boardCommandFrameTypeBusy  = "busy"
+)
+
 // boardCommandConn is the subset of *websocket.Conn this handler writes
 // through, so tests can substitute a fake connection without a real TCP
 // socket. *websocket.Conn satisfies this directly.
@@ -118,15 +127,16 @@ func (h *BoardCommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 func (h *BoardCommandHandler) handlePrompt(ctx context.Context, conn boardCommandConn, data []byte) bool {
 	var req boardCommandRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return writeBoardCommandFrame(conn, boardCommandFrame{Type: "error", Message: "invalid request: " + err.Error()})
+		frame := boardCommandFrame{Type: boardCommandFrameTypeError, Message: "invalid request: " + err.Error()}
+		return writeBoardCommandFrame(conn, frame)
 	}
 
 	events, err := h.runner.Query(ctx, req.Prompt)
 	if err != nil {
 		if errors.Is(err, commandcenter.ErrBusy) {
-			return writeBoardCommandFrame(conn, boardCommandFrame{Type: "busy"})
+			return writeBoardCommandFrame(conn, boardCommandFrame{Type: boardCommandFrameTypeBusy})
 		}
-		return writeBoardCommandFrame(conn, boardCommandFrame{Type: "error", Message: err.Error()})
+		return writeBoardCommandFrame(conn, boardCommandFrame{Type: boardCommandFrameTypeError, Message: err.Error()})
 	}
 	return streamBoardCommandEvents(conn, events)
 }
@@ -151,13 +161,13 @@ func streamBoardCommandEvents(conn boardCommandConn, events <-chan commandcenter
 func eventToBoardCommandFrame(ev commandcenter.Event) boardCommandFrame {
 	switch ev.Type {
 	case commandcenter.EventLine:
-		return boardCommandFrame{Type: "line", Raw: ev.Raw}
+		return boardCommandFrame{Type: boardCommandFrameTypeLine, Raw: ev.Raw}
 	case commandcenter.EventError:
-		return boardCommandFrame{Type: "error", Message: ev.Err}
+		return boardCommandFrame{Type: boardCommandFrameTypeError, Message: ev.Err}
 	case commandcenter.EventDone:
-		return boardCommandFrame{Type: "done"}
+		return boardCommandFrame{Type: boardCommandFrameTypeDone}
 	default:
-		return boardCommandFrame{Type: "error", Message: "unknown event type: " + string(ev.Type)}
+		return boardCommandFrame{Type: boardCommandFrameTypeError, Message: "unknown event type: " + string(ev.Type)}
 	}
 }
 

--- a/internal/ws/board_command.go
+++ b/internal/ws/board_command.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -17,6 +18,23 @@ var boardCommandUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
 	CheckOrigin:     checkOrigin,
+}
+
+// boardCommandWriteTimeout bounds every WriteMessage call this handler
+// makes. Without it, a client that stops reading without closing its TCP
+// connection (a sleeping laptop, a dropped network with no FIN) makes
+// WriteMessage block indefinitely rather than error — the "keep draining
+// without writing" logic in streamBoardCommandEvents only helps once a
+// write actually fails, so an un-deadlined write can still wedge the
+// Runner's single-query busy flag forever.
+const boardCommandWriteTimeout = 10 * time.Second
+
+// boardCommandConn is the subset of *websocket.Conn this handler writes
+// through, so tests can substitute a fake connection without a real TCP
+// socket. *websocket.Conn satisfies this directly.
+type boardCommandConn interface {
+	WriteMessage(messageType int, data []byte) error
+	SetWriteDeadline(t time.Time) error
 }
 
 // boardCommandRunner is the subset of *commandcenter.Runner the WS handler
@@ -97,7 +115,7 @@ func (h *BoardCommandHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 // handlePrompt processes one client prompt message. It returns false when
 // the underlying connection has failed and the caller should stop reading
 // further messages.
-func (h *BoardCommandHandler) handlePrompt(ctx context.Context, conn *websocket.Conn, data []byte) bool {
+func (h *BoardCommandHandler) handlePrompt(ctx context.Context, conn boardCommandConn, data []byte) bool {
 	var req boardCommandRequest
 	if err := json.Unmarshal(data, &req); err != nil {
 		return writeBoardCommandFrame(conn, boardCommandFrame{Type: "error", Message: "invalid request: " + err.Error()})
@@ -117,7 +135,7 @@ func (h *BoardCommandHandler) handlePrompt(ctx context.Context, conn *websocket.
 // write fails, it keeps ranging over events without writing further — never
 // abandoning the channel — so the Runner's own goroutine (and its busy
 // flag) is never left blocked sending into a channel nobody drains.
-func streamBoardCommandEvents(conn *websocket.Conn, events <-chan commandcenter.Event) bool {
+func streamBoardCommandEvents(conn boardCommandConn, events <-chan commandcenter.Event) bool {
 	ok := true
 	for ev := range events {
 		if !ok {
@@ -143,9 +161,15 @@ func eventToBoardCommandFrame(ev commandcenter.Event) boardCommandFrame {
 	}
 }
 
-func writeBoardCommandFrame(conn *websocket.Conn, frame boardCommandFrame) bool {
+func writeBoardCommandFrame(conn boardCommandConn, frame boardCommandFrame) bool {
 	data, err := json.Marshal(frame)
 	if err != nil {
+		return false
+	}
+	// A deadline error from the connection itself (e.g. it's already
+	// closed) is treated the same as a failed write below — either way the
+	// caller must stop writing and fall back to draining only.
+	if err := conn.SetWriteDeadline(time.Now().Add(boardCommandWriteTimeout)); err != nil {
 		return false
 	}
 	return conn.WriteMessage(websocket.TextMessage, data) == nil

--- a/internal/ws/board_command_test.go
+++ b/internal/ws/board_command_test.go
@@ -1,0 +1,238 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"net/http/httptest"
+
+	"panemux/internal/commandcenter"
+)
+
+type fakeBoardCommandRunner struct {
+	queryFn func(ctx context.Context, prompt string) (<-chan commandcenter.Event, error)
+}
+
+func (f *fakeBoardCommandRunner) Query(ctx context.Context, prompt string) (<-chan commandcenter.Event, error) {
+	return f.queryFn(ctx, prompt)
+}
+
+func setupBoardCommandWSServer(runner boardCommandRunner, token string) *httptest.Server {
+	h := NewBoardCommandHandler(runner, token)
+	r := chi.NewRouter()
+	r.Get("/ws/board-command", h.ServeHTTP)
+	return httptest.NewServer(r)
+}
+
+func boardCommandWSURL(srv *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws/board-command"
+}
+
+//nolint:wrapcheck // test helper, callers assert on err directly
+func dialBoardCommand(t *testing.T, srv *httptest.Server, token string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	header := http.Header{}
+	if token != "" {
+		header.Set("Sec-WebSocket-Protocol", token)
+	}
+	return websocket.DefaultDialer.Dial(boardCommandWSURL(srv), header)
+}
+
+func closedEventsChan(events ...commandcenter.Event) <-chan commandcenter.Event {
+	ch := make(chan commandcenter.Event, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+func TestBoardCommandWS_MissingToken_Rejected(t *testing.T) {
+	srv := setupBoardCommandWSServer(&fakeBoardCommandRunner{}, "secret")
+	defer srv.Close()
+
+	_, resp, err := dialBoardCommand(t, srv, "")
+
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestBoardCommandWS_WrongToken_Rejected(t *testing.T) {
+	srv := setupBoardCommandWSServer(&fakeBoardCommandRunner{}, "secret")
+	defer srv.Close()
+
+	_, resp, err := dialBoardCommand(t, srv, "wrong-token")
+
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestBoardCommandWS_CorrectToken_StreamsLineAndDoneEvents(t *testing.T) {
+	runner := &fakeBoardCommandRunner{queryFn: func(_ context.Context, prompt string) (<-chan commandcenter.Event, error) {
+		assert.Equal(t, "hi", prompt)
+		return closedEventsChan(
+			commandcenter.Event{Type: commandcenter.EventLine, Raw: json.RawMessage(`{"type":"result"}`)},
+			commandcenter.Event{Type: commandcenter.EventDone},
+		), nil
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, resp, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+	assert.Equal(t, "secret", resp.Header.Get("Sec-WebSocket-Protocol"))
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "hi"}))
+
+	var f1, f2 boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&f1))
+	require.NoError(t, conn.ReadJSON(&f2))
+
+	assert.Equal(t, "line", f1.Type)
+	assert.JSONEq(t, `{"type":"result"}`, string(f1.Raw))
+	assert.Equal(t, "done", f2.Type)
+}
+
+func TestBoardCommandWS_Busy_SendsBusyFrame(t *testing.T) {
+	runner := &fakeBoardCommandRunner{queryFn: func(context.Context, string) (<-chan commandcenter.Event, error) {
+		return nil, commandcenter.ErrBusy
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "hi"}))
+
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame))
+	assert.Equal(t, "busy", frame.Type)
+}
+
+func TestBoardCommandWS_RunnerError_SendsErrorFrame(t *testing.T) {
+	runner := &fakeBoardCommandRunner{queryFn: func(context.Context, string) (<-chan commandcenter.Event, error) {
+		return nil, errors.New("mcp config build failed")
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "hi"}))
+
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame))
+	assert.Equal(t, "error", frame.Type)
+	assert.Contains(t, frame.Message, "mcp config build failed")
+}
+
+func TestBoardCommandWS_QueryEventError_ForwardedAsErrorFrame(t *testing.T) {
+	runner := &fakeBoardCommandRunner{queryFn: func(context.Context, string) (<-chan commandcenter.Event, error) {
+		ev := commandcenter.Event{Type: commandcenter.EventError, Err: "claude exited with error: exit status 1"}
+		return closedEventsChan(ev), nil
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "hi"}))
+
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame))
+	assert.Equal(t, "error", frame.Type)
+	assert.Contains(t, frame.Message, "exit status 1")
+}
+
+func TestBoardCommandWS_InvalidJSONRequest_SendsErrorFrame(t *testing.T) {
+	srv := setupBoardCommandWSServer(&fakeBoardCommandRunner{}, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("not json")))
+
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame))
+	assert.Equal(t, "error", frame.Type)
+}
+
+func TestBoardCommandWS_MultiplePromptsSequentially(t *testing.T) {
+	calls := 0
+	runner := &fakeBoardCommandRunner{queryFn: func(_ context.Context, prompt string) (<-chan commandcenter.Event, error) {
+		calls++
+		return closedEventsChan(commandcenter.Event{Type: commandcenter.EventDone}), nil
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "first"}))
+	var f1 boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&f1))
+	assert.Equal(t, "done", f1.Type)
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "second"}))
+	var f2 boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&f2))
+	assert.Equal(t, "done", f2.Type)
+
+	assert.Equal(t, 2, calls)
+}
+
+func TestBoardCommandWS_ClientDisconnectMidStream_DrainsEventsWithoutBlocking(t *testing.T) {
+	// A large pre-buffered, already-closed channel standing in for a long
+	// Runner stream. The handler must drain every event even once writes to
+	// the (now-disconnected) client start failing — otherwise the Runner's
+	// own goroutine would stay blocked sending into a channel no one reads,
+	// permanently wedging its busy flag.
+	ch := make(chan commandcenter.Event, 300)
+	for i := 0; i < 200; i++ {
+		ch <- commandcenter.Event{Type: commandcenter.EventLine, Raw: json.RawMessage(`{"n":1}`)}
+	}
+	ch <- commandcenter.Event{Type: commandcenter.EventDone}
+	close(ch)
+
+	runner := &fakeBoardCommandRunner{queryFn: func(context.Context, string) (<-chan commandcenter.Event, error) {
+		return ch, nil
+	}}
+	srv := setupBoardCommandWSServer(runner, "secret")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "secret")
+	require.NoError(t, err)
+
+	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "hi"}))
+	// Read exactly one frame then disconnect abruptly without draining the rest.
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame))
+	require.NoError(t, conn.Close())
+
+	require.Eventually(t, func() bool {
+		return len(ch) == 0
+	}, 2*time.Second, 10*time.Millisecond, "handler must drain all events even after the client disconnects")
+}

--- a/internal/ws/board_command_test.go
+++ b/internal/ws/board_command_test.go
@@ -23,6 +23,27 @@ type fakeBoardCommandRunner struct {
 	queryFn func(ctx context.Context, prompt string) (<-chan commandcenter.Event, error)
 }
 
+//nolint:govet // fieldalignment: test fixture, padding cost is negligible
+type fakeBoardCommandConn struct {
+	writeErr      error
+	deadlineErr   error
+	deadlines     []time.Time
+	writtenFrames [][]byte
+}
+
+func (f *fakeBoardCommandConn) SetWriteDeadline(t time.Time) error {
+	f.deadlines = append(f.deadlines, t)
+	return f.deadlineErr
+}
+
+func (f *fakeBoardCommandConn) WriteMessage(_ int, data []byte) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.writtenFrames = append(f.writtenFrames, data)
+	return nil
+}
+
 func (f *fakeBoardCommandRunner) Query(ctx context.Context, prompt string) (<-chan commandcenter.Event, error) {
 	return f.queryFn(ctx, prompt)
 }
@@ -235,4 +256,40 @@ func TestBoardCommandWS_ClientDisconnectMidStream_DrainsEventsWithoutBlocking(t 
 	require.Eventually(t, func() bool {
 		return len(ch) == 0
 	}, 2*time.Second, 10*time.Millisecond, "handler must drain all events even after the client disconnects")
+}
+
+func TestWriteBoardCommandFrameSetsWriteDeadlineBeforeEveryWrite(t *testing.T) {
+	conn := &fakeBoardCommandConn{}
+	before := time.Now()
+
+	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: "done"})
+
+	assert.True(t, ok)
+	require.Len(t, conn.deadlines, 1)
+	assert.WithinDuration(t, before.Add(boardCommandWriteTimeout), conn.deadlines[0], 2*time.Second)
+	require.Len(t, conn.writtenFrames, 1)
+}
+
+func TestWriteBoardCommandFrameFailsWhenSetWriteDeadlineFails(t *testing.T) {
+	conn := &fakeBoardCommandConn{deadlineErr: errors.New("connection closed")}
+
+	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: "done"})
+
+	assert.False(t, ok)
+	assert.Empty(t, conn.writtenFrames, "must not attempt to write once the deadline itself couldn't be set")
+}
+
+func TestStreamBoardCommandEventsSetsDeadlineOnEveryFrame(t *testing.T) {
+	conn := &fakeBoardCommandConn{}
+	events := closedEventsChan(
+		commandcenter.Event{Type: commandcenter.EventLine, Raw: json.RawMessage(`{"n":1}`)},
+		commandcenter.Event{Type: commandcenter.EventLine, Raw: json.RawMessage(`{"n":2}`)},
+		commandcenter.Event{Type: commandcenter.EventDone},
+	)
+
+	ok := streamBoardCommandEvents(conn, events)
+
+	assert.True(t, ok)
+	assert.Len(t, conn.deadlines, 3, "every write must get its own fresh deadline")
+	assert.Len(t, conn.writtenFrames, 3)
 }

--- a/internal/ws/board_command_test.go
+++ b/internal/ws/board_command_test.go
@@ -122,9 +122,9 @@ func TestBoardCommandWS_CorrectToken_StreamsLineAndDoneEvents(t *testing.T) {
 	require.NoError(t, conn.ReadJSON(&f1))
 	require.NoError(t, conn.ReadJSON(&f2))
 
-	assert.Equal(t, "line", f1.Type)
+	assert.Equal(t, boardCommandFrameTypeLine, f1.Type)
 	assert.JSONEq(t, `{"type":"result"}`, string(f1.Raw))
-	assert.Equal(t, "done", f2.Type)
+	assert.Equal(t, boardCommandFrameTypeDone, f2.Type)
 }
 
 func TestBoardCommandWS_Busy_SendsBusyFrame(t *testing.T) {
@@ -142,7 +142,7 @@ func TestBoardCommandWS_Busy_SendsBusyFrame(t *testing.T) {
 
 	var frame boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&frame))
-	assert.Equal(t, "busy", frame.Type)
+	assert.Equal(t, boardCommandFrameTypeBusy, frame.Type)
 }
 
 func TestBoardCommandWS_RunnerError_SendsErrorFrame(t *testing.T) {
@@ -160,7 +160,7 @@ func TestBoardCommandWS_RunnerError_SendsErrorFrame(t *testing.T) {
 
 	var frame boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&frame))
-	assert.Equal(t, "error", frame.Type)
+	assert.Equal(t, boardCommandFrameTypeError, frame.Type)
 	assert.Contains(t, frame.Message, "mcp config build failed")
 }
 
@@ -180,7 +180,7 @@ func TestBoardCommandWS_QueryEventError_ForwardedAsErrorFrame(t *testing.T) {
 
 	var frame boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&frame))
-	assert.Equal(t, "error", frame.Type)
+	assert.Equal(t, boardCommandFrameTypeError, frame.Type)
 	assert.Contains(t, frame.Message, "exit status 1")
 }
 
@@ -196,7 +196,7 @@ func TestBoardCommandWS_InvalidJSONRequest_SendsErrorFrame(t *testing.T) {
 
 	var frame boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&frame))
-	assert.Equal(t, "error", frame.Type)
+	assert.Equal(t, boardCommandFrameTypeError, frame.Type)
 }
 
 func TestBoardCommandWS_MultiplePromptsSequentially(t *testing.T) {
@@ -215,12 +215,12 @@ func TestBoardCommandWS_MultiplePromptsSequentially(t *testing.T) {
 	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "first"}))
 	var f1 boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&f1))
-	assert.Equal(t, "done", f1.Type)
+	assert.Equal(t, boardCommandFrameTypeDone, f1.Type)
 
 	require.NoError(t, conn.WriteJSON(boardCommandRequest{Prompt: "second"}))
 	var f2 boardCommandFrame
 	require.NoError(t, conn.ReadJSON(&f2))
-	assert.Equal(t, "done", f2.Type)
+	assert.Equal(t, boardCommandFrameTypeDone, f2.Type)
 
 	assert.Equal(t, 2, calls)
 }
@@ -262,7 +262,7 @@ func TestWriteBoardCommandFrameSetsWriteDeadlineBeforeEveryWrite(t *testing.T) {
 	conn := &fakeBoardCommandConn{}
 	before := time.Now()
 
-	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: "done"})
+	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: boardCommandFrameTypeDone})
 
 	assert.True(t, ok)
 	require.Len(t, conn.deadlines, 1)
@@ -273,7 +273,7 @@ func TestWriteBoardCommandFrameSetsWriteDeadlineBeforeEveryWrite(t *testing.T) {
 func TestWriteBoardCommandFrameFailsWhenSetWriteDeadlineFails(t *testing.T) {
 	conn := &fakeBoardCommandConn{deadlineErr: errors.New("connection closed")}
 
-	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: "done"})
+	ok := writeBoardCommandFrame(conn, boardCommandFrame{Type: boardCommandFrameTypeDone})
 
 	assert.False(t, ok)
 	assert.Empty(t, conn.writtenFrames, "must not attempt to write once the deadline itself couldn't be set")

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"panemux/internal/board"
+	"panemux/internal/commandcenter"
 	"panemux/internal/config"
 	"panemux/internal/server"
 	"panemux/internal/session"
@@ -32,6 +33,17 @@ type cliOptions struct {
 var frontendFS embed.FS
 
 func main() {
+	// __board-mcp-server is a hidden subcommand, not an ordinary flag: the
+	// command center's own claude -p subprocess re-invokes this same binary
+	// as its MCP server (see docs/agent-board.md's Command center section),
+	// so it must be recognized before flag.Parse ever runs.
+	if len(os.Args) > 1 && os.Args[1] == commandcenter.BoardMCPServerSubcommand {
+		if err := runBoardMCPServer(context.Background(), os.Getenv, os.Stdin, os.Stdout); err != nil {
+			log.Fatalf("board mcp server: %v", err)
+		}
+		return
+	}
+
 	opts := parseOptions()
 
 	if opts.showVersion {
@@ -50,8 +62,9 @@ func main() {
 	}
 
 	boardCache, boardRelay, boardBootstrap := setupBoard(cfg, manager)
+	commandRunner := setupCommandCenter(cfg)
 
-	srv := server.New(cfg, manager, boardCache, boardRelay, frontendFS)
+	srv := server.New(cfg, manager, boardCache, boardRelay, commandRunner, frontendFS)
 	addr := "http://" + srv.Addr()
 	log.Printf("Listening on %s", addr)
 


### PR DESCRIPTION
## Summary

Implements the Agent Board **command center** per `docs/agent-board.md` (issue #165 Phase 2): a
headless `claude -p [--resume]` chat surface, reachable from the browser dashboard's Spotlight
palette, that reads and writes the board exclusively through panemux's own authenticated REST API
— never agmsg directly, and never by the LLM composing a raw HTTP or shell call itself.

- `internal/commandcenter`: per-query subprocess `Runner` (session/history persistence,
  `BuildMCPConfig`, configurable query timeout).
- `internal/boardmcp`: a narrow JSON-RPC-over-stdio MCP server exposing exactly
  `board_status`/`board_messages`/`board_broadcast`, backed by an `HTTPBoardAPIClient` that calls
  panemux's own `/api/board/*` endpoints — the same ones the browser dashboard uses.
- `panemux __board-mcp-server` (`board_mcp_server.go`): the hidden subcommand the command center's
  own `claude -p` subprocess re-invokes as its MCP server's child process.
- `WS /ws/board-command` (streaming) and `GET /api/board/command/history`, both gated on
  `command_center.enabled` + `server.auth_token`.
- `GET /api/session-token` (deliberately unauthenticated, deliberately **not** under `/api/board/`
  due to a chi routing-precedence pitfall — see `docs/agent-board.md`) so the browser dashboard can
  learn the bearer token it needs for board API calls, which the original design didn't specify.
- Frontend: `Cmd/Ctrl+Shift+K` Spotlight command palette (`CommandPalette.tsx`) and a persistent
  history panel (`CommandHistoryPanel.tsx`), both gated on `command_center_enabled`.
- `docs/agent-board.md`, `docs/behavior.md`, `docs/security.md`, `docs/ui-design.md`, and
  `docs/architecture.md` updated throughout this PR to keep matching the implemented state.

## Hardening after two rounds of adversarial review

Two separate, context-isolated adversarial reviews were run against this implementation after the
initial commit, each verified live against the real `claude` CLI where the finding concerned CLI
argument parsing, not just inferred from `--help` text.

**Round 1** (`ffb0241`) — 12 issues found and fixed, most severe first:
- **Critical: CLI argument injection.** `--allowedTools` was passed as two argv elements, which the
  CLI's variadic flag parsing let swallow the prompt itself, silently breaking every query; and a
  prompt beginning with `-` (e.g. `--help`) was parsed as a CLI flag instead of prompt text. Fixed
  with the `=` form (`--allowedTools=...`) and a literal `--` end-of-options marker before the
  prompt — both regressions are pinned by `TestRunnerBuildArgsShapeIsSafeAgainstArgumentInjection`.
- Unauthenticated session-token leak on a non-loopback `server.host` (fixed with RemoteAddr+Host
  loopback checks, later hardened further — see Round 2 below).
- `streamOutput`'s scanner error path didn't drain remaining subprocess stdout, risking a wedged
  pipe; no WS write deadline, risking the busy flag wedging forever on a stalled client.
- `commandCenterBaseURL` was wrong for a specific non-wildcard `server.host`.
- A stale `--resume` session id permanently broke the command center once claude stopped
  recognizing it; `command_center_enabled` reported the config flag, not actual availability.
- No subprocess query timeout; the MCP server executed tool side effects before checking whether a
  request was actually a notification (which must never dispatch); `AppendHistory` could corrupt
  the history file on partial-write recovery; the frontend's pending/turns state never reset when
  the palette closed mid-query.

**Round 2** (`3f1a912`), a differential review of the round-1 fixes — 7 further issues (F1–F7):
- **F1/F2**: the round-1 session-token loopback guard still failed open behind a reverse proxy on
  the loopback interface (fixed by rejecting `X-Forwarded-For`/`X-Real-IP`/`Forwarded`), and wrongly
  rejected a legitimate `0.0.0.0`-bound deployment's own Host header.
- **F3/F4**: a query killed by the Runner's own timeout was indistinguishable from a genuine
  `--resume` rejection, incorrectly clearing a perfectly good session id; now surfaces a distinct
  "timed out" error and leaves the session id untouched.
- **F5**: `commandCenterBaseURL` double-bracketed an already-bracketed IPv6 host (`"[::]"`,
  `"[::1]"`), producing an undialable `http://[[::]]:...` URL.
- **F6**: a malformed `stream-json` line only cancelled the subprocess via the function's deferred
  `cancel()`, which can't run until `cmd.Wait()` returns — a subprocess that didn't exit on its own
  could hold the busy flag for the full query timeout instead of being killed immediately.
- **F7**: a persisted `--resume` session id was passed to argv unvalidated; a flag-shaped value
  (e.g. one beginning with `-`) risks the same class of argument injection the round-1 `--` fix
  addressed for the prompt, since `--resume`'s value is optional in the CLI's own parser. Now
  regex-validated against the shape claude itself emits before use, falling back to a fresh
  (non-`--resume`) run otherwise.

## CI and tooling fixes

- `edb8bca`: 8 `goconst` findings caught only by the repository's *pinned* `golangci-lint` (v2.12.2)
  — my local binary was a stale, unrelated v2.5.0 that missed them entirely, which is why they
  didn't surface until CI.
- `664935d`: fixed the actual root cause — `lint-go-deps` installed the pinned `golangci-lint` to
  `$GOBIN`/`$GOPATH/bin`, but `lint-go` then invoked a bare `golangci-lint` resolved through
  `$PATH`, which silently preferred an unrelated, differently-versioned binary earlier on `$PATH`
  (e.g. one preinstalled system-wide). Both the version check and the invocation now use the same
  explicit resolved path.

## Docs

- `6ad9ad9`: added an explicit `McpServer` node to both `docs/agent-board.md` architecture diagrams
  — they previously showed the command center's `claude -p` subprocess connecting directly to
  panemux's REST API, collapsing the fact that the actual REST call is made by
  `internal/boardmcp`'s MCP server on the LLM's behalf. Also fixed three stale "command center still
  planned" / "not yet implemented" statements left over from before this PR's Phase 2 work landed
  (`docs/architecture.md` ×2, `docs/security.md` ×1).

## Test plan

- [x] `make check` (build-frontend, lint, full Go + frontend test suite, coverage ≥ 80%) passes,
      verified against the repository's pinned `golangci-lint` v2.12.2 specifically, not just
      whatever happened to be on `$PATH`.
- [x] `TestRunnerBuildArgsShapeIsSafeAgainstArgumentInjection` and the CLI argument-injection fix it
      pins were verified live against the real installed `claude` CLI, not just `--help` text.
- [x] Round 2's F1–F7 fixes each have a dedicated failing-then-passing test (e.g.
      `TestGetBoardSessionToken_XForwardedForHeader_Forbidden`,
      `TestRunnerTimeoutDoesNotClearSessionIdAndReportsTimeoutMessage`,
      `TestCommandCenterBaseURL`'s bracketed-IPv6 cases,
      `TestRunnerMalformedStreamJSONCancelsQueryContextImmediately`,
      `TestRunnerMalformedPersistedSessionIDFallsBackToFirstRun`), confirmed to fail before the fix
      and pass after.
- [x] `go build ./...` and `gofmt -l .` are clean.
- [x] CI (`ci`, `pr-title`, `labeler`) is green on the current head commit.
