### PR TITLE
test: cover config validation, the loopback guards and the command socket (#195)

### DIFF
--- a/internal/api/board_branches_test.go
+++ b/internal/api/board_branches_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two loopback checks below guard GET /api/session-token, the one
+// unauthenticated route that hands out the credential every other board route
+// requires (docs/security.md). Both parse an address that may not have a
+// port, and what they do when it does not is the difference between the guard
+// holding and the guard rejecting every legitimate request.
+
+// A Host header carries no port when the request went to the default one, so
+// SplitHostPort failing is the ordinary case rather than the exceptional one:
+// the whole value is the host. Treating the parse failure as "not loopback"
+// would reject a perfectly normal request to http://localhost/.
+func TestIsLoopbackAuthorityAcceptsAnAuthorityWithNoPort(t *testing.T) {
+	for _, authority := range []string{"localhost", loopbackIPv4, "0.0.0.0"} {
+		assert.True(t, isLoopbackAuthority(authority), "%q with no port is still loopback", authority)
+	}
+	for _, authority := range []string{"localhost:8080", loopbackIPv4 + ":8080"} {
+		assert.True(t, isLoopbackAuthority(authority), "%q with a port is loopback too", authority)
+	}
+
+	assert.False(t, isLoopbackAuthority("panemux.example.com"),
+		"the no-port path must not turn into an accept-everything path")
+	assert.False(t, isLoopbackAuthority("panemux.example.com:8080"))
+}
+
+// RemoteAddr is net/http's own view of the socket peer and normally carries a
+// port, but the same fallback applies — and here the value is checked with
+// net.IP.IsLoopback rather than string equality, since a real peer address
+// can be any loopback representation, including IPv4-mapped IPv6.
+func TestIsLoopbackRemoteAddrAcceptsAnAddressWithNoPort(t *testing.T) {
+	assert.True(t, isLoopbackRemoteAddr(loopbackIPv4))
+	assert.True(t, isLoopbackRemoteAddr("::1"))
+	assert.True(t, isLoopbackRemoteAddr("127.0.0.2:54321"),
+		"the whole 127.0.0.0/8 range is loopback, which string equality would miss")
+
+	assert.False(t, isLoopbackRemoteAddr("192.0.2.10"))
+	assert.False(t, isLoopbackRemoteAddr("not-an-address"),
+		"an unparsable address is not loopback — the fallback must not admit it")
+}
+
+// defaultCommandHistoryFn resolves its path on every call rather than once at
+// construction, so both of its failures reach a live request. Each names the
+// step that failed, because "resolving the path" and "reading the file" are
+// different problems for the operator: the first is an environment without a
+// home directory, the second a file they can go and look at.
+func TestDefaultCommandHistoryFnNamesWhichStepFailed(t *testing.T) {
+	t.Run("path cannot be resolved", func(t *testing.T) {
+		t.Setenv("HOME", "")
+
+		entries, err := defaultCommandHistoryFn()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolving command center history path")
+		assert.Nil(t, entries)
+	})
+
+	t.Run("file cannot be read", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		// The history file lives at ~/.config/panemux/<name>. Making that
+		// directory a regular file leaves the path resolvable but the read
+		// failing with ENOTDIR — the second arm, reached only because the
+		// first one succeeded.
+		require.NoError(t, os.MkdirAll(filepath.Join(home, ".config"), 0750))
+		require.NoError(t, os.WriteFile(filepath.Join(home, ".config", "panemux"), []byte("x\n"), 0600))
+
+		entries, err := defaultCommandHistoryFn()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "loading command center history")
+		assert.NotContains(t, err.Error(), "resolving command center history path",
+			"the path resolved fine; only the read failed")
+		assert.Nil(t, entries)
+	})
+}

