### PR TITLE
test: cover internal/commandcenter/runner.go's failure arms (#195)

### DIFF
--- a/internal/commandcenter/context_test.go
+++ b/internal/commandcenter/context_test.go
@@ -100,6 +100,27 @@ func TestDefaultContextDirIsUnderPanemuxConfig(t *testing.T) {
 	assert.Equal(t, filepath.Join("/workspace/user/home", ".config", "panemux", "command-center"), dir)
 }
 
+// The wrap is what tells an operator which step failed: run() emits this
+// error with errorEvent("%v", err) and adds no context of its own, so if the
+// wrap is dropped here a full disk surfaces as a bare "no space left on
+// device" with nothing naming the work directory.
+func TestNewWorkDirFailureNamesTheStepThatFailed(t *testing.T) {
+	// MkdirTemp with an empty dir argument resolves through TMPDIR, so
+	// pointing it at a path under a regular file makes it fail with ENOTDIR.
+	notADir := filepath.Join(t.TempDir(), "notadir")
+	require.NoError(t, os.WriteFile(notADir, []byte("not a directory\n"), 0600))
+	t.Setenv("TMPDIR", filepath.Join(notADir, "tmp"))
+
+	dir, cleanup, err := NewWorkDir()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "creating command center work directory")
+	assert.Contains(t, err.Error(), "not a directory")
+	assert.Empty(t, dir)
+	require.NotNil(t, cleanup, "the caller defers this unconditionally, so it must never be nil")
+	cleanup()
+}
+
 func TestNewWorkDirIsEmptyAndRemovable(t *testing.T) {
 	dir, cleanup, err := NewWorkDir()
 	require.NoError(t, err)

--- a/internal/commandcenter/runner_branches_test.go
+++ b/internal/commandcenter/runner_branches_test.go
@@ -1,0 +1,230 @@
+package commandcenter
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Every failure in a command-center turn reaches the operator as an
+// EventError on the WS stream and nowhere else — there is no HTTP status to
+// carry it and no caller to return it to. These tests cover the arms that
+// decide what that event says, and, just as importantly, whether the turn
+// stops there or carries on.
+//
+// The distinction is the reason most of these are worth pinning: a setup
+// failure must abort before the subprocess is launched, a failed history
+// write must not fail an otherwise-good query, and a failed session-id write
+// must abort rather than report success, because reporting done would leave
+// the next turn silently starting a new conversation.
+
+// runnerFixture is the seam-by-seam Runner these tests need. newTestRunner
+// covers the happy path; this one exists to fail exactly one seam at a time.
+type runnerFixture struct {
+	started *bool
+	config  RunnerConfig
+}
+
+func newRunnerFixture(t *testing.T, stdout string) *runnerFixture {
+	t.Helper()
+	started := false
+	return &runnerFixture{
+		started: &started,
+		config: RunnerConfig{
+			ClaudeBin:   "claude",
+			SessionPath: filepath.Join(t.TempDir(), "session.json"),
+			HistoryPath: filepath.Join(t.TempDir(), "history.jsonl"),
+			BuildMCPConfig: func() (string, func(), error) {
+				return "/tmp/sample-mcp-config.json", func() {}, nil
+			},
+			NewCommand: func(_ context.Context, _, _ string, _ ...string) cmdRunner {
+				started = true
+				return &fakeCmd{stdout: io.NopCloser(strings.NewReader(stdout))}
+			},
+			Now: func() time.Time { return time.Unix(0, 0).UTC() },
+		},
+	}
+}
+
+// query runs one turn to completion and returns every event it emitted.
+func (f *runnerFixture) query(t *testing.T) []Event {
+	t.Helper()
+	events, err := NewRunner(f.config).Query(context.Background(), "how is the board")
+	require.NoError(t, err)
+	return drain(t, events)
+}
+
+// errorEvents returns just the EventError messages, so a test can assert
+// both what was reported and that nothing else was.
+func errorEvents(events []Event) []string {
+	var msgs []string
+	for _, ev := range events {
+		if ev.Type == EventError {
+			msgs = append(msgs, ev.Err)
+		}
+	}
+	return msgs
+}
+
+func hasDone(events []Event) bool {
+	for _, ev := range events {
+		if ev.Type == EventDone {
+			return true
+		}
+	}
+	return false
+}
+
+// brokenParentPath returns a path whose parent is a regular file, so both
+// reading it and creating it fail with ENOTDIR.
+func brokenParentPath(t *testing.T, name string) string {
+	t.Helper()
+	notADir := filepath.Join(t.TempDir(), "notadir")
+	require.NoError(t, os.WriteFile(notADir, []byte("not a directory\n"), 0600))
+	return filepath.Join(notADir, name)
+}
+
+// ── Setup failures, which must abort before the subprocess is launched ────────
+
+func TestQueryReportsAnUnreadableSessionFile(t *testing.T) {
+	f := newRunnerFixture(t, "")
+	f.config.SessionPath = brokenParentPath(t, "session.json")
+
+	events := f.query(t)
+
+	require.Len(t, errorEvents(events), 1)
+	assert.Contains(t, errorEvents(events)[0], "loading command center session state")
+	assert.False(t, hasDone(events), "a turn that never ran must not report done")
+	assert.False(t, *f.started, "the subprocess must not be launched after a setup failure")
+}
+
+func TestQueryReportsAFailureToMintASessionID(t *testing.T) {
+	f := newRunnerFixture(t, "")
+	f.config.NewSessionID = func() (string, error) { return "", errors.New("no entropy available") }
+
+	events := f.query(t)
+
+	require.Len(t, errorEvents(events), 1)
+	assert.Contains(t, errorEvents(events)[0], "no entropy available")
+	assert.False(t, hasDone(events))
+	assert.False(t, *f.started)
+}
+
+// The work directory is created after the MCP config, so this also pins that
+// the config's cleanup still runs when a later step fails — otherwise the
+// token-bearing temp file that BuildMCPConfig writes (docs/security.md) would
+// outlive the query that needed it.
+func TestQueryReportsAFailureToCreateTheWorkDirAndStillCleansUpTheMCPConfig(t *testing.T) {
+	f := newRunnerFixture(t, "")
+	cleaned := false
+	f.config.BuildMCPConfig = func() (string, func(), error) {
+		return "/tmp/sample-mcp-config.json", func() { cleaned = true }, nil
+	}
+	f.config.NewWorkDir = func() (string, func(), error) {
+		return "", nil, errors.New("creating command center work directory: no space left on device")
+	}
+
+	events := f.query(t)
+
+	require.Len(t, errorEvents(events), 1)
+	assert.Contains(t, errorEvents(events)[0], "creating command center work directory")
+	assert.False(t, hasDone(events))
+	assert.False(t, *f.started)
+	assert.True(t, cleaned, "the mcp config's cleanup must run even when a later step fails")
+}
+
+// The pipe is opened after the command is constructed but before it is
+// started, so this is the last failure that still leaves nothing running.
+// It gets its own message because "creating stdout pipe" and "starting
+// claude" are different operator problems: a pipe failure is a resource
+// limit on this host, a start failure is usually a missing binary.
+func TestQueryReportsAFailureToOpenTheSubprocessStdoutPipe(t *testing.T) {
+	f := newRunnerFixture(t, "")
+	f.config.NewCommand = func(_ context.Context, _, _ string, _ ...string) cmdRunner {
+		return &noStdoutCmd{err: errors.New("too many open files")}
+	}
+
+	events := f.query(t)
+
+	require.Len(t, errorEvents(events), 1)
+	assert.Contains(t, errorEvents(events)[0], "creating stdout pipe")
+	assert.Contains(t, errorEvents(events)[0], "too many open files")
+	assert.False(t, hasDone(events))
+}
+
+// noStdoutCmd fails at StdoutPipe. fakeCmd cannot: its StdoutPipe never
+// returns an error, so the arm above is unreachable through it.
+type noStdoutCmd struct{ err error }
+
+func (c *noStdoutCmd) StdoutPipe() (io.ReadCloser, error) { return nil, c.err }
+func (c *noStdoutCmd) Start() error                       { return nil }
+func (c *noStdoutCmd) Wait() error                        { return nil }
+
+// ── Persistence failures after the turn itself succeeded ─────────────────────
+
+// A history write is a record of what already happened, so losing it is
+// worth reporting but must not turn a completed turn into a failed one — the
+// operator has the answer on screen either way.
+func TestQueryReportsAFailedHistoryWriteWithoutFailingTheTurn(t *testing.T) {
+	f := newRunnerFixture(t, `{"type":"result","session_id":"s","result":"done"}`+"\n")
+	f.config.HistoryPath = brokenParentPath(t, "history.jsonl")
+
+	events := f.query(t)
+
+	require.Len(t, errorEvents(events), 1)
+	assert.Contains(t, errorEvents(events)[0], "persisting command center history")
+	assert.True(t, hasDone(events), "the turn itself succeeded, so it must still report done")
+}
+
+// The session id is the opposite case: it is what the *next* turn resumes
+// from, so a turn that could not persist it has not really succeeded.
+// Reporting done would leave the next query silently starting a new
+// conversation with no sign anything was lost.
+//
+// The fixture is a dangling symlink rather than a regular file, because this
+// arm needs the load to succeed and only the save to fail: reading through a
+// dangling symlink is ErrNotExist, which LoadSessionFile treats as "no
+// session yet", while MkdirAll on one fails with EEXIST.
+func TestQueryReportsAFailureToPersistTheSessionID(t *testing.T) {
+	f := newRunnerFixture(t, `{"type":"result","session_id":"s","result":"done"}`+"\n")
+	dir := t.TempDir()
+	dangling := filepath.Join(dir, "dangling")
+	require.NoError(t, os.Symlink(filepath.Join(dir, "no-such-target"), dangling))
+	f.config.SessionPath = filepath.Join(dangling, "session.json")
+
+	events := f.query(t)
+
+	msgs := errorEvents(events)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0], "persisting command center session id")
+	assert.False(t, hasDone(events),
+		"the next turn would resume nothing, so this turn must not report done")
+}
+
+// ── The stream ───────────────────────────────────────────────────────────────
+
+// A blank line between stream-json objects is skipped rather than parsed.
+// Unlike LoadHistory's equivalent fast path, this one is load-bearing:
+// without it the blank line reaches json.Unmarshal, which fails, and
+// streamOutput treats a parse failure as a malformed stream — aborting the
+// turn and reporting an error for output that was merely padded.
+func TestStreamOutputSkipsBlankLinesRatherThanFailingTheTurn(t *testing.T) {
+	f := newRunnerFixture(t,
+		`{"type":"system","subtype":"init","session_id":"s"}`+"\n"+
+			"\n"+
+			"   \n"+
+			`{"type":"result","session_id":"s","result":"done"}`+"\n")
+
+	events := f.query(t)
+
+	assert.Empty(t, errorEvents(events), "a blank line is padding, not malformed output")
+	assert.True(t, hasDone(events))
+}

