### PR TITLE
test: add diff-scoped mutation testing as a warning (#180 item 6)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,101 @@
+name: mutation
+
+# Diff-scoped mutation testing: gate G4(c) in docs/quality-gateway.md, roadmap
+# item 6 of issue #180.
+#
+# Asks the one question the other three G4 gates cannot: would the tests NOTICE
+# if changed code behaved differently? A block can execute on every run and
+# still have nothing asserted about it — #180's measurement found 108 such
+# mutants in this repository, every one in code the per-block gate (G4(d))
+# correctly reports as covered.
+#
+# THIS JOB DOES NOT FAIL ON A FINDING. It is stage 3 of item 6's four, and the
+# measurement is why: 34% of those 108 survivors are ones nobody should "fix"
+# — buffer sizes and timeout constants whose killing test would be a tautology
+# itself. A job that failed on those would be wrong more often than right in
+# its first weeks, and principle 4 in docs/quality-gateway.md is that a gate
+# which cries wolf gets routed around, taking the working gates with it.
+# Stage 4 is to make it fail, once there is data saying the noise is
+# manageable; that is a separate, deliberate change.
+#
+# It DOES fail when it could not run — a missing base ref, a shallow clone, a
+# gremlins that exited non-zero, a truncated report. A warning that decided
+# nothing must not look like one that found nothing.
+#
+# Pull requests only, and not part of `make check`: it needs the base branch,
+# which the local gate has no business fetching. Same shape as efficacy.yml and
+# coverage-blocks.yml — including the absence of a `paths:` filter, since a
+# path-filtered workflow reports no status at all on the pull requests it skips.
+#
+# `labeled`/`unlabeled` are in the type list because the `mutation-exempt`
+# escape hatch is read from the event payload. Without them, applying the label
+# does not re-run this workflow, and re-running the failed job replays the
+# STORED payload — in which the label is still absent.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # Scoped to the diff against the base branch, so the merge base has
+          # to be in the clone. A shallow default checkout has no history to
+          # diff against, and the script fails rather than skipping when it
+          # cannot find it.
+          fetch-depth: 0
+
+      # The reporter's own tests, before the reporter — the ordering
+      # scenarios.yml and coverage-blocks.yml both use. They drive the script
+      # through `--report` against fixture reports, so they need only sh, git
+      # and awk and run ahead of the toolchain setup. Without this step they
+      # would reach .githooks/pre-push (rung L3) and no further: ci.yml invokes
+      # the suites directly rather than through `make test`, and its `paths:`
+      # filter does not cover `scripts/`.
+      - name: The reporter's own tests
+        run: make test-mutation
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+
+      # gremlins is not a module dependency and `make install-deps` does not
+      # install it — it is a tool this one job needs, not something a developer
+      # must have to build or test the project. Pinned to the version #180's
+      # measurement was taken with, rather than @latest, so a new release
+      # cannot change what this job reports without anyone choosing that: every
+      # number in docs/quality-gateway.md's "Surviving mutants" section came
+      # from v0.6.0.
+      - name: Install gremlins
+        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+
+      # `--timeout-coefficient` and `--workers` are pinned inside
+      # scripts/mutation.sh, and that is not tuning. With gremlins' defaults on
+      # this repository, 465 of 1059 runnable mutants (44%) come back TIMED OUT
+      # — worker contention on a shared runner, not infinite loops — and those
+      # timeouts hide survivors: internal/api alone goes from 0 reported
+      # survivors to 7 once they are gone. A job on the default configuration
+      # would report on a little over half of what it claims to measure.
+      #
+      # The escape hatch is the `mutation-exempt` label, visible on the pull
+      # request itself. The narrower hatch is `//mutation:exempt <reason>` on
+      # the line, which is preferred: it waives one mutant, in the diff a
+      # reviewer is reading, instead of the whole branch.
+      - name: Mutation (do the tests notice changed code behaving differently?)
+        env:
+          MUTATION_BASE: origin/${{ github.event.pull_request.base.ref }}
+          MUTATION_EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'mutation-exempt') && '1' || '0' }}
+        run: make mutation

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -111,6 +111,15 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 - A block that cannot be reached from a test is marked `//coverage:exempt <reason>` on its opening line or the line above. **The reason is required.** The `coverage-blocks-exempt` label exempts the whole branch and is the blunter tool; prefer the marker, which sits in the diff a reviewer reads.
 - A changed file in a package `COVERAGE_PKGS` excludes is reported as **not measured**, not as covered.
 