--- a/internal/config/branches_test.go
+++ b/internal/config/branches_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two groups here, and they fail in opposite directions.
+//
+// EnsureAuthToken is best-effort by design: every failure leaves the token
+// empty and lets panemux start, because a server that will not boot is worse
+// than one whose board routes are unreachable. That makes the log line the
+// operator's only signal, so each test asserts what it says.
+//
+// Validate is the opposite — it exists to stop a config from being accepted,
+// and a rule that never fires is a rule that is not there.
+
+func captureConfigLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevWriter, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}
+
+// ── EnsureAuthToken ──────────────────────────────────────────────────────────
+
+// With no override and no home directory there is nowhere to keep the token,
+// so none is minted. Leaving Server.AuthToken empty is the important half:
+// a token generated but not persisted would change on every restart, silently
+// invalidating the one the dashboard already holds.
+func TestEnsureAuthTokenReportsAnUnresolvablePath(t *testing.T) {
+	logs := captureConfigLog(t)
+	t.Setenv("HOME", "")
+	cfg := &Config{}
+
+	cfg.EnsureAuthToken()
+
+	assert.Empty(t, cfg.Server.AuthToken, "no path means no token, not a token that cannot be kept")
+	assert.Contains(t, logs.String(), "failed to resolve auth token path")
+}
+
+// The directory is created first, so a write failing after that is its own
+// arm and its own message. Pointing the token path at an existing directory
+// reaches it: MkdirAll on the parent succeeds, the write does not.
+func TestEnsureAuthTokenReportsAFailedWrite(t *testing.T) {
+	logs := captureConfigLog(t)
+	dir := filepath.Join(t.TempDir(), "token-is-a-directory")
+	require.NoError(t, os.Mkdir(dir, 0750))
+	cfg := &Config{authTokenPath: dir}
+
+	cfg.EnsureAuthToken()
+
+	assert.Empty(t, cfg.Server.AuthToken,
+		"a token that could not be persisted must not be used for this run either")
+	assert.Contains(t, logs.String(), "failed to persist auth token")
+	assert.NotContains(t, logs.String(), "failed to create auth token directory",
+		"the parent existed; only the write failed")
+}
+
+// The complement, so the failures above are not passing for want of a working
+// path: with a usable one a token is minted, persisted at 0600, and read back
+// on the next call rather than regenerated.
+func TestEnsureAuthTokenMintsPersistsAndReuses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "token")
+	cfg := &Config{authTokenPath: path}
+
+	cfg.EnsureAuthToken()
+	minted := cfg.Server.AuthToken
+	require.NotEmpty(t, minted)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(),
+		"the token is a credential on disk; docs/security.md requires 0600")
+
+	next := &Config{authTokenPath: path}
+	next.EnsureAuthToken()
+	assert.Equal(t, minted, next.Server.AuthToken,
+		"a restart must reuse the token the dashboard already holds, not mint a new one")
+}
+
+// ── Validate ─────────────────────────────────────────────────────────────────
+
+// Each of these rules rejects a config an operator can plausibly write by
+// hand, and each is checked together with a value that must pass, so a rule
+// that rejects everything is as visible as one that rejects nothing.
+
+func TestValidateRejectsAnOutOfRangeVerticalBarWidth(t *testing.T) {
+	cfg := validatableConfig()
+	cfg.Workspaces.VerticalBarWidth = 1
+	require.Error(t, cfg.Validate())
+
+	cfg.Workspaces.VerticalBarWidth = 280
+	assert.NoError(t, cfg.Validate(), "a width in range must still pass")
+}
+
+func TestValidateRejectsAnInvalidChildDirection(t *testing.T) {
+	cfg := validatableConfig()
+	cfg.Workspaces.Items[0].Layout.Children[0].Direction = "diagonal"
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid direction")
+	assert.Contains(t, err.Error(), "diagonal", "the offending value has to be in the message")
+
+	cfg.Workspaces.Items[0].Layout.Children[0].Direction = "vertical"
+	assert.NoError(t, cfg.Validate())
+}
+
+// An ssh pane with no connection name is not a pane that connects nowhere —
+// it is one that cannot be started at all, so it has to be caught at load
+// rather than at first use.
+func TestValidateRejectsAnSSHPaneWithNoConnection(t *testing.T) {
+	cfg := validatableConfig()
+	cfg.Workspaces.Items[0].Layout.Children[0].Pane.Type = "ssh"
+	cfg.Workspaces.Items[0].Layout.Children[0].Pane.Connection = ""
+
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ssh connection name must not be empty")
+}
+
+// isLoopbackHost decides whether server.auth_token is required. A hostname
+// that is not an IP at all is emphatically not loopback: treating an
+// unparsable value as local would let a non-loopback bind skip the token
+// requirement that docs/security.md makes the whole board's gate.
+func TestIsLoopbackHostTreatsANonIPHostAsRemote(t *testing.T) {
+	assert.False(t, isLoopbackHost("panemux.example.com"))
+	assert.False(t, isLoopbackHost("0.0.0.0"), "a wildcard bind reaches every interface")
+
+	assert.True(t, isLoopbackHost(""), "an omitted host defaults to loopback")
+	assert.True(t, isLoopbackHost("localhost"))
+	assert.True(t, isLoopbackHost("127.0.0.1"))
+	assert.True(t, isLoopbackHost("::1"))
+}
+
+// validatableConfig returns the smallest config Validate accepts, so each
+// test above can invalidate exactly one thing.
+func validatableConfig() *Config {
+	return &Config{
+		Server: ServerConfig{Host: "127.0.0.1", Port: 8080},
+		Workspaces: WorkspacesConfig{
+			Active:      "default",
+			TabPosition: "top",
+			Items: []WorkspaceConfig{{
+				ID:    "default",
+				Title: "Default",
+				Layout: LayoutNode{
+					Direction: "horizontal",
+					Children: []LayoutChild{
+						{Size: 100, Pane: &PaneConfig{ID: "main", Type: "local"}},
+					},
+				},
+			}},
+		},
+	}
+}

