### PR TITLE
fix: exclude CJK punctuation from terminal URL link detection

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -710,6 +710,14 @@ attempt itself fails, the pane shows the manual "Reconnect Session" action inste
 - If no text is selected, `Cmd+C` or `Ctrl+C` is left to normal terminal behavior, so shell interrupts still work.
 - This interaction is currently validated in Chrome.
 
+### Terminal link detection
+
+- `http://` and `https://` URLs printed into a pane are auto-detected and become clickable through the xterm.js web links addon.
+- The addon's default URL pattern only excludes ASCII punctuation, so panemux supplies its own pattern (`TERMINAL_URL_REGEX` in `frontend/src/hooks/useTerminal.ts`) that also excludes CJK and fullwidth punctuation. Trailing `。`, `、`, `・`, `…` and enclosing `（）`, `「」`, `【】`, `“”` are not part of the detected link.
+- Non-ASCII *letters* are never excluded, so raw IRIs such as `https://ja.wikipedia.org/wiki/日本語` stay linkable in full. Fullwidth digits and fullwidth letters stay linkable for the same reason.
+- Known limitation: kana or kanji that directly follows a URL with no delimiter (for example `https://example.com/docsを参照`) is still absorbed into the link. That case cannot be distinguished from a legitimate kana IRI path by pattern matching alone. Separate the URL with whitespace or punctuation, or emit an OSC 8 hyperlink — xterm.js resolves those itself, independently of this pattern, and its built-in handler asks for confirmation before navigating.
+- `#<number>` references are linked separately to the pane's GitHub pull request (see [Pane Git and PR metadata](#pane-git-and-pr-metadata)).
+
 ### Resize and layout updates
 
 - `ResizeObserver` triggers terminal fit logic when pane size changes.

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -714,7 +714,7 @@ attempt itself fails, the pane shows the manual "Reconnect Session" action inste
 
 - `http://` and `https://` URLs printed into a pane are auto-detected and become clickable through the xterm.js web links addon.
 - The addon's default URL pattern only excludes ASCII punctuation, so panemux supplies its own pattern (`TERMINAL_URL_REGEX` in `frontend/src/hooks/useTerminal.ts`) that also excludes CJK and fullwidth punctuation. Trailing `。`, `、`, `・`, `…` and enclosing `（）`, `「」`, `【】`, `“”` are not part of the detected link.
-- Non-ASCII *letters* are never excluded, so raw IRIs such as `https://ja.wikipedia.org/wiki/日本語` stay linkable in full. Fullwidth digits and fullwidth letters stay linkable for the same reason.
+- Non-ASCII *letters* are never excluded, so raw IRIs such as `https://ja.wikipedia.org/wiki/日本語` stay linkable in full. Fullwidth digits and fullwidth letters stay linkable for the same reason, as do the letters and numerals interleaved into the CJK symbols block itself (`々`, `〆`, `〇` and the ideographic numerals), so `https://ja.wikipedia.org/wiki/日々` is linked whole.
 - Known limitation: kana or kanji that directly follows a URL with no delimiter (for example `https://example.com/docsを参照`) is still absorbed into the link. That case cannot be distinguished from a legitimate kana IRI path by pattern matching alone. Separate the URL with whitespace or punctuation, or emit an OSC 8 hyperlink — xterm.js resolves those itself, independently of this pattern, and its built-in handler asks for confirmation before navigating.
 - `#<number>` references are linked separately to the pane's GitHub pull request (see [Pane Git and PR metadata](#pane-git-and-pr-metadata)).
 

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -1,6 +1,12 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { __computePullRequestLinksForTests, __resetTerminalEntriesForTests, useTerminal } from './useTerminal'
+import {
+  TERMINAL_URL_REGEX,
+  __computePullRequestLinksForTests,
+  __resetTerminalEntriesForTests,
+  useTerminal,
+} from './useTerminal'
+import { WebLinksAddon } from '@xterm/addon-web-links'
 import { TERMINAL_FONT_FAMILY } from '../utils/fonts'
 
 // ── xterm.js mocks ───────────────────────────────────────────────────────────
