### PR TITLE
test: cover internal/boardmcp's unentered error branches (#195)

### DIFF
--- a/internal/boardmcp/boardmcp_branches_test.go
+++ b/internal/boardmcp/boardmcp_branches_test.go
@@ -1,0 +1,284 @@
+package boardmcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Branches `make coverage-blocks` reported as never entered. Issue #195.
+//
+// This package is the whole surface the command center's LLM subprocess can
+// reach — three tools over a stdio JSON-RPC transport — so its error handling
+// is what stands between a malformed model-generated call and the subprocess
+// losing its connection to panemux entirely. Most of what was unentered is
+// exactly that: the arms that turn bad input into an answer rather than a
+// dropped stream.
+
+// ── The stdio transport ──────────────────────────────────────────────────────
+
+// A blank line between requests is skipped rather than answered with a parse
+// error. Any writer that terminates its last line and then flushes produces
+// one, and answering it would put an unsolicited error response on a stream
+// the client correlates by id.
+func TestServeSkipsBlankLinesBetweenRequests(t *testing.T) {
+	responses := serveLines(t, &fakeBoardAPIClient{},
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}`,
+		"",
+		"   ",
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+	)
+
+	require.Len(t, responses, 2, "the blank lines must produce no response of their own")
+	assert.EqualValues(t, 1, responses[0]["id"])
+	assert.EqualValues(t, 2, responses[1]["id"])
+}
+
+// failingWriter fails every write, standing in for the subprocess's stdout
+// pipe closing because `claude` exited while a response was in flight.
+type failingWriter struct{ err error }
+
+func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
+
+// A broken stdout ends the loop with the reason, rather than spinning through
+// the remaining requests writing into a pipe nobody is reading.
+func TestServeReportsAWriteFailure(t *testing.T) {
+	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n")
+
+	err := NewServer(&fakeBoardAPIClient{}).Serve(
+		context.Background(), in, failingWriter{err: errors.New("broken pipe")},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing mcp response")
+	assert.Contains(t, err.Error(), "broken pipe")
+}
+
+// failingReader fails after handing back whatever it was primed with, so the
+// scanner reports a read error rather than a clean end of input.
+type failingReader struct {
+	err       error
+	remaining string
+}
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.remaining == "" {
+		return 0, f.err
+	}
+	n := copy(p, f.remaining)
+	f.remaining = f.remaining[n:]
+	return n, nil
+}
+
+// A read failure is distinguished from end-of-input: Serve returns nil when
+// the client simply closed, and an error when the stream broke.
+func TestServeReportsAReadFailure(t *testing.T) {
+	r := &failingReader{
+		remaining: `{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n",
+		err:       errors.New("connection reset"),
+	}
+	var out strings.Builder
+
+	err := NewServer(&fakeBoardAPIClient{}).Serve(context.Background(), r, &out)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading mcp request")
+	assert.Contains(t, err.Error(), "connection reset")
+	assert.Contains(t, out.String(), `"id":1`, "the request read before the failure was still answered")
+}
+
+// ── Dispatch ─────────────────────────────────────────────────────────────────
+
+// `notifications/initialized` normally arrives with no id and is answered with
+// nothing at all. A client that sends it as a request anyway gets a response,
+// not a "method not found": the method exists, it just has no result.
+func TestInitializedSentAsARequestIsAnsweredWithANullResult(t *testing.T) {
+	responses := serveLines(t, &fakeBoardAPIClient{},
+		`{"jsonrpc":"2.0","id":7,"method":"notifications/initialized"}`,
+	)
+
+	require.Len(t, responses, 1)
+	assert.EqualValues(t, 7, responses[0]["id"])
+	assert.Nil(t, responses[0]["result"])
+	assert.Nil(t, responses[0]["error"], "the method is known, so this is not method-not-found")
+}
+
+// ── Malformed tool calls ─────────────────────────────────────────────────────
+
+// The three shapes a model can get wrong, each answered as a JSON-RPC error
+// rather than crashing the handler or returning a tool result that looks like
+// success.
+func TestMalformedToolCallsReturnInvalidParams(t *testing.T) {
+	const invalidParams = -32602
+
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "tools/call params are not an object",
+			line: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":"not-an-object"}`,
+			want: "invalid params:",
+		},
+		{
+			name: "board_messages arguments are not an object",
+			line: `{"jsonrpc":"2.0","id":2,"method":"tools/call",` +
+				`"params":{"name":"board_messages","arguments":"not-an-object"}}`,
+			want: "invalid arguments:",
+		},
+		{
+			name: "board_broadcast arguments are not an object",
+			line: `{"jsonrpc":"2.0","id":3,"method":"tools/call",` +
+				`"params":{"name":"board_broadcast","arguments":42}}`,
+			want: "invalid arguments:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses := serveLines(t, &fakeBoardAPIClient{}, tt.line)
+
+			require.Len(t, responses, 1)
+			rpcErr, ok := responses[0]["error"].(map[string]any)
+			require.True(t, ok, "expected a JSON-RPC error, got %v", responses[0])
+			assert.EqualValues(t, invalidParams, rpcErr["code"])
+			assert.Contains(t, rpcErr["message"], tt.want)
+			assert.Nil(t, responses[0]["result"])
+		})
+	}
+}
+
+// A failure from panemux's own REST API is reported as a tool result with
+// isError set, naming the tool. It is deliberately not a JSON-RPC error: the
+// call itself was well-formed, so the model should see the failure as
+// something it can react to rather than a protocol fault.
+func TestClientFailuresSurfaceAsToolErrorsNamingTheTool(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *fakeBoardAPIClient
+		line   string
+		want   string
+	}{
+		{
+			name:   "board_messages",
+			client: &fakeBoardAPIClient{messagesErr: errors.New("relay unreachable")},
+			line: `{"jsonrpc":"2.0","id":1,"method":"tools/call",` +
+				`"params":{"name":"board_messages","arguments":{"since":5}}}`,
+			want: "board_messages: relay unreachable",
+		},
+		{
+			name:   "board_broadcast",
+			client: &fakeBoardAPIClient{broadcastErr: errors.New("no board-enabled panes")},
+			line: `{"jsonrpc":"2.0","id":2,"method":"tools/call",` +
+				`"params":{"name":"board_broadcast","arguments":{"to":["pane-a"],"body":"hi"}}}`,
+			want: "board_broadcast: no board-enabled panes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responses := serveLines(t, tt.client, tt.line)
+
+			require.Len(t, responses, 1)
+			assert.Nil(t, responses[0]["error"], "a backend failure is a tool result, not a protocol error")
+			result, ok := responses[0]["result"].(map[string]any)
+			require.True(t, ok, "expected a tool result, got %v", responses[0])
+			assert.Equal(t, true, result["isError"])
+			content, ok := result["content"].([]any)
+			require.True(t, ok)
+			require.Len(t, content, 1)
+			text, ok := content[0].(map[string]any)["text"].(string)
+			require.True(t, ok)
+			assert.Equal(t, tt.want, text)
+		})
+	}
+}
+
+// jsonrpcError doubles as an ordinary error so callTool can return one
+// directly; Error() is what any %v or errors.Is path would print.
+func TestJSONRPCErrorImplementsError(t *testing.T) {
+	var err error = &jsonrpcError{Code: -32602, Message: "invalid arguments: bad json"}
+
+	assert.Equal(t, "invalid arguments: bad json", err.Error())
+}
+
+// ── The REST client ──────────────────────────────────────────────────────────
+
+// The base URL arrives from the environment (PANEMUX_BOARD_BASE_URL, read by
+// runBoardMCPServer), so a value http.NewRequest cannot parse is real input
+// rather than a hypothetical. It fails at request construction, before
+// anything is dialed — this says nothing about whether the host is loopback,
+// which is not checked here.
+func TestHTTPBoardAPIClientUnbuildableRequestIsReported(t *testing.T) {
+	client := NewHTTPBoardAPIClient("://not-a-url", "token")
+
+	raw, err := client.Status(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "building request")
+	assert.Nil(t, raw)
+}
+
+// panemux not listening is the ordinary failure here: the command center
+// subprocess outlives a server shutdown by however long its query takes.
+func TestHTTPBoardAPIClientUnreachableServerIsReported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	baseURL := server.URL
+	server.Close() // nothing is listening on that port any more
+
+	client := NewHTTPBoardAPIClient(baseURL, "token")
+
+	raw, err := client.Status(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "calling panemux board api")
+	assert.Nil(t, raw)
+}
+
+// A response whose body ends early is reported as a read failure rather than
+// parsed as a short but valid body.
+func TestHTTPBoardAPIClientTruncatedBodyIsReported(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "64")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"panes":`))
+		// Returning without writing the promised 64 bytes makes net/http close
+		// the connection, which the reader sees as an unexpected EOF.
+	}))
+	defer server.Close()
+
+	client := NewHTTPBoardAPIClient(server.URL, "token")
+
+	raw, err := client.Status(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading panemux board api response")
+	assert.Nil(t, raw)
+}
+
+// A trailing slash on the base URL must not produce a double slash in the
+// request path, which some routers treat as a different route entirely.
+func TestHTTPBoardAPIClientTrimsATrailingSlashFromTheBaseURL(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPBoardAPIClient(server.URL+"/", "token")
+
+	raw, err := client.Status(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, "/api/board/status", gotPath)
+	assert.Equal(t, json.RawMessage(`{}`), raw)
+}

--- a/internal/boardmcp/boardmcp_branches_test.go
+++ b/internal/boardmcp/boardmcp_branches_test.go
@@ -49,16 +49,28 @@ func (f failingWriter) Write([]byte) (int, error) { return 0, f.err }
 
 // A broken stdout ends the loop with the reason, rather than spinning through
 // the remaining requests writing into a pipe nobody is reading.
+//
+// The second request line is what makes that observable. With a single line,
+// input exhaustion and an aborted loop are indistinguishable — both leave
+// Serve returning the same wrapped error — so the assertion the comment
+// describes would hold for a Serve that recorded the write error and kept
+// dispatching. `gotSince` is the recorder: it stays zero only if
+// board_messages was never dispatched.
 func TestServeReportsAWriteFailure(t *testing.T) {
-	in := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}` + "\n")
+	in := strings.NewReader(strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"board_messages","arguments":{"since":42}}}`,
+	}, "\n") + "\n")
+	client := &fakeBoardAPIClient{}
 
-	err := NewServer(&fakeBoardAPIClient{}).Serve(
+	err := NewServer(client).Serve(
 		context.Background(), in, failingWriter{err: errors.New("broken pipe")},
 	)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "writing mcp response")
 	assert.Contains(t, err.Error(), "broken pipe")
+	assert.Zero(t, client.gotSince, "the loop must end at the write failure, not keep dispatching")
 }
 
 // failingReader fails after handing back whatever it was primed with, so the

--- a/internal/boardmcp/boardmcp_branches_test.go
+++ b/internal/boardmcp/boardmcp_branches_test.go
@@ -98,16 +98,25 @@ func TestServeReportsAReadFailure(t *testing.T) {
 
 // `notifications/initialized` normally arrives with no id and is answered with
 // nothing at all. A client that sends it as a request anyway gets a response,
-// not a "method not found": the method exists, it just has no result.
-func TestInitializedSentAsARequestIsAnsweredWithANullResult(t *testing.T) {
+// not a "method not found": the method is known, it just has no result.
+//
+// The response carries neither key. `jsonrpcResponse.Result` is `omitempty`,
+// so a nil result is omitted rather than serialized as `"result": null` —
+// worth pinning by key presence rather than by value, since a lookup that
+// returns nil cannot tell an absent key from a null one. Noted rather than
+// changed: JSON-RPC 2.0 asks a response to carry exactly one of result/error,
+// and this shape carries neither, but that is an implementation question and
+// this branch changes no implementation.
+func TestInitializedSentAsARequestIsAnsweredWithoutAResultOrAnError(t *testing.T) {
 	responses := serveLines(t, &fakeBoardAPIClient{},
 		`{"jsonrpc":"2.0","id":7,"method":"notifications/initialized"}`,
 	)
 
 	require.Len(t, responses, 1)
 	assert.EqualValues(t, 7, responses[0]["id"])
-	assert.Nil(t, responses[0]["result"])
-	assert.Nil(t, responses[0]["error"], "the method is known, so this is not method-not-found")
+	assert.Equal(t, "2.0", responses[0]["jsonrpc"])
+	assert.NotContains(t, responses[0], "error", "the method is known, so this is not method-not-found")
+	assert.NotContains(t, responses[0], "result", "and it has no result to report")
 }
 
 // ── Malformed tool calls ─────────────────────────────────────────────────────

--- a/internal/boardmcp/boardmcp_branches_test.go
+++ b/internal/boardmcp/boardmcp_branches_test.go
@@ -238,12 +238,16 @@ func TestHTTPBoardAPIClientUnbuildableRequestIsReported(t *testing.T) {
 
 // panemux not listening is the ordinary failure here: the command center
 // subprocess outlives a server shutdown by however long its query takes.
+//
+// Port 0 rather than a closed httptest server, because "nothing is listening
+// there any more" is not a property a closed listener actually guarantees:
+// closing a listener that never accepted a connection returns its port to the
+// ephemeral pool immediately, and `go test ./...` runs package binaries
+// concurrently against that same pool. A dial to port 0 is refused by the
+// kernel before any connection is attempted, so it cannot reach a foreign
+// server no matter what else the machine is running.
 func TestHTTPBoardAPIClientUnreachableServerIsReported(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	baseURL := server.URL
-	server.Close() // nothing is listening on that port any more
-
-	client := NewHTTPBoardAPIClient(baseURL, "token")
+	client := NewHTTPBoardAPIClient("http://127.0.0.1:0", "token")
 
 	raw, err := client.Status(context.Background())
 


### PR DESCRIPTION
The fourth slice of the per-block backlog, after #203, #205 and #206.

`internal/boardmcp` goes from **15 blocks to 2**, and the repository-wide count from **171 to 155**. Coverage of the gated packages goes from **92.1% to 92.6%**.

**Nothing in the implementation changes.** One test file is added, so `make efficacy` and the diff-scoped `coverage-blocks`/`mutation` gates all report "no implementation changed" and skip.

## Why these branches matter

This package is the whole surface the command center's LLM subprocess can reach — three tools over a stdio JSON-RPC transport. Its error handling is what stands between a malformed model-generated call and the subprocess losing its connection to panemux entirely. Most of what was unentered is exactly that: the arms that turn bad input into an *answer* rather than a dropped stream.

**The transport.** A blank line between requests is skipped rather than answered with an unsolicited parse error — any writer that terminates its last line and flushes produces one, and a response with no id to correlate is worse than silence. A broken stdout ends the loop with the reason instead of spinning through the remaining requests writing into a pipe nobody reads. A read failure is distinguished from a clean end of input, and the request read before it is still answered.

**Dispatch.** `notifications/initialized` sent as a *request* (with an id) reaches `dispatch`'s own arm, which the existing notification test never did — that one returns in `handleLine`, before dispatch. The answer is a null result, not method-not-found: the method is known, it just has no result.

**Malformed tool calls.** The three shapes a model can get wrong, each answered as invalid-params rather than crashing the handler.

**Backend failures.** `board_messages` and `board_broadcast` failures surface as a tool result with `isError` rather than a JSON-RPC error, since the call itself was well-formed — the model should see something it can react to, not a protocol fault. The assertions pin the exact wrapped text, so the tool-result-vs-protocol-error decision is what is being tested, not just that something came back.

**The REST client.** An unbuildable request, a server that is not listening (the ordinary case — the subprocess outlives a shutdown by however long its query takes), and a truncated response body. Plus the trailing-slash trim, which keeps a double slash out of the request path.

## Review

Ran the repo's `diff-reviewer` before opening this. It reported no findings, having verified the property earlier rounds on this issue found missing: **each new test was checked against a perturbation of the code it covers.** Thirteen perturbations, thirteen failures, each in exactly the intended test and no other — including dropping the `board_x: %w` wrap prefixes, deleting the `notifications/initialized` dispatch arm, and removing `strings.TrimSuffix` from the constructor.

It also flagged one comment that misstated *why* a URL fails to build (invalid syntax, not a non-loopback host). Corrected, and the comment now says what the test does not check.

## Left in the backlog

Two blocks: `client.go`'s `encoding broadcast request` and `server.go`'s `encoding mcp response`, both `json.Marshal` on fixed value sets that cannot fail.

No `//coverage:exempt` marker was added, for the reason #203 records: a marker would make these implementation changes, pulling a test-only branch into the efficacy gate.

## Test plan

- [x] `make check` — exit 0
- [x] `make lint-go` — 0 issues (one `fieldalignment` finding fixed)
- [x] `go test ./internal/boardmcp/ -race`
- [x] `make coverage-blocks` — `internal/boardmcp` 15 → 2, repository-wide 171 → 155
- [x] `make efficacy` — skipped, no implementation changed
- [x] `COVERAGE_BLOCKS_BASE=origin/main make coverage-blocks` — skipped, no implementation changed
- [x] `MUTATION_BASE=origin/main make mutation` — skipped, no implementation changed

Closes part of #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z)_