--- a/internal/config/branches_test.go
+++ b/internal/config/branches_test.go
@@ -97,7 +97,7 @@ func TestEnsureAuthTokenMintsPersistsAndReuses(t *testing.T) {
 // hand, and each is checked together with a value that must pass, so a rule
 // that rejects everything is as visible as one that rejects nothing.
 
-// Both bounds, and both of their neighbours. Only the lower one had anything
+// Both bounds, and both of their neighbors. Only the lower one had anything
 // protecting it: with `width > maxWorkspaceVerticalBarWidth` deleted the whole
 // repository suite stayed green, so an arbitrarily wide sidebar was one
 // condition away from being accepted. Verified before writing this, which is

--- a/internal/config/branches_test.go
+++ b/internal/config/branches_test.go
@@ -97,13 +97,38 @@ func TestEnsureAuthTokenMintsPersistsAndReuses(t *testing.T) {
 // hand, and each is checked together with a value that must pass, so a rule
 // that rejects everything is as visible as one that rejects nothing.
 
+// Both bounds, and both of their neighbours. Only the lower one had anything
+// protecting it: with `width > maxWorkspaceVerticalBarWidth` deleted the whole
+// repository suite stayed green, so an arbitrarily wide sidebar was one
+// condition away from being accepted. Verified before writing this, which is
+// why the table is a table rather than the one rejecting value it started as.
 func TestValidateRejectsAnOutOfRangeVerticalBarWidth(t *testing.T) {
-	cfg := validatableConfig()
-	cfg.Workspaces.VerticalBarWidth = 1
-	require.Error(t, cfg.Validate())
+	for _, tc := range []struct {
+		name    string
+		width   int
+		wantErr bool
+	}{
+		{name: "far below the minimum", width: 1, wantErr: true},
+		{name: "just below the minimum", width: minWorkspaceVerticalBarWidth - 1, wantErr: true},
+		{name: "at the minimum", width: minWorkspaceVerticalBarWidth},
+		{name: "at the maximum", width: maxWorkspaceVerticalBarWidth},
+		{name: "just above the maximum", width: maxWorkspaceVerticalBarWidth + 1, wantErr: true},
+		{name: "far above the maximum", width: 10000, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validatableConfig()
+			cfg.Workspaces.VerticalBarWidth = tc.width
 
-	cfg.Workspaces.VerticalBarWidth = 280
-	assert.NoError(t, cfg.Validate(), "a width in range must still pass")
+			err := cfg.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid vertical_bar_width")
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestValidateRejectsAnInvalidChildDirection(t *testing.T) {

--- a/internal/ws/board_command_branches_test.go
+++ b/internal/ws/board_command_branches_test.go
@@ -1,0 +1,100 @@
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"panemux/internal/commandcenter"
+)
+
+// This socket is the command palette's only transport, and it is the one
+// route in panemux that requires the bearer token. The arms below are what
+// stands between a malformed or unexpected client and a palette that stops
+// answering — or, worse, one that answers with nothing at all.
+
+// A GET that carries the right subprotocol but not the upgrade headers gets
+// past the token check and fails at the upgrade. It has to be logged: the
+// dashboard shows a palette that never connects, and without this line there
+// is nothing on the server side saying why.
+func TestBoardCommandServeHTTPLogsAFailedUpgrade(t *testing.T) {
+	logs := captureWSLog(t)
+	srv := setupBoardCommandWSServer(&fakeBoardCommandRunner{}, "sample-token")
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/ws/board-command", nil)
+	require.NoError(t, err)
+	req.Header.Set("Sec-WebSocket-Protocol", "sample-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close() //nolint:errcheck
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"the token was accepted — this is the upgrade failing, not auth")
+	assert.Contains(t, logs.String(), "board command ws upgrade error")
+}
+
+// The protocol is text frames carrying JSON. A binary frame is skipped rather
+// than parsed or answered, and the connection stays open: a client that sends
+// one by mistake must still be able to send a prompt afterwards, which is
+// what separates skipping from closing.
+func TestBoardCommandIgnoresBinaryFramesAndKeepsTheConnection(t *testing.T) {
+	runner := &fakeBoardCommandRunner{
+		queryFn: func(_ context.Context, _ string) (<-chan commandcenter.Event, error) {
+			return closedEventsChan(commandcenter.Event{Type: commandcenter.EventDone}), nil
+		},
+	}
+	srv := setupBoardCommandWSServer(runner, "sample-token")
+	defer srv.Close()
+
+	conn, _, err := dialBoardCommand(t, srv, "sample-token")
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.WriteMessage(websocket.BinaryMessage, []byte("not a prompt")))
+	require.NoError(t, conn.WriteJSON(map[string]string{"prompt": "how is the board"}))
+
+	var frame boardCommandFrame
+	require.NoError(t, conn.ReadJSON(&frame),
+		"the binary frame must not have closed the socket or consumed the prompt behind it")
+	assert.Equal(t, boardCommandFrameTypeDone, frame.Type)
+}
+
+// The runner's event types and this socket's frame types are two enumerations
+// that have to stay in step. If one gains a member the other does not, the
+// default arm is what keeps the client informed rather than silently dropping
+// the event — a frame it can display beats a stream that just stops.
+func TestUnknownEventTypeBecomesAnErrorFrameNamingIt(t *testing.T) {
+	frame := eventToBoardCommandFrame(commandcenter.Event{Type: commandcenter.EventType("thinking")})
+
+	assert.Equal(t, boardCommandFrameTypeError, frame.Type)
+	assert.Contains(t, frame.Message, "thinking",
+		"the unrecognized type has to be in the message, or nobody can tell which one drifted")
+}
+
+// A frame that cannot be encoded is reported as a write failure, which stops
+// the stream rather than leaving the caller to write more frames the client
+// will never be able to interpret.
+//
+// json.RawMessage validates on marshal rather than passing bytes through, so
+// a line the subprocess emitted that is not valid JSON reaches this arm —
+// this is not a hypothetical failure of encoding/json itself.
+func TestWriteBoardCommandFrameFailsOnAnUnencodableFrame(t *testing.T) {
+	conn := &fakeBoardCommandConn{}
+
+	ok := writeBoardCommandFrame(conn, boardCommandFrame{
+		Type: boardCommandFrameTypeLine,
+		Raw:  json.RawMessage("not json"),
+	})
+
+	assert.False(t, ok)
+	assert.Empty(t, conn.writtenFrames, "nothing may be written for a frame that failed to encode")
+	assert.Empty(t, conn.deadlines,
+		"and the deadline must not be set either — the failure is before the write is attempted")
+}


### PR DESCRIPTION
The eleventh slice of the per-block backlog, after #203, #205, #206, #208, #211, #213, #215, #216, #217 and #219.

| file | blocks |
|---|---|
| `internal/config` (`agent_board.go`, `validate.go`) | 9 → **1** |
| `internal/api/board.go` | 4 → **0** |
| `internal/ws/board_command.go` | 4 → **0** |
| repository-wide | 103 → **88** |

**Nothing in the implementation changes.** Three test files are added, so `make efficacy` and the diff-scoped gates all skip.

## Why these branches matter

**`EnsureAuthToken` is best-effort by design.** Every failure leaves the token empty and lets panemux start, because a server that will not boot is worse than one whose board routes are unreachable. That makes the log line the operator's only signal, so each test asserts what it says — *and* that the token stays empty. A token generated but not persisted would change on every restart, silently invalidating the one the dashboard already holds.

**`Validate` is the opposite.** It exists to reject a config, so a rule that never fires is a rule that is not there. Each rejection here is paired with a value that must pass, so a rule that rejects *everything* is as visible as one that rejects nothing.

**The two loopback guards protect `GET /api/session-token`** — the one unauthenticated route, and the one that hands out the credential every other board route requires ([docs/security.md](docs/security.md)). Both parse an address that may carry no port, and the no-port case is the ordinary one, since a Host header omits the port on the default port. Treating the parse failure as "not loopback" would reject legitimate requests to `http://localhost/`.

`isLoopbackHost`'s arm is the mirror image, and the more dangerous direction: an unparsable hostname must not be treated as local, or a non-loopback bind skips the `server.auth_token` requirement that the same document makes the board's gate.

**On the command socket**, a binary frame is skipped and the connection kept. The test sends one *and then a prompt*, because closing and skipping are indistinguishable without something behind it. The unknown-event arm keeps the client informed rather than dropping the event silently, and names the type that drifted — the two enumerations it bridges (`commandcenter.EventType` and the frame types) have to stay in step, and this is what makes a drift visible rather than a stream that just stops.

## Verification

Fourteen perturbations run; each fails exactly the intended test.

| perturbation | caught by |
|---|---|
| swallow the token path-resolve log | `TestEnsureAuthTokenReportsAnUnresolvablePath` |
| swallow the token persist log | `TestEnsureAuthTokenReportsAFailedWrite` |
| skip the vertical-bar-width rule | `TestValidateRejectsAnOutOfRangeVerticalBarWidth` |
| accept any child direction | `TestValidateRejectsAnInvalidChildDirection` |
| accept an empty ssh connection | `TestValidateRejectsAnSSHPaneWithNoConnection` |
| treat an unparsable host as loopback | `TestIsLoopbackHostTreatsANonIPHostAsRemote` |
| drop the no-port fallback in `isLoopbackAuthority` | `TestIsLoopbackAuthorityAcceptsAnAuthorityWithNoPort` |
| drop the no-port fallback in `isLoopbackRemoteAddr` | `TestIsLoopbackRemoteAddrAcceptsAnAddressWithNoPort` |
| drop either history-fn wrap | `TestDefaultCommandHistoryFnNamesWhichStepFailed` |
| change the command-socket upgrade log | `TestBoardCommandServeHTTPLogsAFailedUpgrade` |
| binary frame `continue` → `return` | `TestBoardCommandIgnoresBinaryFramesAndKeepsTheConnection` |
| drop the type from the unknown-event message | `TestUnknownEventTypeBecomesAnErrorFrameNamingIt` |
| ignore a frame that fails to marshal | `TestWriteBoardCommandFrameFailsOnAnUnencodableFrame` |

One perturbation first reported "still green" and was a **build failure** — deleting a log call left `log` unused. Re-run with a compiling replacement, it is caught. Third time on this issue that a `^--- FAIL` filter has read a build failure as a passing suite; worth knowing about the method, not just the result.

## Left in the backlog

Two blocks, both unreachable: `yaml.Marshal` on a fixed struct in `config.go`, and `crypto/rand`'s failure arm in `generateAuthToken`.

No `//coverage:exempt` marker was added, for the reason #203 records.

## Test plan

- [x] `make check` — exit 0
- [x] `make lint-go` — 0 issues
- [x] `go test ./internal/config/ ./internal/api/ ./internal/ws/ -count=1`
- [x] `make coverage-blocks` — repository-wide 103 → 88
- [x] 14 perturbations run; each fails exactly the intended test
- [x] `make efficacy` — skipped, no implementation changed
- [x] `COVERAGE_BLOCKS_BASE=origin/main make coverage-blocks` — skipped, no implementation changed
- [x] `MUTATION_BASE=origin/main make mutation` — skipped, no implementation changed

Closes part of #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpqKsB4vF9pSsqWWQm9a8Z)_