+### Mutation (`make mutation`)
+
+- Asks the question the other three G4 checks cannot: **would the tests notice if your changed code behaved differently?** A block can execute on every run and still have nothing asserted about it.
+- `MUTATION_BASE=origin/main make mutation` runs [gremlins](https://github.com/go-gremlins/gremlins) scoped to the diff and names every mutant on a line your branch changed that survives the whole suite.
+- **It warns; it does not fail.** A survivor prints and exits 0. Roughly a third of this repository's survivors are ones nobody should act on — buffer sizes and timeout constants whose killing test would be a tautology itself — so failing on them would make the check wrong more often than right. Decision D9 in [docs/quality-gateway.md](docs/quality-gateway.md) records the measurement behind that. It *does* exit 1 when it could not run.
+- Needs gremlins, which `make install-deps` does not install: `go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0`. `make test-mutation` — the checker's own tests, inside `make check` — never needs it, because it drives the script through `--report` against fixture reports.
+- A survivor worth keeping is marked `//mutation:exempt <reason>` on the mutated line or the line above. **The reason is required.** The `mutation-exempt` label exempts the whole branch and is the blunter tool.
+- Do not pass gremlins' own defaults: `scripts/mutation.sh` pins `--timeout-coefficient` and `--workers` because the defaults report 44% of runnable mutants as timed out on this repository, and those timeouts hide survivors.
+
 ### Red-check (`make efficacy`)
 
 - A test you change must **fail** when your implementation diff is reverted. That is the machine-checkable half of the TDD rule above: the order lines were written in cannot be recovered after the fact, but the result can.
@@ -125,9 +134,9 @@ Example: `Config.sshConfigPath` uses `sshconfig.DefaultPath()` only when the ove
 - `make check` must pass before `make build`.
 - `make check` must pass before reporting implementation complete.
 - There are no exceptions for frontend-only, docs-adjacent, or "small" code changes.
-- Test commands: `make test-go`, `make test-frontend`, `make test-e2e`, `make test`, `make test-hooks`, `make test-efficacy`, `make test-scenarios-check`, `make test-coverage-blocks`
+- Test commands: `make test-go`, `make test-frontend`, `make test-e2e`, `make test`, `make test-hooks`, `make test-efficacy`, `make test-scenarios-check`, `make test-coverage-blocks`, `make test-mutation`
 - Ledger command: `make check-scenarios`
-- Pull-request-only gates: `make efficacy` and `COVERAGE_BLOCKS_BASE=origin/main make coverage-blocks` (see above)
+- Pull-request-only gates: `make efficacy`, `COVERAGE_BLOCKS_BASE=origin/main make coverage-blocks`, and `MUTATION_BASE=origin/main make mutation` (a warning, not a gate — see above)
 - `make test-hooks` uses `jq` where it parses `settings.json` or a hook payload. `jq` is **optional**: without it those checks report themselves as skipped rather than passing or failing, so `make check` — and therefore `git push` — still works. Install it to actually run them.
 - Coverage commands: `make coverage-go`, `make coverage-frontend`, `make coverage-blocks`
 - Measurement (not a gate): `make bench` for terminal throughput, replay-buffer cost and relay polling; `make test-e2e` also records accessibility violations. Neither asserts a threshold — see [docs/quality-gateway.md](docs/quality-gateway.md)'s "First measurements".

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all build build-frontend build-backend dev clean run install-deps install-deps-ci install-hooks \
         test test-go test-frontend test-e2e test-agmsg-contract test-hooks test-efficacy efficacy \
-        test-scenarios-check check-scenarios coverage-blocks test-coverage-blocks bench \
+        test-scenarios-check check-scenarios coverage-blocks test-coverage-blocks \
+        mutation test-mutation bench \
         fmt fmt-go fmt-check-go \
         lint lint-go lint-go-deps lint-frontend \
         coverage coverage-go coverage-frontend \
@@ -34,7 +35,8 @@ install-hooks:
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
-test: test-go test-frontend test-hooks test-efficacy test-scenarios-check test-coverage-blocks
+test: test-go test-frontend test-hooks test-efficacy test-scenarios-check test-coverage-blocks \
+      test-mutation
 
 test-go:
 	go test ./... -v -race
@@ -144,6 +146,39 @@ coverage-blocks: coverage-go
 # throwaway git repositories, no `go test` run needed.
 test-coverage-blocks:
 	sh scripts/coverage_blocks_test.sh
+
+# ── Mutation: would the tests notice? (gate G4(c)) ────────────────────────────
+#
+# The last of the four G4 questions, and the one the other three cannot answer.
+# (a) asks what percentage of statements ran, (d) asks whether a block on a
+# changed line ran at all, (b) asks whether a CHANGED TEST fails without its
+# implementation. This asks whether the tests would notice changed code
+# behaving differently — and #180's measurement found 108 mutants in this
+# repository that survive every test, all of them in code (d) reports as
+# covered.
+#
+# A WARNING, not a gate: a survivor prints and exits 0. Stage 3 of item 6's
+# four. 34% of the measured survivors are ones nobody should "fix" — buffer
+# sizes and timeout constants whose killing test would be a tautology — so
+# failing on them would make this wrong more often than right, which is how a
+# gate loses the credibility the working ones depend on (principle 4). Making
+# it fail is stage 4, and a deliberate separate change.
+#
+# Needs gremlins, which `make install-deps` does not install:
+#   go install github.com/go-gremlins/gremlins/cmd/gremlins@latest
+#
+# Outside `make check` for the reason `make efficacy` and `make coverage-blocks`
+# are: it needs the base branch. It runs as its own pull-request CI job.
+#
+#   MUTATION_BASE=origin/main make mutation
+mutation:
+	sh scripts/mutation.sh
+
+# The reporter's own tests. Hermetic, and deliberately so: they drive the
+# script through `--report <file>` against fixture reports, so `make check`
+# never needs gremlins installed.
+test-mutation:
+	sh scripts/mutation_test.sh
 
 # The agent-side gates themselves (docs/quality-gateway.md's G1 and G2, run as
 # Claude Code hooks from .claude/). Included in `make test` because a hook that

--- a/docs/quality-gateway.md
+++ b/docs/quality-gateway.md
@@ -168,7 +168,7 @@ Ordering is meaningful: the point is to stop a defect at the cheapest gate that 
 | **G1** | Edit | Maintainability | `gofmt -s`, `tsc --noEmit`, and `go vet` on the touched packages only | Claude Code `PostToolUse` hook in `.claude/settings.json` | Present — `.claude/hooks/post-edit-check.sh` |
 | **G2** | Unit | Functional suitability, fast feedback | `make test-go`, `make test-frontend` — unchanged | Existing (`make check`, pre-push, CI) | Present |
 | **G3** | Contract | **Resistance to refactoring**, compatibility | (a) HTTP/WS integration through the real `server.New()` router; (b) exhaustiveness check on the route table (every registered route against an expected set); (c) Zod schema round-trips; (d) the agmsg contract | New `make test-contract`, folded into `make check`; (b) as an always-on Go test | Partial — (b) and (d) present; (a) present for HTTP (`internal/server/api_integration_test.go` drives every `/api` route and fails when one has no case), absent for `/ws`; (c) absent |
-| **G4** | Efficacy | **Protection against regressions** | (a) coverage — scope tracks the implementation, threshold stays at 80%; (b) **red-check**: a changed test must fail when the implementation diff is reverted; (c) mutation score over changed lines only; (d) **per-block coverage**: no block covering a changed line may be one the suite never entered | (a) existing `make check`; (b), (c) and (d) pull-request CI jobs, `make efficacy` and `make coverage-blocks` | Partial — (a) present and now scoped to every decision-holding package; (b) present (`make efficacy`, a pull-request-only CI job); (d) present (`make coverage-blocks`, likewise); (c) absent |
+| **G4** | Efficacy | **Protection against regressions** | (a) coverage — scope tracks the implementation, threshold stays at 80%; (b) **red-check**: a changed test must fail when the implementation diff is reverted; (c) mutation score over changed lines only; (d) **per-block coverage**: no block covering a changed line may be one the suite never entered | (a) existing `make check`; (b), (c) and (d) pull-request CI jobs, `make efficacy`, `make mutation` and `make coverage-blocks` | Partial — (a) present and now scoped to every decision-holding package; (b) present (`make efficacy`, a pull-request-only CI job); (d) present (`make coverage-blocks`, likewise); (c) present as a **warning** (`make mutation`), not yet as a gate |
 | **G5** | Scenario | Functional suitability, interaction capability | Playwright E2E, plus a check that every test named by an `auto` row in `scenarios.md` actually exists | CI, extending `make test-e2e` | Present — E2E plus `make check-scenarios`, which resolves every `auto` row |
 | **G6** | Adversarial | All characteristics (design judgement) | A fresh-context review of the diff alone. The session that wrote the code does not grade it. Findings limited to correctness and stated requirements. | A review subagent in `.claude/agents/` plus human review. **Does not block** | Present — `.claude/agents/diff-reviewer.md`; still does not block |
 
@@ -201,6 +201,13 @@ lower bound, so it stays used as one. The correct strengthening is **scope, not 
 gremlins' own documentation states it suits small-to-medium modules and that a run on a large one can
 take hours. Chasing a whole-repository MSI would make the gate unaffordable and therefore ignored.
 Scoring only changed lines, outside `make check`, keeps the gate starting from green.
+
+*Amended once measured.* The cost premise was weaker than it looked: the whole module takes **14m25s**
+here, not hours, and `gremlins --diff` brings a typical branch to seconds. The conclusion stands on
+the other half — 108 surviving mutants repo-wide means a whole-repository gate starts red — so the
+governing reason is now the false-positive rate, not the clock. Recorded rather than quietly
+rewritten, because the two reasons fail differently: a cost argument would be reopened by a faster
+tool, and this one would not.
 
 **D3 — Consolidate gates rather than adding them.**
 As #178 showed, a structure where every new feature adds another `*_routes_test.go` is a tax, not a
@@ -341,6 +348,29 @@ reported as *not measured* rather than as covered — failing there would start 
 `internal/session`. The ~275 remain a backlog, listed by `make coverage-blocks`; a gate is the wrong
 instrument for a backlog.
 
+**D9 — The mutation check warns; it does not fail.**
+Stage 3 of #180's item 6, and the measurement is the argument. Of the 108 surviving mutants found at
+`d42e406`, **37 (34%) are ones nobody should act on**: buffer sizes (`64*1024` in three files),
+timeout constants (`30 * time.Second`), and error branches unreachable without fault injection. A
+test written to kill the buffer-size mutants would pin a constant and assert nothing — a tautology,
+which is the exact defect G4 exists to find. A check that failed on those would be wrong more often
+than right in its first weeks, and principle 4 says what happens to a gate that cries wolf.
+
+So `make mutation` prints its findings and exits 0. What it does **not** soften is "could not run":
+a missing base ref, a shallow clone, a gremlins that exited non-zero or a truncated report all exit 1,
+because a check that decided nothing must never look like one that found nothing. Making the findings
+themselves fail is stage 4, and deliberately a separate change with its own evidence — there is no
+environment variable to flip it early, since an unused switch is an invitation to enable it without
+the data that should decide it.
+
+**Its settings are pinned, and that is not tuning.** With gremlins' defaults on this repository, 465
+of 1059 runnable mutants (44%) come back `TIMED OUT`. They are not infinite loops — they are worker
+contention — and they *hide survivors*: `internal/api` alone reports 0 survivors with the defaults and
+7 without them, and the module-wide count goes from 57 to 108. Note what does *not* move: efficacy
+reads 90.40% before and 89.74% after. A percentage that barely shifts while the absolute count doubles
+is how this would have gone unnoticed, and it is why `--timeout-coefficient` and `--workers` are set
+in `scripts/mutation.sh` rather than left to the tool.
+
 ### Rollout order
 
 | Order | Work | Gate | #178 phase | Effect |
@@ -350,9 +380,44 @@ instrument for a backlog.
 | 3 | `.claude/settings.json` with G1/G2 hooks; a review subagent | G1, G6 | — | **Landed.** A `PostToolUse` hook checks the edited file, a `Stop` hook checks what the turn changed, and `.claude/agents/diff-reviewer.md` reviews a diff in a fresh context. `make test-hooks` tests the hooks themselves. |
 | 4 | red-check (`make efficacy`) in pull-request CI | G4(b) | — | **Landed.** `scripts/efficacy.sh` reverts the branch's implementation diff in a scratch worktree and requires each test the branch changed — Go function or vitest case — to pass at HEAD and then go red against the revert, one at a time. Exempted by the `efficacy-exempt` label. |
 | 5 | Core-feature section in `scenarios.md`, ledger cross-check, core E2E | G0, G5 | Phases 4 and 6 | **Landed.** Sections H (core multiplexer) and I (opening URLs from a pane, #177's missing rows) added; `make check-scenarios` resolves every `auto` row; `frontend/e2e/core-multiplexer.spec.ts` covers split, resize, layout restore and workspace CRUD. |
-| 6 | Diff-scoped mutation testing (warn first, gate once stable) | G4(c) | merges with #164 | Measures protection against regressions directly. |
+| 6 | Diff-scoped mutation testing (warn first, gate once stable) | G4(c) | merges with #164 | **Warning landed.** `scripts/mutation.sh` runs gremlins scoped to the diff and names every mutant on a changed line that survives every test. Exits 0 on a finding — see D9. Making it fail is the remaining step. |
 | 7 | Performance and accessibility observation (measure only, do not gate) | — | — | **Landed.** `make bench` measures terminal throughput, replay-buffer cost and the relay's polling cost; `a11y.spec.ts` records axe violations. Both report; neither asserts. |
-| 8 | Per-block coverage on changed lines (#164, not a #180 item) | G4(d) | — | **Landed.** `scripts/coverage_blocks.sh` fails when a block covering a changed line never executed. Row 6 waits on it. |
+| 8 | Per-block coverage on changed lines (#164, not a #180 item) | G4(d) | — | **Landed.** `scripts/coverage_blocks.sh` fails when a block covering a changed line never executed. It unblocked row 6's measurement, which is what row 6 was waiting on. |
+
+## Surviving mutants: the first measurement
+
+Roadmap item 6's second stage asks whether tautologies survive per-block coverage. They do. The run
+below is at `d42e406`, whole module, `gremlins v0.6.0 unleash --timeout-coefficient 10 --workers 2`,
+14m25s.
+
+| | Count |
+|---|---|
+| Killed | 945 |
+| **Lived** | **108** |
+| Not covered | 172 |
+| Timed out | 6 |
+| Test efficacy | 89.74% |
+
+Every survivor is in code the per-block gate reports as covered, by construction: gremlins only
+mutates covered code. The two gates are not redundant.
+
+| Survivor | Count | What it is |
+|---|---|---|
+| Boundary value | 45 | Already required by DEVELOPMENT.md's "Test granularity" |
+| Other logic | 26 | Case by case |
+| Error branch | 25 | Needs fault injection to reach |
+| Tuning constant | 12 | Killing it would pin a constant and assert nothing |
+
+**The worked example, because it is the clearest statement of what G4(c) is for.** `port > 65535`
+appears in `internal/config/validate.go`, `internal/api/handler.go` and `internal/session/loopback.go`.
+Changing it to `>= 65535` makes all three reject port 65535 — a legal port — and every test still
+passes, in all three packages. The cause is identical in each: the tests use `65536`, one past the
+boundary, and never `65535`, the boundary itself. `make coverage-blocks` lists none of those lines,
+and is right not to: the blocks execute. What is missing is not execution but an assertion.
+
+That the same blind spot appears three times, in three packages, written at three different times, is
+the part worth keeping. It is not an oversight in one test; it is a habit the existing gates cannot
+see.
 
 ### Relationship to issue #164
 
@@ -371,9 +436,11 @@ shared `-coverpkg` list emits each block once per test binary. Neither alternati
 moved: [golang/go#70306](https://github.com/golang/go/issues/70306) is still an undecided proposal
 and gobco still instruments one package at a time. This remains block coverage, not C1.
 
-It closes item 6's first stage, not item 6. That item's completion condition — regression protection
+It closed item 6's first stage, not item 6. That item's completion condition — regression protection
 measured by whether the tests would *notice a change* — is untouched by a gate that reports whether a
-block *ran*. The next step it unblocks is the measurement, not a mutation implementation.
+block *ran*. The step it unblocked was the measurement, which has now been taken: 108 mutants survive
+in code this gate reports as covered (see "Surviving mutants" above). The two are complementary, and
+the measurement is what sized G4(c)'s first shape.
 
 ## First measurements
 

--- a/scripts/mutation.sh
+++ b/scripts/mutation.sh
@@ -1,0 +1,442 @@
+#!/bin/sh
+#
+# Diff-scoped mutation testing: gate G4(c) in docs/quality-gateway.md, roadmap
+# item 6 of issue #180.
+#
+# The other three G4 gates each answer a different question, and this one
+# answers the last of them:
+#
+#   (a) make coverage-go      — what percentage of statements ran?
+#   (b) make efficacy         — does a test this branch CHANGED fail when this
+#                               branch's implementation is reverted?
+#   (d) make coverage-blocks  — did every block on a changed line run at all?
+#   (c) THIS                  — would the tests NOTICE if changed code behaved
+#                               differently?
+#
+# (d) and (c) are the pair that look alike and are not. A block can execute on
+# every test run and still have nothing asserted about it. #180's measurement
+# ran gremlins over the whole module at d42e406 and found 108 such mutants —
+# every one of them in code the per-block gate reports as covered, because
+# gremlins only ever mutates covered code.
+#
+# The worked example, because it is the clearest statement of what this gate is
+# for: `port > 65535` appears in internal/config/validate.go, internal/api/
+# handler.go and internal/session/loopback.go. Changing it to `>= 65535` makes
+# all three reject port 65535, which is a legal port. Every test still passes.
+# The cause is the same in all three places — the tests use 65536, one past the
+# boundary, and never 65535, the boundary itself. `make coverage-blocks` lists
+# none of those lines, correctly: the blocks execute.
+#
+# THIS IS A WARNING, NOT A GATE — stage 3 of item 6's four, and the exit code
+# says so: a surviving mutant prints and exits 0. That is not timidity, it is
+# what the measurement showed. Of those 108 survivors, 37 (34%) are ones nobody
+# should "fix": buffer sizes (`64*1024`), timeout constants (`30*time.Second`),
+# and error branches unreachable without fault injection. A test that killed the
+# buffer-size mutants would pin a constant and assert nothing — a tautology, the
+# exact thing G4 exists to catch. Failing on those would make this gate wrong
+# more often than right in its first weeks, and principle 4 in
+# docs/quality-gateway.md is that a gate which cries wolf gets routed around,
+# taking the gates that do work with it. Item 6's stage 4 is to make it fail,
+# once there is data saying the noise is manageable. That is a separate,
+# deliberate change; there is no environment variable here to flip early.
+#
+# "COULD NOT RUN" IS STILL A FAILURE, and that half is not softened. A warning
+# that could not run must not look like a warning that found nothing, which is
+# the rule scripts/efficacy.sh and scripts/coverage_blocks.sh both state.
+#
+# Usage:
+#   make mutation                                # report against origin/main
+#   MUTATION_BASE=origin/develop make mutation
+#   sh scripts/mutation.sh --base origin/main --report gremlins.json
+#   MUTATION_EXEMPT=1 make mutation              # branch-wide, from the CI label
+#
+# `--report <file>` reads an existing gremlins `--output` report instead of
+# running gremlins. scripts/mutation_test.sh drives every case through it, so
+# the suite is hermetic and needs no gremlins install — the same split
+# scripts/coverage_blocks.sh has with `--profile`.
+#
+# SCOPED TO THE DIFF, for the reason decision D2 gave and one the measurement
+# added. D2 scoped it because gremlins' own documentation warns of hours on a
+# large module; measured on this repository the whole module takes 14m25s, so
+# that reason is weaker than it looked. The reason that survives is the false
+# positive rate: 108 survivors repo-wide means a gate over all of them starts
+# red on day one. `gremlins --diff` also makes the run take seconds rather than
+# minutes, which is a welcome side effect rather than the argument.
+#
+# PINNED GREMLINS SETTINGS, and this is not tuning. Run with defaults on this
+# repository, gremlins reports 465 of 1059 runnable mutants (44%) as TIMED OUT.
+# They are not infinite loops — they are worker contention on a shared runner.
+# Re-run with these settings, internal/api's 114 timeouts become 0 and reveal 7
+# survivors the default run had hidden; module-wide the survivor count goes from
+# 57 to 108. A gate built on the default configuration would report on a little
+# over half of what it claims to measure.
+#
+# Escape hatches, narrow before broad, matching //coverage:exempt:
+#   //mutation:exempt <reason>   on the mutated line, or the line directly
+#                                above it. A reason is required — a bare marker
+#                                exempts nothing.
+#   MUTATION_EXEMPT=1            the whole branch, from the CI label.
+#
+# Exit codes: 0 = ran (whether or not survivors were found); 1 = could not run.
+
+set -u
+
+base=${MUTATION_BASE:-}
+report=""
+gremlins_bin=${GREMLINS:-gremlins}
+# Both pinned above; overridable so a future measurement can move them without
+# editing the script, but never defaulted to gremlins' own values.
+timeout_coefficient=${MUTATION_TIMEOUT_COEFFICIENT:-10}
+workers=${MUTATION_WORKERS:-2}
+
+while [ $# -gt 0 ]; do
+	case $1 in
+	--base)
+		[ $# -ge 2 ] || {
+			echo "mutation: --base needs a ref"
+			exit 1
+		}
+		base=$2
+		shift 2
+		;;
+	--report)
+		[ $# -ge 2 ] || {
+			echo "mutation: --report needs a file"
+			exit 1
+		}
+		report=$2
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,80p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
+		exit 0
+		;;
+	*)
+		echo "mutation: unknown argument '$1'"
+		exit 1
+		;;
+	esac
+done
+
+repo_root=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+
+if [ -z "$base" ]; then
+	echo "mutation: ERROR — no base ref."
+	echo "  This check is scoped to the diff, so it cannot run without one:"
+	echo "    MUTATION_BASE=origin/main make mutation"
+	exit 1
+fi
+
+if ! git rev-parse --verify --quiet "$base" > /dev/null 2>&1; then
+	echo "mutation: ERROR — base ref '$base' does not exist."
+	echo "  Without it there is no diff to scope this to, so it cannot run."
+	echo "  In CI this usually means the checkout lost 'fetch-depth: 0'."
+	exit 1
+fi
+
+# Checked, not assumed — the fail-open #188 found in the same family. A failing
+# `git merge-base` prints nothing, the empty ref makes the diff below error out
+# and name no files, and the run lands in "no Go implementation changed" and
+# exits 0 having decided nothing. `rev-parse --verify` above does not cover it:
+# in a clone whose history does not reach the merge base the ref resolves fine
+# and only this command fails.
+merge_base=$(git merge-base "$base" HEAD 2> /dev/null) || merge_base=""
+if [ -z "$merge_base" ]; then
+	echo "mutation: ERROR — no merge base between '$base' and HEAD."
+	echo "  Without it there is no diff to scope this to, so it cannot run."
+	echo "  In CI this usually means the checkout lost 'fetch-depth: 0'."
+	exit 1
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+tab=$(printf '\t')
+
+# The changed Go implementation files. _test.go is excluded on purpose: mutating
+# a test asks whether the tests test the tests, and what judges a changed test
+# is the red-check (G4(b)), which reverts the implementation under it. This gate
+# judges changed implementation.
+changed=""
+for f in $(git -C "$repo_root" diff --name-only "$merge_base" HEAD); do
+	case $f in
+	*_test.go) ;;
+	*.go) changed="$changed $f" ;;
+	esac
+done
+
+if [ -z "$changed" ]; then
+	echo "mutation: no Go implementation changed against $base — nothing to check."
+	exit 0
+fi
+
+# ── The gremlins run ──────────────────────────────────────────────────────────
+
+if [ -z "$report" ]; then
+	if ! command -v "$gremlins_bin" > /dev/null 2>&1; then
+		echo "mutation: ERROR — '$gremlins_bin' not found on PATH."
+		echo "  Install it, or pass a report from an earlier run:"
+		echo "    go install github.com/go-gremlins/gremlins/cmd/gremlins@latest"
+		echo "    sh scripts/mutation.sh --base $base --report gremlins.json"
+		exit 1
+	fi
+	report="$tmp/gremlins.json"
+	# --diff takes the merge base rather than the base ref itself, so a base
+	# branch that has moved ahead does not drag its own commits into this
+	# branch's scope.
+	if ! (cd "$repo_root" && "$gremlins_bin" unleash \
+		--diff "$merge_base" \
+		--timeout-coefficient "$timeout_coefficient" \
+		--workers "$workers" \
+		--output "$report" \
+		. > "$tmp/gremlins.log" 2>&1); then
+		echo "mutation: ERROR — gremlins exited non-zero."
+		sed 's/^/  /' "$tmp/gremlins.log" | tail -20
+		exit 1
+	fi
+fi
+
+case $report in
+/*) report_path=$report ;;
+*) report_path=$PWD/$report ;;
+esac
+
+if [ ! -f "$report_path" ]; then
+	echo "mutation: ERROR — no gremlins report at '$report'."
+	echo "  A report is how this check knows what ran; without one it would"
+	echo "  report no survivors having analysed nothing."
+	exit 1
+fi
+
+# ── Reading the report ────────────────────────────────────────────────────────
+#
+# The report is JSON, and this is a POSIX shell script, so the parse is a
+# deliberately small one: it walks the file recording the current file_name and
+# emitting one line per mutation. It does NOT tolerate a shape it does not
+# recognise — an empty or truncated report is what a killed gremlins run leaves
+# behind, and "no files key" must never read as "no survivors".
+module=""
+if [ -f "$repo_root/go.mod" ]; then
+	module=$(awk '$1 == "module" { print $2; exit }' "$repo_root/go.mod")
+fi
+
+# The shape check. `files` is the one key every gremlins report has, including
+# one that analysed nothing (`"files":[]`), so its absence means the file is not
+# a gremlins report at all — truncated, empty, or something else entirely.
+if ! grep -q '"files"' "$report_path"; then
+	echo "mutation: ERROR — '$report' is not a gremlins report."
+	echo "  It has no \"files\" key, which is what a truncated or empty report"
+	echo "  looks like. Reading it as 'no survivors' would state a result"
+	echo "  nothing measured."
+	exit 1
+fi
+
+# One mutation per line, as file<TAB>line<TAB>status<TAB>type. Braces become
+# record separators so each mutation object is read whole — pairing a status
+# with the type and line from its OWN record rather than reading ahead into the
+# next one.
+awk -v OFS="$tab" '
+	{
+		s = $0
+		gsub(/[{}]/, "\n", s)
+		n = split(s, recs, "\n")
+		for (i = 1; i <= n; i++) {
+			r = recs[i]
+			if (index(r, "file_name") > 0) {
+				if (match(r, /"file_name"[ \t]*:[ \t]*"[^"]*"/)) {
+					seg = substr(r, RSTART, RLENGTH)
+					if (match(seg, /:[ \t]*"[^"]*"$/)) {
+						cur = substr(seg, RSTART + 1, RLENGTH - 1)
+						gsub(/^[ \t]*"|"$/, "", cur)
+					}
+				}
+			}
+			if (index(r, "\"status\"") == 0) continue
+			ty = ""; st = ""; ln = ""
+			if (match(r, /"type"[ \t]*:[ \t]*"[^"]*"/)) {
+				seg = substr(r, RSTART, RLENGTH); sub(/^"type"[ \t]*:[ \t]*"/, "", seg); sub(/"$/, "", seg); ty = seg
+			}
+			if (match(r, /"status"[ \t]*:[ \t]*"[^"]*"/)) {
+				seg = substr(r, RSTART, RLENGTH); sub(/^"status"[ \t]*:[ \t]*"/, "", seg); sub(/"$/, "", seg); st = seg
+			}
+			if (match(r, /"line"[ \t]*:[ \t]*[0-9]+/)) {
+				seg = substr(r, RSTART, RLENGTH); sub(/^"line"[ \t]*:[ \t]*/, "", seg); ln = seg
+			}
+			if (cur != "" && ln != "" && st != "") print cur, ln, st, ty
+		}
+	}
+' "$report_path" > "$tmp/mutations"
+
+# ── Scoping to the diff ───────────────────────────────────────────────────────
+
+# touched_lines <file> — the line numbers this branch added or modified, against
+# the file as it stands now. -U0 keeps the hunk headers exact so no untouched
+# neighbour is swept in.
+#
+# `-C "$repo_root"` is load-bearing. `git diff --name-only` prints
+# repository-relative paths wherever it runs, but a pathspec after `--` resolves
+# against the caller's cwd — so from a subdirectory every pathspec would miss,
+# every touched-line set would come back empty, and this would report nothing
+# having analysed nothing. #188 found exactly that bug in the per-block gate.
+touched_lines() {
+	git -C "$repo_root" diff -U0 "$merge_base" HEAD -- "$1" |
+		awk '
+			/^@@/ {
+				plus = $3
+				sub(/^\+/, "", plus)
+				n = split(plus, parts, ",")
+				start = parts[1] + 0
+				count = (n > 1) ? parts[2] + 0 : 1
+				for (i = 0; i < count; i++) print start + i
+			}
+		'
+}
+
+: > "$tmp/findings"
+: > "$tmp/exempt"
+: > "$tmp/unanalysed"
+bare_marker=0
+
+for f in $changed; do
+	touched_lines "$f" | sort -un > "$tmp/touched"
+	[ -s "$tmp/touched" ] || continue
+
+	# Both spellings of the path. gremlins reports repository-relative paths;
+	# `<module>/<path>` is what coverage.out uses, and accepting it costs one
+	# comparison. Guessing wrong would leave every finding unmatched, which is
+	# this check reporting green.
+	# Tab-separated on the way out as well as in. gremlins' statuses include
+	# "NOT COVERED", which has a space in it: with awk's default OFS the reader
+	# below would split it into status="NOT" and fold "COVERED" into the type.
+	# Today that lands in the same branch either way, so nothing visibly breaks
+	# — which is precisely why it would have survived until a status this gate
+	# does act on gained a space.
+	MOD="$module" FILE="$f" awk -F"$tab" -v OFS="$tab" '
+		BEGIN { mod = ENVIRON["MOD"]; file = ENVIRON["FILE"]; alt = (mod == "") ? "" : mod "/" file }
+		$1 == file || (alt != "" && $1 == alt) { print $2, $3, $4 }
+	' "$tmp/mutations" > "$tmp/file_mutations"
+	[ -s "$tmp/file_mutations" ] || continue
+
+	while IFS="$tab" read -r line status type; do
+		[ -n "$line" ] || continue
+		grep -qx -- "$line" "$tmp/touched" || continue
+
+		case $status in
+		LIVED) ;;
+		SKIPPED)
+			# gremlins decided this mutant was outside its own notion of the
+			# diff, but it is on a line this branch changed. Nothing ran it,
+			# so nothing can be claimed about it.
+			printf '%s%s%s%s%s\n' "$f" "$tab" "$line" "$tab" "$type" >> "$tmp/unanalysed"
+			continue
+			;;
+		*)
+			# KILLED is the good case. NOT COVERED belongs to G4(d), which
+			# fails on it with a clearer message; reporting it here too would
+			# have two gates arguing about one defect.
+			continue
+			;;
+		esac
+
+		marker=$(sed -n "${line}p" "$repo_root/$f" 2> /dev/null)
+		above=""
+		if [ "$line" -gt 1 ]; then
+			above=$(sed -n "$((line - 1))p" "$repo_root/$f" 2> /dev/null)
+		fi
+		# The window is the mutated line, plus the line above ONLY when that
+		# line is a comment. #188's own marker had this bug: reading the two
+		# lines as one string let a marker on one construct's opening line
+		# waive the construct on the next, with no reason ever written for it.
+		window=$marker
+		case $above in
+		*//mutation:exempt*)
+			case $above in
+			*[!\ ]*)
+				trimmed=$(printf '%s' "$above" | sed 's/^[[:space:]]*//')
+				case $trimmed in
+				//*) window="$marker
+$above" ;;
+				esac
+				;;
+			esac
+			;;
+		esac
+
+		case $window in
+		*//mutation:exempt*)
+			# A reason is required. An exemption nobody has to justify is how
+			# an exemption stops being reviewable — the rule //coverage:exempt
+			# states and this one inherits.
+			if printf '%s\n' "$window" | grep -Eq '//mutation:exempt[[:space:]]+[^[:space:]]'; then
+				printf '%s%s%s%s%s\n' "$f" "$tab" "$line" "$tab" "$type" >> "$tmp/exempt"
+			else
+				bare_marker=1
+				printf '%s%s%s%s%s\n' "$f" "$tab" "$line" "$tab" "$type" >> "$tmp/findings"
+			fi
+			;;
+		*)
+			printf '%s%s%s%s%s\n' "$f" "$tab" "$line" "$tab" "$type" >> "$tmp/findings"
+			;;
+		esac
+	done < "$tmp/file_mutations"
+done
+
+kept_count=$(wc -l < "$tmp/findings" | tr -d ' ')
+exempt_count=$(wc -l < "$tmp/exempt" | tr -d ' ')
+unanalysed_count=$(wc -l < "$tmp/unanalysed" | tr -d ' ')
+
+exempt_note=""
+[ "$exempt_count" -gt 0 ] && exempt_note=" ($exempt_count exempt)"
+
+# Listed, not counted. A count says an exemption happened; only the list says
+# WHICH, and an exemption a reviewer cannot see is one nobody reviewed. #188
+# changed its own gate from counting to listing for this reason.
+exempt_list() {
+	[ -s "$tmp/exempt" ] || return 0
+	echo
+	echo "  Exempt by //mutation:exempt:"
+	awk -F"$tab" '{ printf "    %s:%s  %s\n", $1, $2, $3 }' "$tmp/exempt"
+}
+
+unanalysed_list() {
+	[ -s "$tmp/unanalysed" ] || return 0
+	echo
+	echo "  Not analysed — gremlins skipped these mutants although they sit on"
+	echo "  lines this branch changed, so nothing is known about them:"
+	awk -F"$tab" '{ printf "    %s:%s  %s\n", $1, $2, $3 }' "$tmp/unanalysed"
+}
+
+if [ "${MUTATION_EXEMPT:-0}" = "1" ]; then
+	echo "mutation: exempt — MUTATION_EXEMPT=1 waived $kept_count finding(s)$exempt_note."
+	exempt_list
+	unanalysed_list
+	exit 0
+fi
+
+if [ "$kept_count" -eq 0 ]; then
+	echo "mutation: no surviving mutants on lines this branch changed$exempt_note."
+	exempt_list
+	unanalysed_list
+	exit 0
+fi
+
+echo "mutation: $kept_count surviving mutant(s) on lines this branch changed$exempt_note."
+echo
+echo "  A surviving mutant is a change to your code that every test still"
+echo "  passes through. Either an assertion is missing, or the mutant is one"
+echo "  of the kinds worth waiving — a tuning constant, or a branch that needs"
+echo "  fault injection to reach."
+echo
+awk -F"$tab" '{ printf "    %s:%s  %s\n", $1, $2, $3 }' "$tmp/findings"
+exempt_list
+unanalysed_list
+
+if [ "$bare_marker" -eq 1 ]; then
+	echo
+	echo "  Note: a //mutation:exempt with no reason after it exempts nothing."
+fi
+
+echo
+echo "  This is a warning: it does not fail the build. Add the assertion, or"
+echo "  waive it with '//mutation:exempt <reason>' on the line or above it."
+exit 0