@@ -159,6 +165,14 @@ describe('useTerminal', () => {
     const container = makeContainer()
     renderHook(() => useTerminal({ sessionId: 's1', container }))
     expect(mockTerm.loadAddon).toHaveBeenCalledTimes(2)
+  })
+
+  it('configures the web links addon with the CJK-aware url regex', () => {
+    const container = makeContainer()
+    renderHook(() => useTerminal({ sessionId: 's1', container }))
+
+    expect(WebLinksAddon).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(WebLinksAddon).mock.calls[0][1]).toEqual({ urlRegex: TERMINAL_URL_REGEX })
   })
 
   it('registers a custom link provider for pull request numbers', () => {
@@ -988,5 +1002,93 @@ describe('useTerminal', () => {
     expect(written).not.toContain('\x1b[>1h')
     expect(written).toContain('hidden cursor')
     expect(written).toContain('text')
+  })
+})
+
+// The web links addon applies the regex as `new RegExp(regex.source, regex.flags + 'g')`
+// (see LinkComputer.computeLink), so mirror that here instead of matching the regex directly.
+function detectURLs(line: string): string[] {
+  const rex = new RegExp(TERMINAL_URL_REGEX.source, `${TERMINAL_URL_REGEX.flags}g`)
+  const found: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = rex.exec(line)) !== null) {
+    found.push(match[0])
+  }
+  return found
+}
+
+describe('TERMINAL_URL_REGEX', () => {
+  it('is unicode-aware and not global so the addon can safely append the g flag', () => {
+    expect(TERMINAL_URL_REGEX.flags).toContain('u')
+    expect(TERMINAL_URL_REGEX.global).toBe(false)
+  })
+
+  it.each([
+    ['ideographic full stop', 'https://example.com/docs\u3002', 'https://example.com/docs'],
+    ['ideographic comma then text', 'https://example.com/docs\u3001\u6b21\u306e\u624b\u9806\u3078', 'https://example.com/docs'],
+    ['fullwidth parentheses', '\uff08https://example.com/docs\uff09', 'https://example.com/docs'],
+    ['corner brackets', '\u300chttps://example.com/docs\u300d', 'https://example.com/docs'],
+    ['lenticular bracket', 'https://example.com/docs\u3010', 'https://example.com/docs'],
+    ['katakana middle dot', 'https://example.com/docs\u30fb', 'https://example.com/docs'],
+    ['halfwidth ideographic full stop', 'https://example.com/docs\uff61', 'https://example.com/docs'],
+    ['horizontal ellipsis', 'https://example.com/docs\u2026', 'https://example.com/docs'],
+    ['curly double quotes', '\u201chttps://example.com/docs\u201d', 'https://example.com/docs'],
+    ['wave dash', 'https://example.com/docs\u301c', 'https://example.com/docs'],
+    ['fullwidth colon', 'https://example.com/docs\uff1a', 'https://example.com/docs'],
+  ])('drops trailing CJK punctuation (%s)', (_name, line, expected) => {
+    expect(detectURLs(line)).toEqual([expected])
+  })
+
+  it.each([
+    ['full stop', 'https://example.com/a.', 'https://example.com/a'],
+    ['comma', 'https://example.com/a,', 'https://example.com/a'],
+    ['exclamation mark', 'https://example.com/a!', 'https://example.com/a'],
+    ['question mark', 'https://example.com/a?', 'https://example.com/a'],
+    ['colon', 'https://example.com/a:', 'https://example.com/a'],
+    ['closing paren', 'see https://example.com/a) here', 'https://example.com/a'],
+    ['angle brackets', '<https://example.com/a>', 'https://example.com/a'],
+    ['double quotes', '"https://example.com/a"', 'https://example.com/a'],
+  ])('keeps the existing ASCII boundary behaviour (%s)', (_name, line, expected) => {
+    expect(detectURLs(line)).toEqual([expected])
+  })
+
+  it.each([
+    ['raw IRI path', 'https://ja.wikipedia.org/wiki/\u65e5\u672c\u8a9e'],
+    ['percent-encoded path', 'https://example.com/%E6%97%A5%E6%9C%AC%E8%AA%9E'],
+    ['fullwidth alphanumerics in path', 'https://example.com/\uff46\uff55\uff4c\uff4c\uff11\uff12\uff13'],
+    ['trailing slash', 'https://example.com/'],
+    ['bare host', 'https://example.com'],
+    ['credentials, port, query and fragment', 'https://user:pw@example.com:8443/p?q=1#frag'],
+    ['loopback with port', 'http://localhost:8080/path'],
+    ['uppercase scheme', 'HTTPS://example.com/a'],
+  ])('keeps valid urls intact (%s)', (_name, line) => {
+    expect(detectURLs(line)).toEqual([line])
+  })
+
+  it('drops trailing CJK punctuation without truncating a raw IRI path', () => {
+    expect(detectURLs('https://ja.wikipedia.org/wiki/\u65e5\u672c\u8a9e\u3002')).toEqual([
+      'https://ja.wikipedia.org/wiki/\u65e5\u672c\u8a9e',
+    ])
+  })
+
+  it('detects every url on a line that mixes CJK delimiters', () => {
+    const line = '\uff08https://a.example.com/x\uff09\u3068\u300chttps://b.example.com/y\u300d'
+    expect(detectURLs(line)).toEqual(['https://a.example.com/x', 'https://b.example.com/y'])
+  })
+
+  it.each([
+    ['unsupported scheme', 'ftp://example.com/a'],
+    ['file scheme', 'file:///tmp/sample-project'],
+    ['scheme-less host', 'example.com/a'],
+    ['scheme only', 'https://'],
+  ])('does not detect a link for %s', (_name, line) => {
+    expect(detectURLs(line)).toEqual([])
+  })
+
+  // Documented limitation (see issue #173): kana directly following a url cannot be
+  // distinguished from a legitimate kana IRI path, so the whole run stays part of the link.
+  it('still absorbs kana that directly follows a url with no delimiter', () => {
+    const line = 'https://example.com/docs\u3092\u53c2\u7167\u3057\u3066\u304f\u3060\u3055\u3044'
+    expect(detectURLs(line)).toEqual([line])
   })
 })