--- a/internal/commandcenter/runner_branches_test.go
+++ b/internal/commandcenter/runner_branches_test.go
@@ -129,16 +129,40 @@ func TestQueryReportsAFailureToCreateTheWorkDirAndStillCleansUpTheMCPConfig(t *t
 		return "/tmp/sample-mcp-config.json", func() { cleaned = true }, nil
 	}
 	f.config.NewWorkDir = func() (string, func(), error) {
-		return "", nil, errors.New("creating command center work directory: no space left on device")
+		return "", nil, errors.New("no space left on device")
 	}
 
 	events := f.query(t)
 
 	require.Len(t, errorEvents(events), 1)
-	assert.Contains(t, errorEvents(events)[0], "creating command center work directory")
+	// A bare error, deliberately: run() emits this arm as errorEvent("%v", err)
+	// and adds no prefix of its own, so asserting the "creating command center
+	// work directory" context here would only round-trip this fixture's own
+	// literal. That context comes from NewWorkDir's own wrap, and is asserted
+	// where it lives — TestNewWorkDirFailureNamesTheStepThatFailed.
+	assert.Contains(t, errorEvents(events)[0], "no space left on device")
 	assert.False(t, hasDone(events))
 	assert.False(t, *f.started)
 	assert.True(t, cleaned, "the mcp config's cleanup must run even when a later step fails")