--- a/scripts/mutation_test.sh
+++ b/scripts/mutation_test.sh
@@ -1,0 +1,616 @@
+#!/bin/sh
+#
+# Tests for scripts/mutation.sh.
+#
+# The suite never runs gremlins. That is deliberate, not a shortcut: `make test`
+# runs this, `make check` runs `make test`, and `.githooks/pre-push` runs
+# `make check` — so a suite that needed a tool `make install-deps` does not
+# install would block every push on every machine that lacks it. scripts/
+# mutation.sh takes `--report <file>` for exactly this reason, the way
+# scripts/coverage_blocks.sh takes `--profile`: the half that runs the external
+# tool and the half that decides what the results MEAN are separable, and only
+# the second half holds the logic worth testing.
+#
+# Three properties carry this gate, and each is a way it could report green
+# having decided nothing:
+#
+#   1. Scoping to the diff. Only survivors on lines this branch changed are
+#      reported. The repository has 108 surviving mutants today (issue #180's
+#      measurement); a gate that named all of them would start red, and
+#      docs/quality-gateway.md principle 4 says what happens next.
+#   2. Reporting what gremlins SKIPPED on a changed line. `--diff` decides for
+#      itself which mutants to run, and if its notion of "changed" is narrower
+#      than the gate's, the survivors it never ran would be invisible — the
+#      gate would print "no survivors" about lines nothing analysed. A skipped
+#      mutant on a changed line is reported as unanalysed, not as passing.
+#   3. Warning, not failing, on a survivor. Roadmap item 6 of #180 says stage 3
+#      starts as a warning, and the measurement says why: 34% of this
+#      repository's survivors are ones nobody should "fix" — buffer sizes and
+#      timeout constants whose killing test would be a tautology itself.
+#      "Could not run" is still a failure, because a check that decided nothing
+#      must never look like one that passed.
+#
+# Run with: make test-mutation
+
+set -u
+
+# The two variables DEVELOPMENT.md tells developers to set are exactly the two
+# that would silently rewrite what this suite is testing — a base ref makes the
+# no-base cases run the gate instead, and the branch-wide exemption makes every
+# survivor case pass. scripts/coverage_blocks_test.sh unsets the same pair for
+# the same reason.
+unset MUTATION_BASE MUTATION_EXEMPT
+
+scripts_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+checker="$scripts_dir/mutation.sh"
+
+failures=0
+checks=0
+
+fail() {
+	failures=$((failures + 1))
+	echo "FAIL: $1"
+	[ -n "${2:-}" ] && printf '%s\n' "$2" | sed 's/^/      /'
+	return 0
+}
+pass() { echo "ok   $1"; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# new_repo — an empty git repository with a go.mod and one commit on `main`, so
+# there is always a base ref to diff against. Prints its path.
+#
+# `mktemp -d`, not a counter: this runs in a command substitution, so a counter
+# would be incremented in a subshell and never seen by the caller.
+new_repo() {
+	repo=$(mktemp -d "$work/repoXXXXXX")
+	mkdir -p "$repo/pkg"
+	(
+		cd "$repo" || exit 1
+		git init -q -b main .
+		git config user.email dev@example.com
+		git config user.name dev
+		git config commit.gpgsign false
+		printf 'module example\n\ngo 1.25\n' > go.mod
+		git add go.mod
+		git commit -qm base
+		# The gate diffs HEAD against a base ref. Committing onto `main`
+		# itself would make the merge base equal HEAD, and every case would
+		# pass for the wrong reason — "nothing changed" rather than "nothing
+		# survived".
+		git checkout -qb feature
+	) || return 1
+	printf '%s\n' "$repo"
+}
+
+# commit_on_main <repo> <message> — commit pkg/ onto `main` and re-branch, so
+# those files are part of the base rather than of the branch under test.
+# Without this, a file meant to be pre-existing is added BY the branch, every
+# line of it counts as changed, and a case meant to prove the gate ignores
+# untouched code proves nothing.
+commit_on_main() {
+	(
+		cd "$1" || exit 1
+		git checkout -q main
+		git add -A pkg
+		git commit -qm "$2"
+		git branch -f feature main
+		git checkout -q feature
+	) > /dev/null 2>&1
+}
+
+commit_on_branch() {
+	(
+		cd "$1" || exit 1
+		git add -A
+		git commit -qm "$2"
+	) > /dev/null 2>&1
+}
+
+# report <file> <json-body> — write a gremlins --output report.
+write_report() {
+	printf '%s\n' "$2" > "$1"
+}
+
+run_checker() {
+	rc_repo=$1
+	shift
+	(cd "$rc_repo" && sh "$checker" "$@" 2>&1)
+}
+
+# findings_only <output> — the part of the report before the exempt list.
+# An exempt survivor is still PRINTED, under "Exempt by", so grepping the whole
+# output for its line number cannot tell "not reported as a finding" from
+# "reported". The section boundary is what carries that distinction.
+findings_only() {
+	printf '%s\n' "$1" | sed -n '1,/Exempt by/p' | sed '$d'
+}
+
+# ── 1. Diff scoping ───────────────────────────────────────────────────────────
+
+# The survivor that must NOT be reported sits in the SAME file as the one that
+# must — on a line the branch did not touch. A separate untouched file would
+# only exercise the file-level filter, which is a different mechanism: dropping
+# the line-level check entirely would still pass such a case, since an untouched
+# file never enters the loop at all. Confirmed by perturbation.
+checks=$((checks + 1))
+repo=$(new_repo)
+cat > "$repo/pkg/mixed.go" <<'EOF'
+package pkg
+
+func Old(n int) bool {
+	if n > 3 {
+		return true
+	}
+	return false
+}
+EOF
+commit_on_main "$repo" "pre-existing"
+cat > "$repo/pkg/mixed.go" <<'EOF'
+package pkg
+
+func Old(n int) bool {
+	if n > 3 {
+		return true
+	}
+	return false
+}
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/mixed.go","mutations":[
+   {"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5},
+   {"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":11,"column":5}]}]}'
+commit_on_branch "$repo" "append New to mixed.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+	fail "a survivor on a changed line warns rather than failing" "exit $rc: $out"
+elif ! printf '%s' "$out" | grep -q 'pkg/mixed.go:11'; then
+	fail "a survivor on a changed line is reported" "$out"
+elif printf '%s' "$out" | grep -q 'pkg/mixed.go:4'; then
+	fail "a survivor on an UNCHANGED line of a CHANGED file is not reported" "$out"
+elif ! printf '%s' "$out" | grep -q '1 surviving mutant'; then
+	fail "exactly one of the two survivors is reported" "$out"
+else
+	pass "reports survivors on changed lines only, and warns rather than failing"
+fi
+
+# ── 2. A skipped mutant on a changed line is reported as unanalysed ───────────
+#
+# The fail-open this closes: `gremlins --diff` decides for itself what changed.
+# If its answer is narrower than the gate's, the mutants it skipped were never
+# run, and counting them as "no survivor" states a result nothing measured.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"SKIPPED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -qi 'not analysed\|not analyzed'; then
+	fail "a SKIPPED mutant on a changed line is reported as unanalysed" "$out"
+else
+	pass "a SKIPPED mutant on a changed line is reported as unanalysed"
+fi
+
+# ── 3. NOT COVERED is left to the per-block gate, not double-reported ─────────
+#
+# G4(d) (scripts/coverage_blocks.sh) already fails on a block on a changed line
+# that never executed. Reporting the same line again here would make two gates
+# argue about one defect, and the one with the clearer message is the other one.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"NOT COVERED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+# Asserting the clean message as well as the absence: a bare "does not contain
+# 'survivor'" would also hold for a script that failed to run at all.
+if ! printf '%s' "$out" | grep -q 'no surviving'; then
+	fail "a NOT COVERED mutant leaves the gate reporting a clean branch" "$out"
+elif printf '%s' "$out" | grep -q 'pkg/new.go:4'; then
+	fail "NOT COVERED is not reported as a survivor" "$out"
+else
+	pass "NOT COVERED is left to the per-block gate"
+fi
+
+# ── 4. //mutation:exempt ──────────────────────────────────────────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	//mutation:exempt buffer size, a test pinning it would be a tautology
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":5,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -q 'no surviving mutants'; then
+	fail "an exempt survivor leaves no findings" "$out"
+elif printf '%s' "$(findings_only "$out")" | grep -q 'pkg/new.go:5'; then
+	fail "an exempt survivor is not reported as a finding" "$out"
+elif ! printf '%s' "$out" | grep -q 'Exempt by'; then
+	fail "an exempt survivor is still listed, so a reviewer can see it" "$out"
+elif ! printf '%s' "$out" | grep -q 'pkg/new.go:5'; then
+	fail "the exempt list names the waived line" "$out"
+else
+	pass "//mutation:exempt on the line above waives that survivor, and lists it"
+fi
+
+# ── 5. A bare marker exempts nothing ──────────────────────────────────────────
+#
+# Same rule as //coverage:exempt: "an exemption nobody has to justify is how an
+# exemption stops being reviewable."
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	//mutation:exempt
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":5,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+# It has to land in FINDINGS, not merely appear somewhere: a script that
+# honoured the reasonless marker would still print the line, under "Exempt by".
+if ! printf '%s' "$(findings_only "$out")" | grep -q 'pkg/new.go:5'; then
+	fail "a bare //mutation:exempt exempts nothing" "$out"
+elif ! printf '%s' "$out" | grep -q 'exempts nothing'; then
+	fail "a bare //mutation:exempt is called out, not silently ignored" "$out"
+else
+	pass "a bare //mutation:exempt exempts nothing"
+fi
+
+# ── 6. The exemption window does not leak onto the next line ──────────────────
+#
+# The bug #188 fixed in its own marker: reading `line-1`..`line` as one string
+# let a marker on one construct's OPENING line also waive the construct on the
+# next. Reproducing it needs the marker INLINE on a mutated line, with another
+# mutated line directly below — a marker on its own comment line two rows up
+# cannot reach the second construct whether the window leaks or not, so a
+# fixture in that shape passes either way. Confirmed by perturbation.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n, m int) bool {
+	if n > 7 { //mutation:exempt only the outer test is a tuning constant
+		if m > 9 {
+			return true
+		}
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[
+   {"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5},
+   {"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":5,"column":6}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -q '1 surviving mutant'; then
+	fail "exactly one of the two survivors is waived" "$out"
+elif printf '%s' "$(findings_only "$out")" | grep -q 'pkg/new.go:4'; then
+	fail "the exempt line itself is waived" "$out"
+elif ! printf '%s' "$(findings_only "$out")" | grep -q 'pkg/new.go:5'; then
+	fail "the line BELOW an INLINE marker is still reported as a finding" "$out"
+else
+	pass "an inline exemption does not leak onto the next line"
+fi
+
+# ── 7. MUTATION_EXEMPT waives the branch, and says how many ───────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(cd "$repo" && MUTATION_EXEMPT=1 sh "$checker" --base main --report rep.json 2>&1)
+if ! printf '%s' "$out" | grep -q 'MUTATION_EXEMPT'; then
+	fail "MUTATION_EXEMPT=1 says it waived the branch" "$out"
+elif ! printf '%s' "$out" | grep -q '1'; then
+	fail "MUTATION_EXEMPT=1 says how many findings it waived" "$out"
+else
+	pass "MUTATION_EXEMPT=1 waives the branch and says how many"
+fi
+
+# ── 8. No Go implementation changed ───────────────────────────────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+printf 'docs only\n' > "$repo/README.md"
+write_report "$repo/rep.json" '{"go_module":"example","files":[]}'
+commit_on_branch "$repo" "docs"
+out=$(run_checker "$repo" --base main --report rep.json)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+	fail "a docs-only branch exits 0" "exit $rc: $out"
+elif ! printf '%s' "$out" | grep -q 'no Go implementation changed'; then
+	fail "a docs-only branch says why it did nothing" "$out"
+else
+	pass "a docs-only branch skips, and says so"
+fi
+
+# ── 9. Test files are not the subject ─────────────────────────────────────────
+#
+# Mutating a _test.go file asks whether the tests test the tests. The red-check
+# (G4(b)) is what judges changed tests; this gate judges changed implementation.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new_test.go" <<'EOF'
+package pkg
+
+import "testing"
+
+func TestSomething(t *testing.T) {
+	if 1 > 0 {
+		t.Log("ok")
+	}
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[]}'
+commit_on_branch "$repo" "test only"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -q 'no Go implementation changed'; then
+	fail "a test-only branch is not the subject of this gate" "$out"
+else
+	pass "a test-only branch is left to the red-check"
+fi
+
+# ── 10. Could not run: missing base ref ───────────────────────────────────────
+#
+# "Could not check" is a failure, never a skip — the rule scripts/efficacy.sh
+# and scripts/coverage_blocks.sh both state. A required check that decided
+# nothing must not look like one that passed.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+printf 'package pkg\n\nfunc F() {}\n' > "$repo/pkg/new.go"
+write_report "$repo/rep.json" '{"go_module":"example","files":[]}'
+commit_on_branch "$repo" "add"
+out=$(run_checker "$repo" --base does-not-exist --report rep.json)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+	fail "a missing base ref fails rather than skipping" "$out"
+elif ! printf '%s' "$out" | grep -q 'does-not-exist'; then
+	fail "a missing base ref names the ref" "$out"
+else
+	pass "a missing base ref fails, naming the ref"
+fi
+
+# ── 11. Could not run: missing report ─────────────────────────────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+printf 'package pkg\n\nfunc F(n int) bool { return n > 1 }\n' > "$repo/pkg/new.go"
+commit_on_branch "$repo" "add"
+out=$(run_checker "$repo" --base main --report absent.json)
+rc=$?
+# The message matters as much as the code: exit 127 from a missing script is
+# also non-zero, and a case that accepted it would pass before this gate
+# existed.
+if [ "$rc" -eq 0 ]; then
+	fail "a missing report fails rather than reporting no survivors" "$out"
+elif ! printf '%s' "$out" | grep -q 'mutation: ERROR'; then
+	fail "a missing report says what is wrong" "$out"
+else
+	pass "a missing report fails rather than reporting no survivors"
+fi
+
+# ── 12. Could not run: unparseable report ─────────────────────────────────────
+#
+# An empty or truncated report is what a killed gremlins run leaves behind. It
+# has no `files` key, which must not read as "no survivors".
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+printf 'package pkg\n\nfunc F(n int) bool { return n > 1 }\n' > "$repo/pkg/new.go"
+write_report "$repo/rep.json" 'not json at all'
+commit_on_branch "$repo" "add"
+out=$(run_checker "$repo" --base main --report rep.json)
+rc=$?
+if [ "$rc" -eq 0 ]; then
+	fail "an unparseable report fails rather than reporting no survivors" "$out"
+elif ! printf '%s' "$out" | grep -q 'mutation: ERROR'; then
+	fail "an unparseable report says what is wrong" "$out"
+else
+	pass "an unparseable report fails rather than reporting no survivors"
+fi
+
+# ── 13. A clean branch says so ────────────────────────────────────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"KILLED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+	fail "a branch whose mutants were all killed exits 0" "exit $rc: $out"
+elif ! printf '%s' "$out" | grep -q 'no surviving'; then
+	fail "a clean branch says every mutant was killed" "$out"
+else
+	pass "a branch whose mutants were all killed says so"
+fi
+
+# ── 14. Module-prefixed paths in the report resolve ───────────────────────────
+#
+# gremlins reports repository-relative paths, but the profile-style
+# `<module>/<path>` spelling is what coverage.out uses and what a future
+# gremlins might. Accepting both costs one substitution; guessing wrong makes
+# every finding silently unmatched, which is this gate reporting green.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"example/pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -q 'pkg/new.go:4'; then
+	fail "a module-prefixed path in the report resolves to a repository path" "$out"
+else
+	pass "a module-prefixed path in the report resolves"
+fi
+
+# ── 15. Runs from a subdirectory ──────────────────────────────────────────────
+#
+# The third fail-open #188 found: `git diff --name-only` prints
+# repository-relative paths wherever it runs, but a pathspec after `--` resolves
+# against the caller's cwd. From a subdirectory every pathspec misses, every
+# touched-line set comes back empty, and the gate reports nothing having
+# measured nothing. No root-only case can see this.
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n int) bool {
+	if n > 7 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[{"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(cd "$repo/pkg" && sh "$checker" --base main --report ../rep.json 2>&1)
+if ! printf '%s' "$out" | grep -q 'pkg/new.go:4'; then
+	fail "the gate works when run from a subdirectory" "$out"
+else
+	pass "the gate works when run from a subdirectory"
+fi
+
+# ── 16. The summary counts survivors, not mutations ───────────────────────────
+
+checks=$((checks + 1))
+repo=$(new_repo)
+commit_on_main "$repo" "empty base"
+cat > "$repo/pkg/new.go" <<'EOF'
+package pkg
+
+func New(n, m int) bool {
+	if n > 7 {
+		return true
+	}
+	if m > 9 {
+		return true
+	}
+	return false
+}
+EOF
+write_report "$repo/rep.json" '{"go_module":"example","files":[
+ {"file_name":"pkg/new.go","mutations":[
+   {"type":"CONDITIONALS_BOUNDARY","status":"LIVED","line":4,"column":5},
+   {"type":"CONDITIONALS_NEGATION","status":"LIVED","line":4,"column":5},
+   {"type":"CONDITIONALS_BOUNDARY","status":"KILLED","line":7,"column":5}]}]}'
+commit_on_branch "$repo" "add new.go"
+out=$(run_checker "$repo" --base main --report rep.json)
+if ! printf '%s' "$out" | grep -q '2 surviving'; then
+	fail "the summary counts surviving mutants" "$out"
+else
+	pass "the summary counts surviving mutants"
+fi
+
+# ── Result ────────────────────────────────────────────────────────────────────
+
+echo
+if [ "$failures" -gt 0 ]; then
+	echo "$failures of $checks mutation checks failed"
+	exit 1
+fi
+echo "all $checks mutation checks passed"


### PR DESCRIPTION
Roadmap item 6 of #180 — gate **G4(c)** in [docs/quality-gateway.md](https://github.com/tomo-chan/panemux/blob/main/docs/quality-gateway.md). Third of the item's four stages, sized by the second.

- [x] まず #164 のブロック単位カバレッジを実装する — #188 `d42e406`
- [x] それを通り抜ける tautology が実際に残るかを**測る** — 残る。108 件
- [x] 変更行に限定した mutation score を追加する（**警告のみ**で開始）
- [ ] 安定したらゲート化する — 別の変更。フラグは意図的に置いていない

## The measurement that sized this

#188 unblocked the question item 6 actually asks: do tautologies survive per-block coverage? **They do.** gremlins v0.6.0 over the whole module at `d42e406`:

| | Count |
|---|---|
| Killed | 945 |
| **Lived** | **108** |
| Not covered | 172 |
| Test efficacy | 89.74% |

Every survivor is in code `make coverage-blocks` reports as covered — by construction, since gremlins only mutates covered code. The two gates are complementary, not redundant.

**The clearest case.** `port > 65535` appears in three packages:

```go
internal/config/validate.go:35   if c.Server.Port < 1 || c.Server.Port > 65535 {
internal/api/handler.go:600      if req.Port < 0 || req.Port > 65535 {
internal/session/loopback.go:35  if port < 1 || port > 65535 {
```

Change it to `>= 65535` and all three reject port 65535 — a legal port — and **every test still passes, in all three packages**. The cause is identical in each: the tests use `65536`, one past the boundary, and never `65535`, the boundary itself. `make coverage-blocks` lists none of those lines, and is right not to: the blocks execute. What is missing is not execution but an assertion.

That the same blind spot appears three times, in three packages, written at three different times, is the part worth keeping. It is not an oversight in one test; it is a habit the existing gates cannot see.

| Survivor | Count | What it is |
|---|---|---|
| Boundary value | 45 | Already required by DEVELOPMENT.md's "Test granularity" |
| Other logic | 26 | Case by case |
| Error branch | 25 | Needs fault injection |
| Tuning constant | 12 | Killing it would pin a constant and assert nothing |

## It warns; it does not fail

**Decision D9**, and the measurement is the argument rather than caution. **37 of the 108 (34%) are survivors nobody should act on** — `64*1024` buffer sizes in three files, `30 * time.Second` timeouts, error branches unreachable without injection. A test written to kill the buffer-size mutants would pin a constant and assert nothing: a tautology, which is the exact defect G4 exists to find.

A check that failed on those would be wrong more often than right in its first weeks, and principle 4 says what happens to a gate that cries wolf. So a survivor prints and exits 0.

**"Could not run" is not softened.** A missing base ref, a shallow clone, a gremlins that exited non-zero, a truncated report — all exit 1. A check that decided nothing must never look like one that found nothing.

Stage 4 is a separate change with its own evidence. There is deliberately **no environment variable to flip it early**: an unused switch is an invitation to enable it without the data that should decide it.

## The settings are pinned, and that is not tuning

Run with gremlins' defaults on this repository, **465 of 1059 runnable mutants (44%) come back `TIMED OUT`**. They are not infinite loops — they are worker contention on a shared runner — and they *hide survivors*:

| | KILLED | LIVED | TIMED OUT |
|---|---|---|---|
| `internal/api`, defaults | 40 | **0** | 114 |
| `internal/api`, pinned | 147 | **7** | 0 |

Module-wide the count goes from 57 to 108. Note what does **not** move: efficacy reads 90.40% before and 89.74% after. A percentage that barely shifts while the absolute count doubles is how this would have gone unnoticed, and it is why `--timeout-coefficient` and `--workers` live in the script rather than being left to the tool.

## D2's cost premise is amended, not quietly rewritten

D2 scoped mutation to the diff because gremlins' documentation warns of hours on a large module. Measured here the whole module takes **14m25s**, and `--diff` brings a typical branch to seconds — so that reason is weaker than it looked. The conclusion stands on the other half: 108 survivors repo-wide means a whole-repository gate starts red.

Recorded as an amendment because the two reasons fail differently: a cost argument would be reopened by a faster tool, and a false-positive argument would not.

## Its own tests

`scripts/mutation_test.sh` (`make test-mutation`, inside `make check`) — **16 checks, and none of them runs gremlins**. `--report <file>` feeds fixture reports, the split `scripts/coverage_blocks.sh` has with `--profile`, so `make check` — and therefore `git push` — needs no gremlins install.

Eight perturbations were confirmed red. **Three of them first exposed weak fixtures rather than the bugs they were named for**, which is the pattern #185's rounds kept hitting and is why they are listed:

| Perturbation | What it first revealed |
|---|---|
| Drop line-level diff scoping | The case tested **file**-level scoping while claiming line-level — an untouched file never enters the loop, so dropping the line check still passed. Rewritten to put both survivors in the *same* file. |
| Accept a reasonless marker | The assertion was "the line appears in the output", which the **exempt list** also satisfies. Rewritten to require it in the findings section. |
| Widen the exemption window | The fixture's marker sat on its own comment line two rows above — a position the leak cannot reach either way. Rewritten to #188's actual shape: an **inline** marker with another mutated line directly below. |
| Report `NOT COVERED` as a survivor | **A real defect.** `NOT COVERED` contains a space, and `read -r line status type` was splitting it into `status="NOT"` with `COVERED` folded into the type. It happened to land in the right branch, so nothing visibly broke — which is exactly why it would have survived until a status this gate acts on gained a space. |

## Verified against this repository, not only fixtures

| Step | Result |
|---|---|
| New function + a test that calls it but asserts nothing | `2 surviving mutant(s)`, both named at `callback.go:137` |
| Same function, test rewritten to cover the boundary (`3`/`4`) | `no surviving mutants on lines this branch changed` |

The temporary fixture was removed; only the gate is in the diff.

## Test plan

- [x] `make test-mutation` — 16/16
- [x] All eight perturbations confirmed red, then reverted
- [x] End-to-end against this repository in both directions (table above)
- [x] `gremlins --diff` scoping confirmed to leave the whole-module coverage context intact (1231 skipped, only the branch's own mutants run, 1.7s)
- [x] `make lint` — 0 issues
- [x] `make check` — passes end to end (hook 26, efficacy 29, scenarios 22, coverage-blocks 47, mutation 16; Go coverage 86.4%)

> Note: this PR's own run of the new job will find nothing to report — the branch changes no Go implementation, only shell, CI and docs, so it exits at "no Go implementation changed". The gate's finding path is covered by `make test-mutation` and by the end-to-end table above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTfbAi8NhyieDyRgcaC7qN)_