--- a/frontend/src/hooks/useTerminal.test.ts
+++ b/frontend/src/hooks/useTerminal.test.ts
@@ -1061,6 +1061,9 @@ describe('TERMINAL_URL_REGEX', () => {
     ['credentials, port, query and fragment', 'https://user:pw@example.com:8443/p?q=1#frag'],
     ['loopback with port', 'http://localhost:8080/path'],
     ['uppercase scheme', 'HTTPS://example.com/a'],
+    ['ideographic iteration mark in path', 'https://ja.wikipedia.org/wiki/\u65e5\u3005'],
+    ['ideographic closing mark in path', 'https://ja.wikipedia.org/wiki/\u3006\u5207'],
+    ['ideographic number zero in path', 'https://ja.wikipedia.org/wiki/\u3007\u3007'],
   ])('keeps valid urls intact (%s)', (_name, line) => {
     expect(detectURLs(line)).toEqual([line])
   })

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -8,6 +8,34 @@ import type { SessionState } from '../schemas'
 
 const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 
+// Characters that must never be part of an auto-detected URL, on top of the ASCII
+// symbols the web links addon already excludes. The addon default only knows about
+// ASCII punctuation, so Japanese output such as `https://example.com/docs。` or
+// `（https://example.com/docs）` swallowed the trailing CJK punctuation into the link.
+//
+// Ranges (deliberately punctuation only, never letters or digits):
+//   U+2018-U+201F, U+2026   curly quotes and the horizontal ellipsis
+//   U+3000-U+303F           CJK symbols and punctuation (、。「」【】〜 ...)
+//   U+30FB                  katakana middle dot (・)
+//   U+FF01-U+FF0F, U+FF1A-U+FF20, U+FF3B-U+FF40, U+FF5B-U+FF65
+//                           fullwidth ASCII punctuation and halfwidth kana punctuation
+// Fullwidth digits (U+FF10-U+FF19) and fullwidth letters are intentionally left out so
+// they stay linkable, and non-ASCII letters are not excluded at all: raw IRIs such as
+// `https://ja.wikipedia.org/wiki/日本語` must keep working. Kana directly following a URL
+// with no delimiter is therefore still absorbed — that case is indistinguishable from a
+// legitimate kana IRI path by regex alone.
+const NON_URL_CJK_PUNCTUATION =
+  '\\u2018-\\u201f\\u2026\\u3000-\\u303f\\u30fb\\uff01-\\uff0f\\uff1a-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65'
+
+// The addon default regex with the ranges above added to both character classes.
+// Kept non-global on purpose: the addon derives its own global copy via
+// `new RegExp(regex.source, regex.flags + 'g')`, which throws on a duplicate `g`.
+export const TERMINAL_URL_REGEX = new RegExp(
+  `(https?|HTTPS?):[/]{2}[^\\s"'!*(){}|\\\\\\^<>\`${NON_URL_CJK_PUNCTUATION}]*` +
+    `[^\\s"':,.!?{}|\\\\\\^~\\[\\]\`()<>${NON_URL_CJK_PUNCTUATION}]`,
+  'u',
+)
+
 interface UseTerminalOptions {
   sessionId: string
   container: HTMLElement | null
@@ -364,7 +392,7 @@ function getOrCreateTerminalEntry(sessionId: string): TerminalEntry {
   })
 
   const fitAddon = new FitAddon()