+}
+
+// The mirror of the case above: nothing pinned that run() ever invokes the
+// cleanup NewWorkDir hands back. Without it every command-center query leaks
+// a panemux-command-center-* directory into /tmp for the life of the host —
+// one per palette query, never reclaimed.
+func TestQueryCleansUpTheWorkDirWhenTheTurnFails(t *testing.T) {
+	f := newRunnerFixture(t, "")
+	cleaned := false
+	f.config.NewWorkDir = func() (string, func(), error) {
+		return t.TempDir(), func() { cleaned = true }, nil
+	}
+	f.config.NewCommand = func(_ context.Context, _, _ string, _ ...string) cmdRunner {
+		return &noStdoutCmd{err: errors.New("too many open files")}
+	}
+
+	f.query(t)
+
+	assert.True(t, cleaned, "the work directory must be removed however the turn ends")
 }
 
 // The pipe is opened after the command is constructed but before it is
@@ -148,9 +172,8 @@ func TestQueryReportsAFailureToCreateTheWorkDirAndStillCleansUpTheMCPConfig(t *t
 // limit on this host, a start failure is usually a missing binary.
 func TestQueryReportsAFailureToOpenTheSubprocessStdoutPipe(t *testing.T) {
 	f := newRunnerFixture(t, "")
-	f.config.NewCommand = func(_ context.Context, _, _ string, _ ...string) cmdRunner {
-		return &noStdoutCmd{err: errors.New("too many open files")}
-	}
+	cmd := &noStdoutCmd{err: errors.New("too many open files")}
+	f.config.NewCommand = func(_ context.Context, _, _ string, _ ...string) cmdRunner { return cmd }
 
 	events := f.query(t)
 
@@ -158,21 +181,39 @@ func TestQueryReportsAFailureToOpenTheSubprocessStdoutPipe(t *testing.T) {
 	assert.Contains(t, errorEvents(events)[0], "creating stdout pipe")
 	assert.Contains(t, errorEvents(events)[0], "too many open files")
 	assert.False(t, hasDone(events))
+	assert.False(t, cmd.started,
+		"the pipe is opened before Start, and it must stay that way: a subprocess started and then "+
+			"abandoned on the pipe error is never Wait()ed, leaving a zombie claude per failed query, "+
+			"while the deferred work-dir cleanup deletes the directory out from under it")
 }
 
-// noStdoutCmd fails at StdoutPipe. fakeCmd cannot: its StdoutPipe never
-// returns an error, so the arm above is unreachable through it.
-type noStdoutCmd struct{ err error }
+// noStdoutCmd fails at StdoutPipe and records whether Start was reached.
+// fakeCmd can do neither: its StdoutPipe never returns an error, and nothing
+// it records survives the factory this test replaces.
+type noStdoutCmd struct {
+	err     error
+	started bool
+}
 
 func (c *noStdoutCmd) StdoutPipe() (io.ReadCloser, error) { return nil, c.err }
-func (c *noStdoutCmd) Start() error                       { return nil }
+func (c *noStdoutCmd) Start() error                       { c.started = true; return nil }
 func (c *noStdoutCmd) Wait() error                        { return nil }
 
 // ── Persistence failures after the turn itself succeeded ─────────────────────
 
-// A history write is a record of what already happened, so losing it is
-// worth reporting but must not turn a completed turn into a failed one — the
-// operator has the answer on screen either way.
+// A history write is a record of what already happened, so losing it must not
+// turn a completed turn into a failed one — the operator has the answer on
+// screen either way. Continuing rather than returning is right.
+//
+// How it is *reported* is not, and this test pins the present shape rather
+// than endorsing it: an EventError followed by an EventDone. Both are
+// terminal — docs/behavior.md says each is "always the last frame for that
+// query", and EventDone's own doc comment in runner.go says it "is never sent
+// after an EventError on the same channel" — so this path violates both, and
+// the dashboard renders the turn as complete *and* errored because
+// applyFrame's error arm sets done and the later done frame does not clear
+// the message. Filed as #214; the fix is a frame-contract decision, and this
+// branch changes no implementation.
 func TestQueryReportsAFailedHistoryWriteWithoutFailingTheTurn(t *testing.T) {
 	f := newRunnerFixture(t, `{"type":"result","session_id":"s","result":"done"}`+"\n")
 	f.config.HistoryPath = brokenParentPath(t, "history.jsonl")
@@ -181,7 +222,9 @@ func TestQueryReportsAFailedHistoryWriteWithoutFailingTheTurn(t *testing.T) {
 
 	require.Len(t, errorEvents(events), 1)
 	assert.Contains(t, errorEvents(events)[0], "persisting command center history")
-	assert.True(t, hasDone(events), "the turn itself succeeded, so it must still report done")
+	assert.True(t, hasDone(events),
+		"the turn itself succeeded, so it still reports done today — see #214 for why that, "+
+			"alongside the error frame above, is the shape rather than the intent")
 }
 
 // The session id is the opposite case: it is what the *next* turn resumes
@@ -216,7 +259,14 @@ func TestQueryReportsAFailureToPersistTheSessionID(t *testing.T) {
 // without it the blank line reaches json.Unmarshal, which fails, and
 // streamOutput treats a parse failure as a malformed stream — aborting the
 // turn and reporting an error for output that was merely padded.
-func TestStreamOutputSkipsBlankLinesRatherThanFailingTheTurn(t *testing.T) {
+//
+// Asserting the absence of an error and the presence of done is not enough on
+// its own, and this test used to stop there. Turning the `continue` into a
+// `break` also produces no error and still reaches done, while silently
+// dropping every frame after the first blank line — including the result the
+// operator is waiting for. So the line *after* the blank ones is what has to
+// be asserted: skipping and stopping are only distinguishable there.
+func TestStreamOutputSkipsBlankLinesAndKeepsForwardingWhatFollows(t *testing.T) {
 	f := newRunnerFixture(t,
 		`{"type":"system","subtype":"init","session_id":"s"}`+"\n"+
 			"\n"+
@@ -227,4 +277,14 @@ func TestStreamOutputSkipsBlankLinesRatherThanFailingTheTurn(t *testing.T) {
 
 	assert.Empty(t, errorEvents(events), "a blank line is padding, not malformed output")
 	assert.True(t, hasDone(events))
+
+	var lines []string
+	for _, ev := range events {
+		if ev.Type == EventLine {
+			lines = append(lines, string(ev.Raw))
+		}
+	}
+	require.Len(t, lines, 2, "the blank lines produce no frame of their own, and neither one ends the stream")
+	assert.Contains(t, lines[1], `"type":"result"`,
+		"the frame after the blank lines is the answer, and it must still reach the operator")
 }

--- a/internal/commandcenter/runner_test.go
+++ b/internal/commandcenter/runner_test.go
@@ -617,6 +617,8 @@ func TestRunnerBuildMCPConfigFailureEmitsErrorAndNeverStartsProcess(t *testing.T
 
 	require.Len(t, got, 1)
 	assert.Equal(t, EventError, got[0].Type)
+	assert.Contains(t, got[0].Err, "building mcp config",
+		"the operator has to be able to tell this apart from a failure to start claude")
 	assert.Contains(t, got[0].Err, "disk full")
 	assert.False(t, started, "must never spawn claude when mcp config setup fails")
 }


### PR DESCRIPTION
The sixth slice of the per-block backlog, after #203, #205, #206, #208 and #211.

`internal/commandcenter/runner.go` goes from **9 blocks to 1**, and the repository-wide count from **146 to 138**.

**Nothing in the implementation changes.** One test file is added and one assertion is added to an existing test, so `make efficacy` and the diff-scoped `coverage-blocks`/`mutation` gates all report "no implementation changed" and skip.

## Why these branches matter

Every failure in a command-center turn reaches the operator as an `EventError` on the WS stream and nowhere else — there is no HTTP status to carry it and no caller to return it to. These are the arms that decide what that event says, and whether the turn stops there.

That second half is what most of them actually pin:

- **A setup failure must abort before the subprocess is launched.** Session-state load, session-id mint, work-directory creation, stdout pipe: each asserts no `claude` process was started, not just that an error was reported.
- **A failed history write must not fail the turn.** History is a record of what already happened; the operator has the answer on screen either way. The turn still reports done.
- **A failed session-id write must abort.** This is the opposite case and the one worth having a test for: the session id is what the *next* turn resumes from, so reporting done would leave the next query silently starting a new conversation with no sign anything was lost.

The work-directory test also pins that the MCP config's cleanup still runs when a later step fails — otherwise the token-bearing temp file `BuildMCPConfig` writes ([docs/security.md](docs/security.md)) would outlive the query that needed it.

## Two fixtures worth noting

**The session-id arm needs the load to succeed and only the save to fail**, so its path sits under a dangling symlink. Reading through one is `ErrNotExist`, which `LoadSessionFile` treats as "no session yet", while `MkdirAll` on one fails with `EEXIST`. A regular-file parent — the fixture the other tests use — fails the load instead and lands on a different arm.

**The stdout-pipe arm needs a `cmdRunner` whose `StdoutPipe` can fail**, which the existing `fakeCmd` cannot do: it always returns a nil error, so that arm is unreachable through it.

## Verification

Every test was checked against a perturbation of the code it covers; each kills exactly the intended test.

One process note, since this PR's own standard is "perturb and confirm red": my first pass reported the blank-line perturbation as a survivor. It was not — deleting that arm made `bytes` an unused import, and my check was matching on `^--- FAIL` only, so a build failure read as "no test failed". Re-run properly, it kills the test. Worth recording because the verification method can produce a false negative that looks exactly like a real one.

## One test written and then dropped

A `BuildMCPConfig` failure test was written for this and removed before opening the PR: `TestRunnerBuildMCPConfigFailureEmitsErrorAndNeverStartsProcess` already covers that block, so a second one would have retired nothing — the anti-pattern [#209](https://github.com/tomo-chan/panemux/issues/209) records.

What it added over the existing test moved into that test instead: an assertion on the `building mcp config` wrap prefix. The existing test asserted only that the underlying message (`disk full`) appeared, so dropping the prefix did not fail it — confirmed by perturbation, and it fails now. Without the prefix an operator cannot tell a config failure from a failure to start `claude`, which are different problems on their host.

## Left in the backlog

One block: `promptHistoryEntry`'s `json.Marshal` fallback, which the code's own comment already records as unreachable (`json.Marshal` on a `map[string]string` cannot fail; the fallback exists to keep the entry well-formed if that ever stops being true).

No `//coverage:exempt` marker was added, for the reason #203 records: a marker would make this an implementation change and pull a test-only branch into the efficacy gate.

## Test plan

- [x] `make check` — exit 0
- [x] `make lint-go` — 0 issues (one `fieldalignment` finding fixed)
- [x] `go test ./internal/commandcenter/ -race -count=3`
- [x] `make coverage-blocks` — `runner.go` 9 → 1, repository-wide 146 → 138
- [x] 9 perturbations run; each kills exactly the intended test
- [x] `make efficacy` — skipped, no implementation changed
- [x] `COVERAGE_BLOCKS_BASE=origin/main make coverage-blocks` — skipped, no implementation changed
- [x] `MUTATION_BASE=origin/main make mutation` — skipped, no implementation changed

Closes part of #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z)_