### PR TITLE
refactor: make the HTTP route table a single source of truth

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,7 +213,11 @@ Replay lifecycle contract:
 
 ### `internal/server`
 
-This package wires chi routes, middleware, REST handlers, WebSocket handlers, and static file serving.
+This package wires middleware, WebSocket handlers, and static file serving, and decides which part of
+the API is authenticated. The `/api` route table itself lives in `internal/api` (`Handler.Mount`,
+`internal/api/routes.go`) so production wiring and that package's own handler tests cannot describe
+different routes; `registerRoutes` passes `bearerAuthMiddleware` to `Mount` as the middleware for the
+`api.BoardRoutePrefix` sub-router. See [security.md](security.md#auth-token-and-transport-encryption).
 
 Why `chi`:
 

--- a/docs/quality-gateway.md
+++ b/docs/quality-gateway.md
@@ -21,11 +21,12 @@ panemux does not have a shortage of tests. At the commit above:
 | E2E (Playwright) | 8 specs, 23 tests | not gated |
 
 And yet [issue #178](https://github.com/tomo-chan/panemux/issues/178) established that the route
-table in `internal/server/server.go` can be renamed, reordered, or wrapped in new middleware and
-161 tests in `internal/api` stay green, because those tests build their own copy of the router
-rather than going through `server.New()`. The `/api/board/*` routes are registered in that copy
-*without* `bearerAuthMiddleware`, so 25 board handler tests assert against a shape that does not
-exist in production.
+table in `internal/server/server.go` could be renamed, reordered, or wrapped in new middleware and
+161 tests in `internal/api` would stay green, because those tests built their own copy of the router
+rather than going through `server.New()`. The `/api/board/*` routes were registered in that copy
+*without* `bearerAuthMiddleware`, so 25 board handler tests asserted against a shape that did not
+exist in production. That specific defect is closed — see gate G3 below — but it is the reason this
+document exists, and the reasoning it produced applies to every gate here, not just that one.
 
 That is not a gap in test quantity. It is a gap in two things this repository has never written
 down:
@@ -72,9 +73,9 @@ refactoring is the one that is not negotiable.
 | Pillar | Meaning | What can measure it | panemux today |
 |---|---|---|---|
 | Protection against regressions | Probability a test fails when a bug is introduced | Coverage is only a *lower bound* proxy. The real measure is mutation score | Coverage 88%; mutation never measured |
-| Resistance to refactoring | Behavior-preserving changes do not fail tests (few false positives) | No direct metric exists. Only structure can guarantee it | **Structurally defective** — the duplicated router (#178) |
+| Resistance to refactoring | Behavior-preserving changes do not fail tests (few false positives) | No direct metric exists. Only structure can guarantee it | The duplicated router that prompted this document is gone; nothing measures the property itself |
 | Fast feedback | Wall-clock time | Seconds | Go ≈3s for the gated packages, ≈8s for the whole suite under `-race`; frontend ≈13s. Good |
-| Maintainability | The tests are themselves readable and durable | Test volume, duplication | 4 router copies, 3 `*_routes_test.go` files. Growing |
+| Maintainability | The tests are themselves readable and durable | Test volume, duplication | Was 4 router copies and 3 `*_routes_test.go` files; the copies are gone and the per-route files are consolidated |
 
 ### Why coverage alone misleads
 
@@ -103,7 +104,7 @@ written. Every unprotected area in panemux reduces to "there is no injection poi
 
 | Principle | Rule | Evidence in this repository |
 |---|---|---|
-| **P1 — Single source of truth** | Do not encode the same knowledge twice. Never reconstruct production wiring inside a test. | The route table exists in both `internal/server/server.go` and `internal/api/handler_test.go`, and has drifted: `/api/board/*` is authenticated in one and flat and unauthenticated in the other. |
+| **P1 — Single source of truth** | Do not encode the same knowledge twice. Never reconstruct production wiring inside a test. | The route table used to exist in both `internal/server/server.go` and `internal/api/handler_test.go`, and had drifted: `/api/board/*` was authenticated in one and flat and unauthenticated in the other. It now lives once, in `internal/api`'s `Handler.Mount`. |
 | **P2 — Humble object** | Keep the side-effecting boundary (PTY, SSH, `exec`, filesystem, network) as thin as possible; put decisions in pure functions. | Works: `validRemotePath`, `classifySSHWaitError`, `frontend/src/utils/layoutTree.ts`. Fails: `internal/session/ssh.go`'s lifecycle methods mix transport with decisions and sit at 0%. |
 | **P3 — Injection points are typed** | Do not call globals, environment variables or `os.UserHomeDir()` directly; make them a struct field or constructor argument. | Already stated in [DEVELOPMENT.md](../DEVELOPMENT.md#test-granularity)'s testability rule (`Config.sshConfigPath`). Not applied to `main.go` (0%) or `board.go` (47.8%). |
 | **P4 — Name the observable behavior** | What a test drives is a published contract with domain vocabulary — HTTP responses, WS frames, persisted files, rendered output — not call ordering or mock setup. | `frontend/src/hooks/useTerminalLinks.test.ts` is the model: it drives the real xterm terminal and the real addon, and is named after the behavior rather than a source file. |
@@ -166,7 +167,7 @@ Ordering is meaningful: the point is to stop a defect at the cheapest gate that 
 | **G0** | Spec | Functional suitability (rework) | The change is tied to a row in [scenarios.md](scenarios.md). A user-visible change adds or updates a row in the same commit. | CI: fail when the diff touches `frontend/src`, `internal/api` or `internal/config` and `scenarios.md` is unchanged; a label grants explicit exemption | Absent |
 | **G1** | Edit | Maintainability | `gofmt -s`, `tsc --noEmit`, and `go vet` on the touched packages only | Claude Code `PostToolUse` hook in `.claude/settings.json` | Absent |
 | **G2** | Unit | Functional suitability, fast feedback | `make test-go`, `make test-frontend` — unchanged | Existing (`make check`, pre-push, CI) | Present |
-| **G3** | Contract | **Resistance to refactoring**, compatibility | (a) HTTP/WS integration through the real `server.New()` router; (b) exhaustiveness check on the route table (every registered route against an expected set); (c) Zod schema round-trips; (d) the agmsg contract | New `make test-contract`, folded into `make check`; (b) as an always-on Go test | Partial (agmsg only) |
+| **G3** | Contract | **Resistance to refactoring**, compatibility | (a) HTTP/WS integration through the real `server.New()` router; (b) exhaustiveness check on the route table (every registered route against an expected set); (c) Zod schema round-trips; (d) the agmsg contract | New `make test-contract`, folded into `make check`; (b) as an always-on Go test | Partial — (b) and (d) present, (a) and (c) absent |
 | **G4** | Efficacy | **Protection against regressions** | (a) coverage — scope tracks the implementation, threshold stays at 80%; (b) **red-check**: a changed test must fail when the implementation diff is reverted; (c) mutation score over changed lines only | (a) existing `make check`; (b) and (c) a pull-request CI job, `make efficacy` | Partial ((a) only) |
 | **G5** | Scenario | Functional suitability, interaction capability | Playwright E2E, plus a check that every test named by an `auto` row in `scenarios.md` actually exists | CI, extending `make test-e2e` | Partial (E2E only; no ledger cross-check) |
 | **G6** | Adversarial | All characteristics (design judgement) | A fresh-context review of the diff alone. The session that wrote the code does not grade it. Findings limited to correctness and stated requirements. | A review subagent in `.claude/agents/` plus human review. **Does not block** | Absent |
@@ -231,7 +232,7 @@ pre-push and CI. A gate that sacrifices fast feedback gets bypassed.
 
 | Order | Work | Gate | #178 phase | Effect |
 |---|---|---|---|---|
-| 1 | Real-router integration harness; single source of truth for the route table plus an exhaustiveness check | G3 | Phase 1 | Removes the structural defect in resistance to refactoring. Everything else builds on it. |
+| 1 | Real-router integration harness; single source of truth for the route table plus an exhaustiveness check | G3 | Phase 1 | **Landed.** The table has one definition and the exhaustiveness check pins it; the full HTTP/WS integration half is still open. |
 | 2 | Widen coverage scope (threshold unchanged) | G4(a) | Phases 2 and 5 | Makes ~2,600 previously ungated lines visible. |
 | 3 | `.claude/settings.json` with G1/G2 hooks; a review subagent | G1, G6 | — | Promotes L0 discipline to L2. Closes the agent's own verification loop. |
 | 4 | red-check (`make efficacy`) in pull-request CI | G4(b) | — | Detects tautological tests mechanically. The largest single win under AI-assisted development. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -373,8 +373,13 @@ the list of board routes **from the router itself** with `chi.Walk` rather than 
 `/api/board/*` route added later — or, the failure this actually guards, one registered outside the
 authenticated sub-router — is covered the day it is registered, without anyone remembering to extend
 a list. It also pins the complete route table, so a route cannot silently appear, move, or be renamed.
-Both properties were confirmed by perturbation, not assumed: registering `/api/board/leaked` outside
-the sub-router fails the auth test, and renaming a route fails the table test.
+Both properties were confirmed by perturbation, not assumed: registering a *reachable*
+`/api/board/leaked` outside the sub-router fails the auth test, and renaming a route fails the table
+test. One nuance is worth recording, because it bounds what the auth test alone proves: a
+`/api/board/*` route registered inside the `/api` sub-router is *shadowed* by the `/api/board/*`
+mount, so the probe still gets its `401` from the middleware and the auth test passes — what catches
+that case is the table test, which lists a route the router can never actually reach. The two tests
+are complementary, not redundant.
 See [agent-board.md](agent-board.md)'s status note.
 
 **`WS /ws/board-command` cannot use the `Authorization` header at all** — browsers do not allow a

--- a/docs/security.md
+++ b/docs/security.md
@@ -366,9 +366,13 @@ asserting anything about the shipped auth posture, by construction — that asse
 `internal/server`, against the router `server.New()` really builds.
 
 Two files cover this scoping as a regression. `internal/server/board_routes_test.go` checks that an
-incorrect token on `/api/board/*` is rejected with `401`, the correct token reaches `200`, and
-pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no `Authorization` header at
-all. `internal/server/route_table_test.go` adds the missing-token case and, more importantly, derives
+incorrect token on `/api/board/*` is rejected with `401`, that the correct token reaches `200`, and
+that `/api/session-token` and `/ws/{sessionID}` stay reachable with no `Authorization` header at all.
+`internal/server/route_table_test.go` adds the missing-token case and the complementary check that no
+route outside `/api/board/` sits behind the middleware at all — it probes each route's own middleware
+chain, as `chi.Walk` reports it, rather than dispatching a real request, so the check covers the
+`POST`/`PUT`/`DELETE` half of the API the frontend depends on without creating a session or writing
+config as a side effect. More importantly, it derives
 the list of board routes **from the router itself** with `chi.Walk` rather than naming them: a
 `/api/board/*` route added later — or, the failure this actually guards, one registered outside the
 authenticated sub-router — is covered the day it is registered, without anyone remembering to extend

--- a/docs/security.md
+++ b/docs/security.md
@@ -348,14 +348,34 @@ proxy, SSH tunnel, or VPN in front of the non-loopback listener. See
 [agent-board.md](agent-board.md#security-model) for the full rationale.
 
 `internal/server`'s constant-time bearer-token middleware (`bearerAuthMiddleware`, `internal/server/auth.go`)
-is implemented, unit-tested, and wired into `registerRoutes` — but **only** onto the
-`r.Route("/api/board", ...)` sub-route (`GET /status`, `GET /messages`, `POST /broadcast`, `GET
-/command/history`), not onto any pre-existing `/api/*` route or `/ws/{sessionID}`. Widening it to
+is implemented, unit-tested, and wired in `registerRoutes` — but **only** onto the
+`api.BoardRoutePrefix` (`/api/board`) sub-router (`GET /status`, `GET /messages`, `POST /broadcast`,
+`GET /command/history`), not onto any pre-existing `/api/*` route or `/ws/{sessionID}`. Widening it to
 those routes without a matching frontend change would break every existing, currently-unauthenticated
-request, so that remains a separate, larger change. `internal/server/board_routes_test.go` covers this
-scoping as a regression: missing/incorrect token on `/api/board/*` is rejected with `401`, the correct
-token reaches `200`, and pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no
-`Authorization` header at all. See [agent-board.md](agent-board.md)'s status note.
+request, so that remains a separate, larger change.
+
+**Which package owns which half of that sentence matters, because it changed.** The route table
+itself — every path, method and the `r.Route` nesting, including which routes sit under
+`BoardRoutePrefix` — lives in `internal/api`'s `Handler.Mount` (`internal/api/routes.go`), so that
+`internal/server`'s production wiring and `internal/api`'s own handler tests cannot describe
+different routes; they previously could, and had already drifted, with `/api/board/*` registered flat
+and with no middleware in the test copy. **Choosing the middleware stays with `internal/server`**:
+`registerRoutes` passes `bearerAuthMiddleware(authToken)` as `Mount`'s `boardAuth` argument, and the
+handler tests pass `nil`. A test that mounts the board routes unauthenticated is therefore no longer
+asserting anything about the shipped auth posture, by construction — that assertion lives only in
+`internal/server`, against the router `server.New()` really builds.
+
+Two files cover this scoping as a regression. `internal/server/board_routes_test.go` checks that an
+incorrect token on `/api/board/*` is rejected with `401`, the correct token reaches `200`, and
+pre-existing `/api/*` routes plus `/ws/{sessionID}` stay reachable with no `Authorization` header at
+all. `internal/server/route_table_test.go` adds the missing-token case and, more importantly, derives
+the list of board routes **from the router itself** with `chi.Walk` rather than naming them: a
+`/api/board/*` route added later — or, the failure this actually guards, one registered outside the
+authenticated sub-router — is covered the day it is registered, without anyone remembering to extend
+a list. It also pins the complete route table, so a route cannot silently appear, move, or be renamed.
+Both properties were confirmed by perturbation, not assumed: registering `/api/board/leaked` outside
+the sub-router fails the auth test, and renaming a route fails the table test.
+See [agent-board.md](agent-board.md)'s status note.
 
 **`WS /ws/board-command` cannot use the `Authorization` header at all** — browsers do not allow a
 WebSocket upgrade request to carry arbitrary headers. `internal/ws/board_command.go`'s

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -89,33 +89,13 @@ func setupRouter(cfg *config.Config, mgr *session.Manager) *chi.Mux {
 
 func setupRouterWithHandler(h *Handler) *chi.Mux {
 	r := chi.NewRouter()
-	r.Get("/api/layout", h.GetLayout)
-	r.Put("/api/layout", h.PutLayout)
-	r.Get("/api/workspaces", h.GetWorkspaces)
-	r.Post("/api/workspaces", h.PostWorkspace)
-	r.Put("/api/workspaces/active", h.PutActiveWorkspace)
-	r.Put("/api/workspaces/tab-position", h.PutWorkspaceTabPosition)
-	r.Put("/api/workspaces/vertical-bar-width", h.PutWorkspaceVerticalBarWidth)
-	r.Put("/api/workspaces/{id}", h.PutWorkspace)
-	r.Delete("/api/workspaces/{id}", h.DeleteWorkspace)
-	r.Put("/api/workspaces/{id}/layout", h.PutWorkspaceLayout)
-	r.Get("/api/sessions", h.GetSessions)
-	r.Post("/api/sessions", h.PostSession)
-	r.Delete("/api/sessions/{id}", h.DeleteSession)
-	r.Post("/api/sessions/{id}/restart", h.RestartSession)
-	r.Post("/api/sessions/{id}/open-url", h.PostOpenURL)
-	r.Get("/api/sessions/{id}/git-info", h.GetGitInfo)
-	r.Get("/api/display", h.GetDisplay)
-	r.Get("/api/ssh-connections", h.GetSSHConnections)
-	r.Get("/api/ssh-config/hosts", h.GetSSHConfigHosts)
-	r.Post("/api/ssh-config/hosts", h.PostSSHConfigHost)
-	r.Get("/api/detect-shell", h.GetDetectShell)
-	r.Get("/api/directories", h.GetDirectories)
-	r.Get("/api/session-token", h.GetBoardSessionToken)
-	r.Get("/api/board/status", h.GetBoardStatus)
-	r.Get("/api/board/messages", h.GetBoardMessages)
-	r.Post("/api/board/broadcast", h.PostBoardBroadcast)
-	r.Get("/api/board/command/history", h.GetBoardCommandHistory)
+	// Mount is the same route table internal/server wires in production, so
+	// these tests exercise the real paths, methods and mount structure
+	// rather than a hand-maintained copy of them. boardAuth is nil here:
+	// whether the bearer token is enforced is internal/server's contract,
+	// covered by its own tests against the router the binary really serves.
+	// See docs/quality-gateway.md's gate G3.
+	h.Mount(r, nil)
 	return r
 }
 
@@ -1649,15 +1629,9 @@ func (m *mockRemoteGitSession) InspectGitContext(cwd string) (session.GitContext
 	return ctx, nil
 }
 
-func setupRouterWithVSCode(h *Handler) *chi.Mux {
-	r := setupRouterWithHandler(h)
-	r.Post("/api/sessions/{id}/open-vscode", h.PostOpenVSCode)
-	return r
-}
-
 func TestPostOpenVSCode_NotFound_404(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/missing/open-vscode", nil)
@@ -1670,7 +1644,7 @@ func TestPostOpenVSCode_NoCWDGetter_422(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/s1/open-vscode", nil)
@@ -1729,7 +1703,7 @@ func TestPostOpenVSCode_EndedAgentKeepsLastWorktree(t *testing.T) {
 	mgr.Add(sess)
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	resp := postOpenVSCodeOKWithRouter(t, r, "local-sticky")
 	assert.Equal(t, worktreeDir, resp.Cwd)
@@ -1754,7 +1728,7 @@ func TestPostOpenVSCode_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	mgr.Add(sess)
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	resp := postOpenVSCodeOKWithRouter(t, r, "local-open-stale")
 	assert.Equal(t, worktreeDir, resp.Cwd)
@@ -1813,7 +1787,7 @@ func postOpenVSCodeOK(t *testing.T, id string, sess session.Session) openVSCodeR
 	mgr.Add(sess)
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	return postOpenVSCodeOKWithRouter(t, r, id)
 }
@@ -1841,7 +1815,7 @@ func TestPostOpenVSCode_Local_DeletedDir_422(t *testing.T) {
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/local-del/open-vscode", nil)
@@ -1869,7 +1843,7 @@ func TestPostOpenVSCode_SSH_InvalidConnName_422(t *testing.T) {
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.codeBinaryPath = "/bin/echo"
-	r := setupRouterWithVSCode(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/sessions/ssh-bad/open-vscode", nil)
@@ -2012,15 +1986,9 @@ func writeFakeGHBinary(t *testing.T, body string) string {
 	return path
 }
 
-func setupRouterWithGitInfo(h *Handler) *chi.Mux {
-	r := setupRouterWithHandler(h)
-	r.Get("/api/sessions/{id}/git-info", h.GetGitInfo)
-	return r
-}
-
 func TestGetGitInfo_NotFound_404(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), session.NewManager(), nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/missing/git-info", nil)
@@ -2033,7 +2001,7 @@ func TestGetGitInfo_NoCWDGetter_IsGitFalse(t *testing.T) {
 	mgr := session.NewManager()
 	mgr.Add(newMockSession("s1"))
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/s1/git-info", nil)
@@ -2053,7 +2021,7 @@ func TestGetGitInfo_NotAGitRepo_IsGitFalse(t *testing.T) {
 		cwd:         dir,
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local1/git-info", nil)
@@ -2084,7 +2052,7 @@ func TestGetGitInfo_NotAGitRepo_LogsCauseAndRemediation(t *testing.T) {
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-log/git-info", nil)
@@ -2110,7 +2078,7 @@ func TestGetGitInfo_IsGitRepo_ReturnsBranchAndRepo(t *testing.T) {
 		cwd:         dir,
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local2/git-info", nil)
@@ -2147,7 +2115,7 @@ func TestGetGitInfo_IsGitRepo_WithLinkedPR_ReturnsPRInfo(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/123\",\"number\":123}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-pr/git-info", nil)
@@ -2174,7 +2142,7 @@ func TestGetGitInfo_SubdirOfGitRepo_ReturnsBranchAndRepo(t *testing.T) {
 		cwd:         subdir,
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/sub1/git-info", nil)
@@ -2196,7 +2164,7 @@ func TestGetGitInfo_PRLookupFails_StillReturnsGitInfo(t *testing.T) {
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.ghBinaryPath = writeFakeGHBinary(t, "#!/bin/sh\nexit 1\n")
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-pr-miss/git-info", nil)
@@ -2222,7 +2190,7 @@ func TestGetGitInfo_DetachedHead_StillReturnsGitInfo(t *testing.T) {
 		cwd:         dir,
 	})
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/detached/git-info", nil)
@@ -2264,7 +2232,7 @@ func TestGetGitInfo_ActiveAgentWorkdir_PrefersWorktreeBranch(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/456\",\"number\":456}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-worktree/git-info", nil)
@@ -2300,7 +2268,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_ReturnsAllWorktreesWithPRs(t *testin
 		"*) exit 1 ;;\n"+
 		"esac\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-multi/git-info", nil)
@@ -2345,7 +2313,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_DuplicateRootDeduped(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/111\",\"number\":111}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-dup/git-info", nil)
@@ -2378,7 +2346,7 @@ func TestGetGitInfo_MultipleActiveWorktrees_OnePRLookupFails_OthersStillReturned
 		"*) exit 1 ;;\n"+
 		"esac\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-partial/git-info", nil)
@@ -2414,7 +2382,7 @@ func TestGetGitInfo_EndedAgentFallsBackToPaneCWD(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/789\",\"number\":789}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-fallback/git-info", nil)
@@ -2444,7 +2412,7 @@ func TestGetGitInfo_EndedAgentKeepsLastWorktree(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/999\",\"number\":999}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-sticky/git-info", nil)
@@ -2482,7 +2450,7 @@ func TestGetGitInfo_StaleStickyWorktreeFallsBackToPaneCWD(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-stale/git-info", nil)
@@ -2629,7 +2597,7 @@ func TestGetGitInfo_RemoteEndedAgentKeepsLastWorktree(t *testing.T) {
 		t,
 		"#!/bin/sh\necho '{\"url\":\"https://github.com/example/panemux/pull/654\",\"number\":654}'\n",
 	)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-sticky/git-info", nil)
@@ -2662,7 +2630,7 @@ func TestGetGitInfo_GitNotFound_IsGitFalse(t *testing.T) {
 	prev := gitExistsFn
 	gitExistsFn = func() error { return errors.New("git not found") }
 	t.Cleanup(func() { gitExistsFn = prev })
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local3/git-info", nil)
@@ -2685,7 +2653,7 @@ func TestGetGitInfo_SecondRequestWithinTTL_ServesCachedResponseWithoutRecomputin
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-cached/git-info", nil)
@@ -2721,7 +2689,7 @@ func TestGetGitInfo_RequestAfterTTLExpires_Recomputes(t *testing.T) {
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	now := time.Now()
 	h.nowFn = func() time.Time { return now }
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-expired/git-info", nil)
@@ -2749,7 +2717,7 @@ func TestGetGitInfo_AfterSessionRecreatedWithSameID_DoesNotServeOldSessionsCache
 	mgr := session.NewManager()
 	mgr.Add(oldSess)
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/local-recreated/git-info", nil)
@@ -2807,7 +2775,7 @@ func TestGetGitInfo_RemoteGitContext_ReturnsBranchAndRepo(t *testing.T) {
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote/git-info", nil)
@@ -2852,7 +2820,7 @@ func TestGetGitInfo_RemoteGitContextFailure_LogsCauseAndRemediation(t *testing.T
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-log/git-info", nil)
@@ -2894,7 +2862,7 @@ func TestGetGitInfo_RemoteActiveWorkdir_PrefersRemoteWorktreeBranch(t *testing.T
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-worktree/git-info", nil)
@@ -2928,7 +2896,7 @@ func TestGetGitInfo_RemoteGitContext_WithOrigin_ReturnsRepoURL(t *testing.T) {
 	})
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote-origin/git-info", nil)
@@ -2961,7 +2929,7 @@ func TestGetGitInfo_RemoteGitContext_WithSSHConfigAliasOrigin_ReturnsResolvedRep
 
 	h := NewHandler(defaultTestConfig(), mgr, nil, nil)
 	h.sshConfigPath = writeTempSSHConfigForAPI(t, "Host github-work\n    HostName github.com\n    User git\n")
-	r := setupRouterWithGitInfo(h)
+	r := setupRouterWithHandler(h)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/sessions/ssh-remote-alias-origin/git-info", nil)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -94,7 +94,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	// rather than a hand-maintained copy of them. boardAuth is nil here:
 	// whether the bearer token is enforced is internal/server's contract,
 	// covered by its own tests against the router the binary really serves.
-	// See issue #178.
+	// See docs/quality-gateway.md's gate G3, and issue #178.
 	h.Mount(r, nil)
 	return r
 }

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -94,7 +94,7 @@ func setupRouterWithHandler(h *Handler) *chi.Mux {
 	// rather than a hand-maintained copy of them. boardAuth is nil here:
 	// whether the bearer token is enforced is internal/server's contract,
 	// covered by its own tests against the router the binary really serves.
-	// See docs/quality-gateway.md's gate G3.
+	// See issue #178.
 	h.Mount(r, nil)
 	return r
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// BoardRoutePrefix is the path prefix for the only part of the HTTP API that
+// is gated behind the board bearer token. It is exported so the server that
+// mounts these routes can name the same prefix its auth middleware guards
+// instead of repeating the literal.
+const BoardRoutePrefix = "/api/board"
+
+// Mount registers the whole /api surface on r.
+//
+// This function is the single definition of the route table. Production
+// wiring in internal/server and this package's own handler tests both go
+// through it, so a route cannot be renamed, moved, or added in one place and
+// silently missed in the other. That used to be possible: the handler tests
+// built their own chi router listing the routes by hand, and the two had
+// already drifted — /api/board/* was registered there flat and with no
+// middleware, a shape that never existed in production. See
+// docs/quality-gateway.md's gate G3 and issue #178.
+//
+// boardAuth wraps the BoardRoutePrefix sub-router. Production passes the
+// bearer-token middleware. A nil value mounts those routes with no
+// middleware, which is what handler-level tests want: whether the token is
+// actually enforced is internal/server's contract and is tested there,
+// against the router this repository really serves.
+func (h *Handler) Mount(r chi.Router, boardAuth func(http.Handler) http.Handler) {
+	r.Route("/api", func(r chi.Router) {
+		r.Get("/layout", h.GetLayout)
+		r.Put("/layout", h.PutLayout)
+		r.Get("/workspaces", h.GetWorkspaces)
+		r.Post("/workspaces", h.PostWorkspace)
+		r.Put("/workspaces/active", h.PutActiveWorkspace)
+		r.Put("/workspaces/tab-position", h.PutWorkspaceTabPosition)
+		r.Put("/workspaces/vertical-bar-width", h.PutWorkspaceVerticalBarWidth)
+		r.Put("/workspaces/{id}", h.PutWorkspace)
+		r.Delete("/workspaces/{id}", h.DeleteWorkspace)
+		r.Put("/workspaces/{id}/layout", h.PutWorkspaceLayout)
+		r.Get("/sessions", h.GetSessions)
+		r.Post("/sessions", h.PostSession)
+		r.Delete("/sessions/{id}", h.DeleteSession)
+		r.Post("/sessions/{id}/restart", h.RestartSession)
+		r.Post("/sessions/{id}/open-vscode", h.PostOpenVSCode)
+		r.Post("/sessions/{id}/open-url", h.PostOpenURL)
+		r.Get("/sessions/{id}/git-info", h.GetGitInfo)
+		r.Get("/display", h.GetDisplay)
+		r.Get("/ssh-connections", h.GetSSHConnections)
+		r.Get("/ssh-config/hosts", h.GetSSHConfigHosts)
+		r.Post("/ssh-config/hosts", h.PostSSHConfigHost)
+		r.Get("/detect-shell", h.GetDetectShell)
+		r.Get("/directories", h.GetDirectories)
+		// Deliberately NOT placed under /board/ — chi routes any path
+		// starting with /api/board/ into the BoardRoutePrefix sub-router
+		// below regardless of where else a handler for that path is
+		// registered, so a route literally named /api/board/session-token
+		// would always be caught by boardAuth even when defined here. See
+		// GetBoardSessionToken's own doc comment for why this one route
+		// must stay unauthenticated.
+		r.Get("/session-token", h.GetBoardSessionToken)
+	})
+	r.Route(BoardRoutePrefix, func(r chi.Router) {
+		if boardAuth != nil {
+			r.Use(boardAuth)
+		}
+		r.Get("/status", h.GetBoardStatus)
+		r.Get("/messages", h.GetBoardMessages)
+		r.Post("/broadcast", h.PostBoardBroadcast)
+		r.Get("/command/history", h.GetBoardCommandHistory)
+	})
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -20,8 +20,7 @@ const BoardRoutePrefix = "/api/board"
 // silently missed in the other. That used to be possible: the handler tests
 // built their own chi router listing the routes by hand, and the two had
 // already drifted — /api/board/* was registered there flat and with no
-// middleware, a shape that never existed in production. See
-// docs/quality-gateway.md's gate G3 and issue #178.
+// middleware, a shape that never existed in production. See issue #178.
 //
 // boardAuth wraps the BoardRoutePrefix sub-router. Production passes the
 // bearer-token middleware. A nil value mounts those routes with no

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -20,7 +20,8 @@ const BoardRoutePrefix = "/api/board"
 // silently missed in the other. That used to be possible: the handler tests
 // built their own chi router listing the routes by hand, and the two had
 // already drifted — /api/board/* was registered there flat and with no
-// middleware, a shape that never existed in production. See issue #178.
+// middleware, a shape that never existed in production. See
+// docs/quality-gateway.md's gate G3, and issue #178.
 //
 // boardAuth wraps the BoardRoutePrefix sub-router. Production passes the
 // bearer-token middleware. A nil value mounts those routes with no

--- a/internal/server/board_routes_test.go
+++ b/internal/server/board_routes_test.go
@@ -71,26 +71,6 @@ func TestServer_SessionTokenRoute_RemainsUnauthenticated(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "session-token must be reachable with no Authorization header")
 }
 
-func TestServer_ExistingAPIRoutes_RemainUnauthenticated(t *testing.T) {
-	// Regression test: scoping bearerAuthMiddleware to /api/board must not
-	// widen to any pre-existing route — the current frontend sends no
-	// token at all.
-	cfg := testConfigWithToken("secret-token")
-	mgr := session.NewManager()
-	srv := New(cfg, mgr, board.NewBoardCache(), nil, nil, emptyFS)
-
-	paths := []string{"/api/layout", "/api/workspaces", "/api/sessions", "/api/display"}
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, path, nil)
-			srv.httpSrv.Handler.ServeHTTP(rec, req)
-			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
-				"existing routes must stay reachable with no Authorization header")
-		})
-	}
-}
-
 func TestServer_WSRoute_RemainsUnauthenticated(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()

--- a/internal/server/board_routes_test.go
+++ b/internal/server/board_routes_test.go
@@ -19,23 +19,6 @@ func testConfigWithToken(token string) *config.Config {
 	return cfg
 }
 
-func TestServer_BoardRoutesWired_RequireAuth(t *testing.T) {
-	cfg := testConfigWithToken("secret-token")
-	mgr := session.NewManager()
-	cache := board.NewBoardCache()
-	srv := New(cfg, mgr, cache, nil, nil, emptyFS)
-
-	paths := []string{"/api/board/status", "/api/board/messages", "/api/board/command/history"}
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, path, nil)
-			srv.httpSrv.Handler.ServeHTTP(rec, req)
-			assert.Equal(t, http.StatusUnauthorized, rec.Code, "missing token must be rejected")
-		})
-	}
-}
-
 func TestServer_BoardRoutes_WrongToken_Rejected(t *testing.T) {
 	cfg := testConfigWithToken("secret-token")
 	mgr := session.NewManager()

--- a/internal/server/route_table_test.go
+++ b/internal/server/route_table_test.go
@@ -154,40 +154,60 @@ func TestServer_EveryBoardRouteRequiresAuth(t *testing.T) {
 	require.Positive(t, checked, "no board routes were found — the prefix or the router changed")
 }
 
-// The complement of the test above: the routes outside /api/board/ follow the
-// unauthenticated posture the frontend still depends on. Restricted to GET so
-// the check cannot start a session or write config as a side effect.
-func TestServer_NonBoardAPIRoutesStayUnauthenticated(t *testing.T) {
-	// These are real requests against real handlers, and the walk includes
-	// /api/directories, /api/ssh-connections and /api/ssh-config/hosts, which
-	// resolve their paths from the home directory. server.New() builds its own
-	// api.Handler, so there is no override to inject — point HOME at a temp
-	// directory instead, before New() calls sshconfig.DefaultPath(), so the
-	// test never reads the developer's real ~/.ssh/config or home directory.
-	t.Setenv("HOME", t.TempDir())
+// chainMiddleware wraps h in mws in the order chi itself would apply them:
+// the first entry is outermost, so it runs first.
+func chainMiddleware(mws []func(http.Handler) http.Handler, h http.Handler) http.Handler {
+	for i := len(mws) - 1; i >= 0; i-- {
+		h = mws[i](h)
+	}
+	return h
+}
 
+// The complement of the test above: no route outside /api/board/ is behind
+// the bearer-token middleware, which is the unauthenticated posture the
+// frontend still depends on.
+//
+// The probe runs the route's own middleware chain — chi.Walk hands it to the
+// callback alongside the pattern — against a sentinel handler, instead of
+// dispatching a real request at the real handler. That matters for coverage,
+// not just tidiness: an earlier revision issued real requests and therefore
+// had to restrict itself to GET so it could not start a session or rewrite
+// config as a side effect, which left every POST/PUT/DELETE route — the
+// session, workspace and layout writes the frontend makes constantly —
+// unguarded. Gating those behind the token would break the app just as badly
+// as gating the reads, and would not have failed a single test. Running only
+// the middlewares has no side effects at all, so every method is covered, and
+// nothing here reads the developer's home directory either.
+func TestServer_NonBoardAPIRoutesStayUnauthenticated(t *testing.T) {
 	srv := New(testConfigWithToken("secret-token"), session.NewManager(), nil, nil, nil, emptyFS)
 
+	mux, ok := srv.httpSrv.Handler.(*chi.Mux)
+	require.True(t, ok, "the server's handler must be the chi router itself")
+
 	var checked int
-	for _, route := range walkRoutes(t, srv) {
-		method, pattern, _ := strings.Cut(route, " ")
-		if method != http.MethodGet || !strings.HasPrefix(pattern, "/api/") {
-			continue
-		}
-		if strings.HasPrefix(pattern, boardRoutePrefix) {
-			continue
+	err := chi.Walk(mux, func(method, pattern string, _ http.Handler, mws ...func(http.Handler) http.Handler) error {
+		if !strings.HasPrefix(pattern, "/api/") || strings.HasPrefix(pattern, boardRoutePrefix) {
+			return nil
 		}
 		checked++
 
-		t.Run(route, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(method, routeRequestPath(pattern), nil)
-			srv.httpSrv.Handler.ServeHTTP(rec, req)
+		t.Run(method+" "+pattern, func(t *testing.T) {
+			reached := false
+			h := chainMiddleware(mws, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				reached = true
+			}))
 
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(method, routeRequestPath(pattern), nil))
+
+			assert.True(t, reached,
+				"widening bearer auth beyond %s would break every existing frontend request", boardRoutePrefix)
 			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
 				"widening bearer auth beyond %s would break every existing frontend request", boardRoutePrefix)
 		})
-	}
+		return nil
+	})
+	require.NoError(t, err)
 
-	require.Positive(t, checked, "no unauthenticated GET routes were found — the router changed")
+	require.Positive(t, checked, "no unauthenticated routes were found — the router changed")
 }

--- a/internal/server/route_table_test.go
+++ b/internal/server/route_table_test.go
@@ -1,0 +1,183 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/board"
+	"panemux/internal/commandcenter"
+	"panemux/internal/session"
+)
+
+// These tests are the exhaustiveness gate over the HTTP route table. They
+// exist because the api package's handler tests used to build their own copy
+// of the router, so a route could be renamed, reordered, or moved behind
+// different middleware in internal/server without a single one of them
+// failing — and the /api/board/* routes had already drifted apart, registered
+// flat and unauthenticated in the test copy. See docs/quality-gateway.md's
+// gate G3, and issue #178.
+//
+// Adding a route to the server is now expected to fail these tests until the
+// expected sets below are updated. That is the point: the table is stated in
+// exactly two places, the code and this test, and they are compared.
+
+// walkRoutes returns every route registered on the real server.New() router,
+// as "METHOD /pattern", sorted. It reads the router the server actually
+// serves, not a reconstruction of it.
+func walkRoutes(t *testing.T, srv *Server) []string {
+	t.Helper()
+
+	mux, ok := srv.httpSrv.Handler.(*chi.Mux)
+	require.True(t, ok, "the server's handler must be the chi router itself")
+
+	var routes []string
+	err := chi.Walk(mux, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		routes = append(routes, method+" "+route)
+		return nil
+	})
+	require.NoError(t, err)
+
+	sort.Strings(routes)
+	return routes
+}
+
+// expectedRoutes is every route registered when the command center is
+// disabled. Keep it sorted; the comparison is order-independent but a sorted
+// literal is easier to diff by eye.
+var expectedRoutes = []string{
+	"DELETE /api/sessions/{id}",
+	"DELETE /api/workspaces/{id}",
+	"GET /*",
+	"GET /api/board/command/history",
+	"GET /api/board/messages",
+	"GET /api/board/status",
+	"GET /api/detect-shell",
+	"GET /api/directories",
+	"GET /api/display",
+	"GET /api/layout",
+	"GET /api/session-token",
+	"GET /api/sessions",
+	"GET /api/sessions/{id}/git-info",
+	"GET /api/ssh-config/hosts",
+	"GET /api/ssh-connections",
+	"GET /api/workspaces",
+	"GET /ws/{sessionID}",
+	"POST /api/board/broadcast",
+	"POST /api/sessions",
+	"POST /api/sessions/{id}/open-url",
+	"POST /api/sessions/{id}/open-vscode",
+	"POST /api/sessions/{id}/restart",
+	"POST /api/ssh-config/hosts",
+	"POST /api/workspaces",
+	"PUT /api/layout",
+	"PUT /api/workspaces/active",
+	"PUT /api/workspaces/tab-position",
+	"PUT /api/workspaces/vertical-bar-width",
+	"PUT /api/workspaces/{id}",
+	"PUT /api/workspaces/{id}/layout",
+}
+
+func TestServer_RouteTable_CommandCenterDisabled(t *testing.T) {
+	srv := New(testConfig(), session.NewManager(), nil, nil, nil, emptyFS)
+
+	assert.Equal(t, expectedRoutes, walkRoutes(t, srv))
+}
+
+// With a runner present the table gains exactly one route. Asserting the
+// difference rather than a second full literal keeps the two lists from
+// drifting against each other.
+func TestServer_RouteTable_CommandCenterEnabled_AddsOnlyBoardCommandWS(t *testing.T) {
+	runner := commandcenter.NewRunner(commandcenter.RunnerConfig{})
+	srv := New(testConfigWithToken("secret-token"), session.NewManager(), nil, nil, runner, emptyFS)
+
+	want := append(append([]string{}, expectedRoutes...), "GET /ws/board-command")
+	sort.Strings(want)
+
+	assert.Equal(t, want, walkRoutes(t, srv))
+}
+
+// boardRoutePrefix is the path prefix chi mounts behind the bearer-token
+// middleware. Everything under it must be authenticated; nothing outside it
+// is, today.
+const boardRoutePrefix = "/api/board/"
+
+// routeRequestPath turns a chi pattern into a concrete request path. Board
+// routes carry no URL parameters today, but substituting rather than skipping
+// keeps the test working if one gains a parameter later.
+func routeRequestPath(pattern string) string {
+	var out []string
+	for _, seg := range strings.Split(pattern, "/") {
+		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {
+			out = append(out, "placeholder")
+			continue
+		}
+		out = append(out, seg)
+	}
+	return strings.Join(out, "/")
+}
+
+// Every board route is derived from the router itself rather than listed by
+// hand, so a board route added later is covered by this test the day it is
+// registered — the failure mode being guarded against is a new /api/board/*
+// route registered outside the authenticated sub-router.
+func TestServer_EveryBoardRouteRequiresAuth(t *testing.T) {
+	cache := board.NewBoardCache()
+	srv := New(testConfigWithToken("secret-token"), session.NewManager(), cache, nil, nil, emptyFS)
+
+	var checked int
+	for _, route := range walkRoutes(t, srv) {
+		method, pattern, _ := strings.Cut(route, " ")
+		if !strings.HasPrefix(pattern, boardRoutePrefix) {
+			continue
+		}
+		checked++
+
+		t.Run(route, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, routeRequestPath(pattern), nil)
+			srv.httpSrv.Handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusUnauthorized, rec.Code,
+				"a route under %s must reject a request carrying no bearer token", boardRoutePrefix)
+		})
+	}
+
+	require.Positive(t, checked, "no board routes were found — the prefix or the router changed")
+}
+
+// The complement of the test above: the routes outside /api/board/ follow the
+// unauthenticated posture the frontend still depends on. Restricted to GET so
+// the check cannot start a session or write config as a side effect.
+func TestServer_NonBoardAPIRoutesStayUnauthenticated(t *testing.T) {
+	srv := New(testConfigWithToken("secret-token"), session.NewManager(), nil, nil, nil, emptyFS)
+
+	var checked int
+	for _, route := range walkRoutes(t, srv) {
+		method, pattern, _ := strings.Cut(route, " ")
+		if method != http.MethodGet || !strings.HasPrefix(pattern, "/api/") {
+			continue
+		}
+		if strings.HasPrefix(pattern, boardRoutePrefix) {
+			continue
+		}
+		checked++
+
+		t.Run(route, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, routeRequestPath(pattern), nil)
+			srv.httpSrv.Handler.ServeHTTP(rec, req)
+
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code,
+				"widening bearer auth beyond %s would break every existing frontend request", boardRoutePrefix)
+		})
+	}
+
+	require.Positive(t, checked, "no unauthenticated GET routes were found — the router changed")
+}

--- a/internal/server/route_table_test.go
+++ b/internal/server/route_table_test.go
@@ -22,7 +22,8 @@ import (
 // of the router, so a route could be renamed, reordered, or moved behind
 // different middleware in internal/server without a single one of them
 // failing — and the /api/board/* routes had already drifted apart, registered
-// flat and unauthenticated in the test copy. See issue #178.
+// flat and unauthenticated in the test copy. See
+// docs/quality-gateway.md's gate G3, and issue #178.
 //
 // Adding a route to the server is now expected to fail these tests until the
 // expected sets below are updated. That is the point: the table is stated in

--- a/internal/server/route_table_test.go
+++ b/internal/server/route_table_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"panemux/internal/api"
 	"panemux/internal/board"
 	"panemux/internal/commandcenter"
 	"panemux/internal/session"
@@ -21,8 +22,7 @@ import (
 // of the router, so a route could be renamed, reordered, or moved behind
 // different middleware in internal/server without a single one of them
 // failing — and the /api/board/* routes had already drifted apart, registered
-// flat and unauthenticated in the test copy. See docs/quality-gateway.md's
-// gate G3, and issue #178.
+// flat and unauthenticated in the test copy. See issue #178.
 //
 // Adding a route to the server is now expected to fail these tests until the
 // expected sets below are updated. That is the point: the table is stated in
@@ -105,8 +105,10 @@ func TestServer_RouteTable_CommandCenterEnabled_AddsOnlyBoardCommandWS(t *testin
 
 // boardRoutePrefix is the path prefix chi mounts behind the bearer-token
 // middleware. Everything under it must be authenticated; nothing outside it
-// is, today.
-const boardRoutePrefix = "/api/board/"
+// is, today. It is derived from api.BoardRoutePrefix rather than restated,
+// so renaming the prefix moves these tests with it instead of silently
+// leaving them looking for a prefix nothing is mounted at.
+var boardRoutePrefix = api.BoardRoutePrefix + "/"
 
 // routeRequestPath turns a chi pattern into a concrete request path. Board
 // routes carry no URL parameters today, but substituting rather than skipping
@@ -156,6 +158,14 @@ func TestServer_EveryBoardRouteRequiresAuth(t *testing.T) {
 // unauthenticated posture the frontend still depends on. Restricted to GET so
 // the check cannot start a session or write config as a side effect.
 func TestServer_NonBoardAPIRoutesStayUnauthenticated(t *testing.T) {
+	// These are real requests against real handlers, and the walk includes
+	// /api/directories, /api/ssh-connections and /api/ssh-config/hosts, which
+	// resolve their paths from the home directory. server.New() builds its own
+	// api.Handler, so there is no override to inject — point HOME at a temp
+	// directory instead, before New() calls sshconfig.DefaultPath(), so the
+	// test never reads the developer's real ~/.ssh/config or home directory.
+	t.Setenv("HOME", t.TempDir())
+
 	srv := New(testConfigWithToken("secret-token"), session.NewManager(), nil, nil, nil, emptyFS)
 
 	var checked int

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,55 +75,22 @@ func registerRoutes(
 	r chi.Router, apiHandler *api.Handler, wsHandler *ws.Handler, commandRunner *commandcenter.Runner,
 	frontendFS embed.FS, authToken string,
 ) {
-	r.Route("/api", func(r chi.Router) {
-		r.Get("/layout", apiHandler.GetLayout)
-		r.Put("/layout", apiHandler.PutLayout)
-		r.Get("/workspaces", apiHandler.GetWorkspaces)
-		r.Post("/workspaces", apiHandler.PostWorkspace)
-		r.Put("/workspaces/active", apiHandler.PutActiveWorkspace)
-		r.Put("/workspaces/tab-position", apiHandler.PutWorkspaceTabPosition)
-		r.Put("/workspaces/vertical-bar-width", apiHandler.PutWorkspaceVerticalBarWidth)
-		r.Put("/workspaces/{id}", apiHandler.PutWorkspace)
-		r.Delete("/workspaces/{id}", apiHandler.DeleteWorkspace)
-		r.Put("/workspaces/{id}/layout", apiHandler.PutWorkspaceLayout)
-		r.Get("/sessions", apiHandler.GetSessions)
-		r.Post("/sessions", apiHandler.PostSession)
-		r.Delete("/sessions/{id}", apiHandler.DeleteSession)
-		r.Post("/sessions/{id}/restart", apiHandler.RestartSession)
-		r.Post("/sessions/{id}/open-vscode", apiHandler.PostOpenVSCode)
-		r.Post("/sessions/{id}/open-url", apiHandler.PostOpenURL)
-		r.Get("/sessions/{id}/git-info", apiHandler.GetGitInfo)
-		r.Get("/display", apiHandler.GetDisplay)
-		r.Get("/ssh-connections", apiHandler.GetSSHConnections)
-		r.Get("/ssh-config/hosts", apiHandler.GetSSHConfigHosts)
-		r.Post("/ssh-config/hosts", apiHandler.PostSSHConfigHost)
-		r.Get("/detect-shell", apiHandler.GetDetectShell)
-		r.Get("/directories", apiHandler.GetDirectories)
-		// Deliberately NOT placed under /board/ — chi routes any path
-		// starting with /api/board/ into the r.Route("/api/board", ...)
-		// sub-router below regardless of where else a handler for that path
-		// is registered, so a route literally named /api/board/session-token
-		// would always be caught by bearerAuthMiddleware even when defined
-		// here. See GetBoardSessionToken's own doc comment for why this one
-		// route must stay unauthenticated.
-		r.Get("/session-token", apiHandler.GetBoardSessionToken)
-	})
-	// /api/board/* is the only part of the API gated behind bearer-token
-	// auth today: unlike every other /api/* route and /ws/{sessionID},
+	// The route table itself lives in internal/api (api.Handler.Mount), so
+	// this wiring and the api package's own handler tests cannot describe
+	// different routes. What stays here is the decision this package owns:
+	// which part of the table is authenticated.
+	//
+	// api.BoardRoutePrefix is the only part of the API gated behind bearer-
+	// token auth today: unlike every other /api/* route and /ws/{sessionID},
 	// these endpoints were gated from day one, before the frontend called
 	// any of them — GetBoardStatus/GetBoardMessages are now polled by the
 	// dashboard's useBoardStatus hook and GetBoardCommandHistory by the
 	// command palette/history panel (see docs/agent-board.md), but the
 	// auth gate itself was never contingent on that. Retrofitting auth
-	// onto the already-relied-upon unauthenticated routes above is a
-	// separate, larger change. See docs/security.md.
-	r.Route("/api/board", func(r chi.Router) {
-		r.Use(bearerAuthMiddleware(authToken))
-		r.Get("/status", apiHandler.GetBoardStatus)
-		r.Get("/messages", apiHandler.GetBoardMessages)
-		r.Post("/broadcast", apiHandler.PostBoardBroadcast)
-		r.Get("/command/history", apiHandler.GetBoardCommandHistory)
-	})
+	// onto the rest of the table, which the frontend already relies on
+	// being unauthenticated, is a separate, larger change. See
+	// docs/security.md.
+	apiHandler.Mount(r, bearerAuthMiddleware(authToken))
 	r.Get("/ws/{sessionID}", wsHandler.ServeHTTP)
 	// /ws/board-command is only registered when the command center is
 	// enabled (commandRunner != nil) — see docs/agent-board.md's Command

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -209,16 +209,3 @@ func performWorkspaceSettingUpdate(t *testing.T, srv *Server, path string, body 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	return rec
 }
-
-func TestServer_DirectoriesRouteWired(t *testing.T) {
-	cfg := testConfig()
-	mgr := session.NewManager()
-	srv := New(cfg, mgr, nil, nil, nil, emptyFS)
-	require.NotNil(t, srv)
-
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/directories", nil)
-	srv.httpSrv.Handler.ServeHTTP(rec, req)
-
-	assert.NotEqual(t, http.StatusNotFound, rec.Code)
-}


### PR DESCRIPTION
## Summary

Closes the structural defect #178 identified as G1, and lands gate **G3** from the quality gateway design (#180 step 1).

`internal/api`'s handler tests built their own chi router, listing every route by hand. That copy is not the router the binary serves, so a route could be renamed, reordered, or moved behind different middleware in `internal/server` without any of those tests failing.

The two had already drifted:

```
--- only in server.go ---
POST /api/sessions/{id}/open-vscode      # missing from the base test copy;
                                         # setupRouterWithVSCode existed to patch it back in
--- only in handler_test.go ---
GET  /api/board/status                   # registered flat and with NO middleware —
GET  /api/board/messages                 # a shape that has never existed in production
POST /api/board/broadcast
GET  /api/board/command/history
```

25 board handler tests were therefore asserting against something the server does not build. And this is not a hypothetical defect class — it already shipped once: putting `/api/session-token` under `/api/board/` made it get caught by the very middleware it exists to bypass, and only a manual `curl` against the real server found it (recorded in `docs/security.md`).

## The change

**The table moves to `api.Handler.Mount`** (new `internal/api/routes.go`). Production wiring and the handler tests both go through it, so they cannot describe different routes.

**Choosing the middleware stays with `internal/server`.** `registerRoutes` passes `bearerAuthMiddleware(authToken)` as `Mount`'s `boardAuth` argument; handler tests pass `nil`. A handler test therefore no longer asserts anything about the shipped auth posture *by construction* — that assertion exists only in `internal/server`, against the router `server.New()` really builds.

**`internal/server/route_table_test.go` is the gate over the result:**

| Test | What it pins |
|---|---|
| `TestServer_RouteTable_CommandCenterDisabled` | The complete route table. Adding a route fails until the expected set is updated. |
| `TestServer_RouteTable_CommandCenterEnabled_AddsOnlyBoardCommandWS` | Enabling the command center adds exactly one route and nothing else. |
| `TestServer_EveryBoardRouteRequiresAuth` | Every `/api/board/*` route rejects a request with no token — **derived from the router via `chi.Walk`, not named by hand**, so a board route added later is covered the day it appears. |
| `TestServer_NonBoardAPIRoutesStayUnauthenticated` | The complement: **no** route outside `/api/board/` sits behind the middleware — all 24 `/api` routes, reads and writes alike. |

## How the complement test works, and why it was rewritten

The first version dispatched a real request at the real handler, so it had to restrict itself to `GET` — covering `POST /api/sessions` would have started a session, `PUT /api/layout` would have rewritten config. That restriction left **every write route unguarded by the gate**: putting bearer auth on `POST /api/sessions`, `PUT /api/layout` or `DELETE /api/workspaces/{id}` would break the frontend exactly as badly as gating the reads, and would not have failed a single test.

It now probes each route's **own middleware chain**, which `chi.Walk` hands to its callback alongside the pattern, against a sentinel handler. Running middlewares has no side effects, so the restriction is unnecessary: coverage goes from 12 GET routes to all 24. It also removes the need for a `t.Setenv("HOME", t.TempDir())` guard, since no real handler runs.

## Verification by perturbation

No gate here is assumed to work — each was confirmed to go red on real drift:

| Perturbation | Result |
|---|---|
| Rename `/api/detect-shell` → `/api/detect-shells` | `TestServer_RouteTable_CommandCenterDisabled` fails, diffing the exact route |
| Register a **reachable** `/api/board/leaked` on the root router, outside the sub-router | `TestServer_EveryBoardRouteRequiresAuth/GET_/api/board/leaked` fails, `expected: 401, actual: 200` |
| Register `/api/board/leaked` **inside** the `/api` block | Auth test **passes** — chi shadows it with the `/api/board/*` mount, so the probe's 401 still comes from the middleware. The *table* test is what fails, listing a route the router can never reach. |
| Wrap `POST /api/sessions` in a 401-returning middleware | `TestServer_NonBoardAPIRoutesStayUnauthenticated/POST_/api/sessions` fails. The earlier GET-only version passed this same perturbation. |

Rows 3 and 4 came out of adversarial review of earlier commits on this branch; both were reproduced independently before being accepted. Row 3 is why the two tests are **complementary, not redundant** — the original description of that bound was too strong, and `docs/security.md` now records the nuance. Every perturbation was reverted and `git diff` confirmed empty before continuing.

## Removed tests

Three are now strictly subsumed. Flagged explicitly so this is a reviewable call rather than a quiet deletion:

- `TestServer_DirectoriesRouteWired` — asserted `!= 404`, which is exactly "the route is registered".
- `TestServer_BoardRoutesWired_RequireAuth` — named three paths by hand; the derived auth test covers four, including the `POST`.
- `TestServer_ExistingAPIRoutes_RemainUnauthenticated` — named four paths by hand; a strict subset of the walk-derived complement test.

Everything asserting behavior beyond registration is **kept**, including `TestServer_WorkspaceRenameRouteWired` (asserts the config actually mutates) and both chi-precedence tests (`.../tab-position` vs `.../{id}`), which exhaustiveness cannot cover. `setupRouterWithGitInfo` was deleted as dead weight — it re-registered a route the base router already had.

## Coverage

Go coverage lands at **87.8%** (threshold 80%), against 87.8% on `main`. It peaked at 88.1% mid-branch and came back down when the complement test stopped executing real handlers — incidental coverage from a test that was not asserting handler behavior, which is not protection.

## Scope

No route, method, middleware or mount structure changes. The table test was written **first** and passed against the pre-refactor code unmodified — that is the evidence the move preserved the table exactly, and why the expected set is a characterization of `main`, not a new specification.

`docs/scenarios.md` gains no row: no user-facing use case changes. `docs/security.md` and `docs/architecture.md` are updated in the same change — the former named `registerRoutes` and `r.Route("/api/board", ...)` as the table's location and `board_routes_test.go` as its sole regression cover, the latter still described `internal/server` as the package that "wires chi routes". Both moved.

Code comments cite **issue #178** rather than `docs/quality-gateway.md`, since that document is not on `main` — it arrives in #179. Re-pointing them is a follow-up once that merges.

## Test plan

- [x] `make check` passes — Go coverage 87.8%, 704 frontend tests passing
- [x] `go test ./internal/api/ ./internal/server/ -race` passes; all previously-existing api tests pass unmodified against the real table
- [x] Route-table test written first and confirmed green against pre-refactor `main`, then green again after the refactor — the table is byte-identical
- [x] Perturbation 1: renaming a route fails the table test
- [x] Perturbation 2: a *reachable* board route outside the auth sub-router fails the auth test
- [x] Perturbation 3: a *shadowed* board route inside `/api` leaves the auth test passing and fails the table test
- [x] Perturbation 4: auth applied to `POST /api/sessions` fails the complement test; the GET-only version passed it
- [x] Complement test covers all 24 `/api` routes (10 GET, 6 POST, 6 PUT, 2 DELETE), verified by subtest names
- [x] `gofmt -s`, `go vet`, `golangci-lint` clean via `make lint`
- [x] `/api/sessions/{id}/open-vscode` — previously absent from the base test router — is now present in the single table and reachable in both callers
- [x] No test reads the developer's real home directory or `~/.ssh/config`

Refs #178, #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019W7x1EEtMwuX1U2LfEJUXB