-  const webLinksAddon = new WebLinksAddon()
+  const webLinksAddon = new WebLinksAddon(undefined, { urlRegex: TERMINAL_URL_REGEX })
   const entry: TerminalEntry = {
     term,
     fitAddon,

--- a/frontend/src/hooks/useTerminal.ts
+++ b/frontend/src/hooks/useTerminal.ts
@@ -15,7 +15,12 @@ const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 //
 // Ranges (deliberately punctuation only, never letters or digits):
 //   U+2018-U+201F, U+2026   curly quotes and the horizontal ellipsis
-//   U+3000-U+303F           CJK symbols and punctuation (、。「」【】〜 ...)
+//   U+3000-U+3004, U+3008-U+3020, U+3030, U+303D-U+303F
+//                           CJK symbols and punctuation (、。「」【】〜 ...). The gaps skip the
+//                           letters and digits interleaved into this block: U+3005-U+3007
+//                           (々〆〇), U+3021-U+3029 and U+3038-U+303C (Hangzhou/ideographic
+//                           numerals and iteration marks), and the U+302A-U+302F combining
+//                           marks.
 //   U+30FB                  katakana middle dot (・)
 //   U+FF01-U+FF0F, U+FF1A-U+FF20, U+FF3B-U+FF40, U+FF5B-U+FF65
 //                           fullwidth ASCII punctuation and halfwidth kana punctuation
@@ -25,7 +30,8 @@ const REPAINT_SETTLE_DELAYS_MS = [50, 250]
 // with no delimiter is therefore still absorbed — that case is indistinguishable from a
 // legitimate kana IRI path by regex alone.
 const NON_URL_CJK_PUNCTUATION =
-  '\\u2018-\\u201f\\u2026\\u3000-\\u303f\\u30fb\\uff01-\\uff0f\\uff1a-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65'
+  '\\u2018-\\u201f\\u2026\\u3000-\\u3004\\u3008-\\u3020\\u3030\\u303d-\\u303f' +
+  '\\u30fb\\uff01-\\uff0f\\uff1a-\\uff20\\uff3b-\\uff40\\uff5b-\\uff65'
 
 // The addon default regex with the ranges above added to both character classes.
 // Kept non-global on purpose: the addon derives its own global copy via

--- a/frontend/src/hooks/useTerminalLinks.test.ts
+++ b/frontend/src/hooks/useTerminalLinks.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { Terminal } from '@xterm/xterm'
+import type { ILink, ILinkProvider } from '@xterm/xterm'
+import { WebLinksAddon } from '@xterm/addon-web-links'
+import { TERMINAL_URL_REGEX } from './useTerminal'
+
+// Integration check against the real xterm.js terminal and the real web links addon.
+// useTerminal.test.ts mocks both of those, so it can only assert which options panemux
+// passes; this file verifies the addon actually honours TERMINAL_URL_REGEX and yields
+// the link ranges we expect for CJK-adjacent urls.
+async function detectLinks(line: string): Promise<ILink[]> {
+  const term = new Terminal({ cols: 200, rows: 10, allowProposedApi: true })
+
+  let provider: ILinkProvider | undefined
+  const registerLinkProvider = term.registerLinkProvider.bind(term)
+  term.registerLinkProvider = (candidate: ILinkProvider) => {
+    provider = candidate
+    return registerLinkProvider(candidate)
+  }
+
+  term.loadAddon(new WebLinksAddon(undefined, { urlRegex: TERMINAL_URL_REGEX }))
+  await new Promise<void>((resolve) => term.write(line, resolve))
+
+  const links = await new Promise<ILink[] | undefined>((resolve) => {
+    provider?.provideLinks(1, resolve)
+  })
+  term.dispose()
+  return links ?? []
+}
+
+describe('web links addon integration', () => {
+  it('excludes a trailing ideographic full stop from the link text and range', async () => {
+    const links = await detectLinks('参照: https://example.com/docs。')
+
+    expect(links).toHaveLength(1)
+    expect(links[0].text).toBe('https://example.com/docs')
+    // 1-based columns, right side including: '参照: ' occupies 6 cells (参 and 照 are wide).
+    expect(links[0].range).toEqual({
+      start: { x: 7, y: 1 },
+      end: { x: 30, y: 1 },
+    })
+  })
+
+  it('excludes enclosing fullwidth parentheses from the link', async () => {
+    const links = await detectLinks('（https://example.com/docs）')
+
+    expect(links).toHaveLength(1)
+    expect(links[0].text).toBe('https://example.com/docs')
+  })
+
+  it('keeps a raw IRI path intact', async () => {
+    const links = await detectLinks('https://ja.wikipedia.org/wiki/日本語。')
+
+    expect(links).toHaveLength(1)
+    expect(links[0].text).toBe('https://ja.wikipedia.org/wiki/日本語')
+  })
+
+  it('detects both urls on a line delimited only by CJK punctuation', async () => {
+    const links = await detectLinks('（https://a.example.com/x）と「https://b.example.com/y」')
+
+    expect(links.map((link) => link.text)).toEqual([
+      'https://a.example.com/x',
+      'https://b.example.com/y',
+    ])
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom'
+
+// xterm.js measures glyphs through a 2d canvas context when its module is imported.
+// jsdom does not implement one, so stub the minimum it needs to stay quiet. Tests that
+// mock xterm.js entirely are unaffected.
+HTMLCanvasElement.prototype.getContext = (() => ({
+  measureText: () => ({ width: 8 }),
+})) as unknown as HTMLCanvasElement['getContext']


### PR DESCRIPTION
Fixes #173.

## Problem

`@xterm/addon-web-links`' default URL pattern only excludes ASCII punctuation, so any CJK or fullwidth punctuation directly after a URL was swallowed into the detected link. Japanese output such as `https://example.com/docs。` or `（https://example.com/docs）` produced links ending in `%E3%80%82` / `%EF%BC%89` that opened a broken URL.

ASCII trailing punctuation (`.` `,` `)` `!` `?` `:`) was already handled upstream, which is why this only ever showed up in Japanese output.

## Change

Pass an explicit `urlRegex` to `WebLinksAddon` (`TERMINAL_URL_REGEX` in `frontend/src/hooks/useTerminal.ts`) that adds CJK/fullwidth punctuation to both of the default pattern's character classes. The addon has exposed `ILinkProviderOptions.urlRegex` since 0.11.0, so no fork or post-processing is needed.

Only **punctuation** is excluded, never letters or digits:

- `U+2018-U+201F`, `U+2026` — curly quotes, ellipsis
- `U+3000-U+3004`, `U+3008-U+3020`, `U+3030`, `U+303D-U+303F` — CJK symbols and punctuation
- `U+30FB` — `・`
- `U+FF01-U+FF0F`, `U+FF1A-U+FF20`, `U+FF3B-U+FF40`, `U+FF5B-U+FF65` — fullwidth ASCII punctuation and halfwidth kana punctuation

The gaps in the `U+30xx` ranges are deliberate: that block interleaves letters and numerals (`々` `〆` `〇` at `U+3005-U+3007`, the Hangzhou/ideographic numerals at `U+3021-U+3029` and `U+3038-U+303C`, combining marks at `U+302A-U+302F`). The first commit on this branch took the whole block and truncated `https://ja.wikipedia.org/wiki/日々` to `.../wiki/日`; an adversarial review caught it and the second commit narrows the range. Fullwidth digits and letters are left out for the same reason, so raw IRIs stay linkable in full.

### Known limitation

Kana that directly follows a URL with no delimiter at all (`https://example.com/docsを参照`) is still absorbed. That case is indistinguishable from a legitimate kana IRI path by pattern matching alone. It is pinned by a test and documented in `docs/behavior.md` along with OSC 8 as the unambiguous alternative.

## Tests

- `useTerminal.test.ts` — table-driven coverage of the pattern: trailing CJK punctuation, enclosing brackets, ASCII boundary regressions, raw IRIs, `々`/`〆`/`〇`, percent-encoding, fullwidth alphanumerics, URL structure (trailing slash, query, fragment, credentials, port), non-matches, and the ambiguous kana case. Plus an assertion that the addon is constructed with the pattern.
- `useTerminalLinks.test.ts` (new) — integration test driving the **real** xterm.js terminal and the **real** web links addon, since the unit tests mock both and can only assert what panemux passes in. Confirms the addon honours the pattern and reports the expected link ranges, including correct columns across wide characters.
- `src/test/setup.ts` — stubs the 2d canvas context jsdom does not implement, which xterm.js probes on import.

## Test plan

- [x] `make check` passes (exit 0; frontend 501 tests, Go tests + lint + coverage 87.3%)
- [x] `make test-go`
- [x] `make test-frontend`
- [x] `make lint`
- [x] `make coverage-go` / `make coverage-frontend`
- [x] `make test-e2e` — 5/5 passing. Note: this sandbox ships an older Chromium build (1194) than `@playwright/test` 1.59 expects (1217), so the run needed a local `executablePath` override pointing at the preinstalled browser. Environment-only, not committed, unrelated to this change.
- [x] Pattern behaviour verified directly against Node for every case in the tables above, before and after the fix

## Docs

`docs/behavior.md` gains a `### Terminal link detection` section covering what is and is not part of a detected link, why non-ASCII letters are never excluded, and the kana limitation with the OSC 8 workaround.