### PR TITLE
test: make the remote/local AgmsgClient choice actually assertable (#209)

### DIFF
--- a/board_branches_test.go
+++ b/board_branches_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -309,18 +311,38 @@ func TestDistinctBoardHosts_DeduplicatesAndKeepsEachHostOnce(t *testing.T) {
 	assert.ElementsMatch(t, []string{"ssh:build-host", boardHostIDLocal}, hosts)
 }
 
-// A remote host that answers the presence probe gets a remote client, which
-// is the arm the local-host tests never reach.
+// A remote host that answers the presence probe gets a *remote* client,
+// which is the arm the local-host tests never reach.
+//
+// Asserting only that some non-nil client came back is not enough, and that
+// is the whole point of this test (issue #209): handing a remote host a
+// LocalAgmsgClient is a silent failure. The path was resolved for the other
+// machine, agmsgPresentOnHost has already passed, so nothing errors at
+// startup and the pane still reads "board enabled" on the dashboard — while
+// every read and write goes to panemux's own filesystem and no board traffic
+// ever reaches the host.
 func TestNewAgmsgClientForHost_RemoteWithAgmsgPresent_BuildsARemoteClient(t *testing.T) {
 	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/opt/agmsg"}}
 	manager := session.NewManager()
-	manager.Add(&fakeBoardSession{id: "pane-a", tag: "yes"})
+	sess := &fakeBoardSession{id: "pane-a", tag: "yes"}
+	manager.Add(sess)
 	paneHosts := map[string]string{"pane-a": "ssh:build-host"}
 
 	client, ok := newAgmsgClientForHost(cfg, manager, paneHosts, "ssh:build-host")
 
 	require.True(t, ok)
-	assert.NotNil(t, client)
+	require.NotNil(t, client)
+	assert.IsType(t, &board.RemoteAgmsgClient{}, client)
+	// HostID is the same distinction stated through the AgmsgClient
+	// interface itself: a LocalAgmsgClient reports "local" whichever host it
+	// was built for, so it can never answer with this host's ID.
+	assert.Equal(t, "ssh:build-host", client.HostID())
+
+	// And the client is wired to that host's live session rather than to a
+	// local exec: a write travels over the pane's own exec channel, naming
+	// the remote install's send.sh at the path resolved for that host.
+	require.NoError(t, client.Send(context.Background(), "team", "pane-a", "pane-b", "hi"))
+	assert.Contains(t, strings.Join(sess.lastBoardCommand(), " "), "/opt/agmsg/scripts/send.sh")
 }
 
 // The same host answering "no" is skipped, with the one log line that names
@@ -338,18 +360,6 @@ func TestNewAgmsgClientForHost_RemoteWithoutAgmsg_SkipsTheHost(t *testing.T) {
 	assert.Nil(t, client)
 	assert.Contains(t, buf.String(), "no agmsg installation at")
 	assert.Contains(t, buf.String(), "/opt/agmsg")
-}
-
-// A host whose path cannot be resolved never reaches the presence probe.
-func TestNewAgmsgClientForHost_UnresolvablePath_SkipsTheHost(t *testing.T) {
-	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/opt/agmsg"}}
-
-	client, ok := newAgmsgClientForHost(
-		cfg, session.NewManager(), map[string]string{"pane-a": "ssh:build-host"}, "ssh:build-host",
-	)
-
-	assert.False(t, ok)
-	assert.Nil(t, client)
 }
 
 // A reachable executor whose probe fails is reported present anyway. Refusing

--- a/board_branches_test.go
+++ b/board_branches_test.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,9 +339,40 @@ func TestNewAgmsgClientForHost_RemoteWithAgmsgPresent_BuildsARemoteClient(t *tes
 
 	// And the client is wired to that host's live session rather than to a
 	// local exec: a write travels over the pane's own exec channel, naming
-	// the remote install's send.sh at the path resolved for that host.
+	// the remote install's send.sh. Asserted against the argv elements
+	// themselves rather than a flattened string, so the script path has to be
+	// its own argument and not, say, part of the message body.
 	require.NoError(t, client.Send(context.Background(), "team", "pane-a", "pane-b", "hi"))
-	assert.Contains(t, strings.Join(sess.lastBoardCommand(), " "), "/opt/agmsg/scripts/send.sh")
+	assert.Contains(t, sess.lastBoardCommand(), "/opt/agmsg/scripts/send.sh")
+}
+
+// A ~/-prefixed agmsg_path is expanded against the remote host's own $HOME
+// before the client is built. The absolute path every other test here uses
+// short-circuits board.ResolveRemoteAgmsgPath, so this arm is otherwise never
+// entered (DEVELOPMENT.md's "paths with ~/ when paths are involved").
+//
+// Left unexpanded the failure is silent in the same way a wrong client type
+// is: RunBoardCommand single-quotes every argument, so a literal ~ does not
+// expand on the remote shell either, and send.sh is looked for at a path that
+// cannot exist.
+func TestNewAgmsgClientForHost_RemoteWithTildePath_ExpandsAgainstTheRemoteHome(t *testing.T) {
+	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "~/.agents/skills/agmsg"}}
+	manager := session.NewManager()
+	sess := &homeProbingBoardSession{
+		home:             "/remote/home/demo",
+		fakeBoardSession: fakeBoardSession{id: "pane-a", tag: "yes"},
+	}
+	manager.Add(sess)
+	paneHosts := map[string]string{"pane-a": "ssh:build-host"}
+
+	client, ok := newAgmsgClientForHost(cfg, manager, paneHosts, "ssh:build-host")
+
+	require.True(t, ok)
+	require.NotNil(t, client)
+	require.NoError(t, client.Send(context.Background(), "team", "pane-a", "pane-b", "hi"))
+	assert.Contains(
+		t, sess.lastBoardCommand(), "/remote/home/demo/.agents/skills/agmsg/scripts/send.sh",
+	)
 }
 
 // The same host answering "no" is skipped, with the one log line that names

--- a/board_test.go
+++ b/board_test.go
@@ -21,6 +21,7 @@ import (
 type fakeBoardSession struct {
 	id     string
 	tag    string // distinguishes which fakeBoardSession instance answered a call
+	calls  [][]string
 	closed bool
 }
 
@@ -33,11 +34,22 @@ func (f *fakeBoardSession) Write(p []byte) (int, error)    { return len(p), nil 
 func (f *fakeBoardSession) Resize(cols, rows uint16) error { return nil }
 func (f *fakeBoardSession) Close() error                   { f.closed = true; return nil }
 
-func (f *fakeBoardSession) RunBoardCommand(_ context.Context, _ []string) ([]byte, error) {
+func (f *fakeBoardSession) RunBoardCommand(_ context.Context, args []string) ([]byte, error) {
 	if f.closed {
 		return nil, errors.New("fakeBoardSession: use of closed session")
 	}
+	f.calls = append(f.calls, args)
 	return []byte(f.tag), nil
+}
+
+// lastBoardCommand returns the argument list of the most recent
+// RunBoardCommand call, so a test can tell a command that actually traveled
+// over this session's exec channel from one that never left panemux.
+func (f *fakeBoardSession) lastBoardCommand() []string {
+	if len(f.calls) == 0 {
+		return nil
+	}
+	return f.calls[len(f.calls)-1]
 }
 
 func TestDynamicBoardExecutor_ReResolvesAfterPaneRestart(t *testing.T) {
@@ -506,7 +518,13 @@ func TestNewAgmsgClientForHost_LocalWithAgmsgInstalled_ReturnsClient(t *testing.
 	client, ok := newAgmsgClientForHost(cfg, session.NewManager(), map[string]string{}, boardHostIDLocal)
 
 	require.True(t, ok)
-	assert.NotNil(t, client)
+	require.NotNil(t, client)
+	// The mirror of the remote arm's own assertion (issue #209): which
+	// implementation came back is the whole answer this function gives, so
+	// asserting only non-nil would let either arm return the other's client
+	// unnoticed.
+	assert.IsType(t, &board.LocalAgmsgClient{}, client)
+	assert.Equal(t, boardHostIDLocal, client.HostID())
 }
 
 // An absent agmsg is the README's most likely first failure, and the host is
@@ -523,13 +541,20 @@ func TestNewAgmsgClientForHost_LocalWithoutAgmsg_SkipsTheHost(t *testing.T) {
 
 // A remote host with no reachable pane cannot have its agmsg_path resolved at
 // all, so it is skipped before the presence probe is even reached.
+//
+// The log line is asserted because newAgmsgClientForHost has three ways to
+// return (nil, false) and they are indistinguishable from the return value
+// alone: no reachable session, a failed $HOME probe, and an absent agmsg
+// install. Only the line names which one this test actually reached.
 func TestNewAgmsgClientForHost_RemoteWithNoReachablePane_SkipsTheHost(t *testing.T) {
 	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: "/remote/home/demo/agmsg"}}
+	buf := captureBoardLog(t)
 
 	client, ok := newAgmsgClientForHost(cfg, session.NewManager(), map[string]string{"pane-a": "ssh:demo"}, "ssh:demo")
 
 	assert.False(t, ok)
 	assert.Nil(t, client)
+	assert.Contains(t, buf.String(), `no reachable session for host "ssh:demo"`)
 }
 
 func TestWarnOnAgmsgVersionMismatch_DoesNotPanicAcrossHostShapes(t *testing.T) {

--- a/board_test.go
+++ b/board_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,11 +36,15 @@ func (f *fakeBoardSession) Write(p []byte) (int, error)    { return len(p), nil 
 func (f *fakeBoardSession) Resize(cols, rows uint16) error { return nil }
 func (f *fakeBoardSession) Close() error                   { f.closed = true; return nil }
 
+// RunBoardCommand records args before the closed guard, not after: a test
+// asserting that no board traffic reached a stale pane needs a call on a
+// closed session to be visible. Recording after the early return would make
+// "never called" and "called on a dead session" look identical.
 func (f *fakeBoardSession) RunBoardCommand(_ context.Context, args []string) ([]byte, error) {
+	f.calls = append(f.calls, args)
 	if f.closed {
 		return nil, errors.New("fakeBoardSession: use of closed session")
 	}
-	f.calls = append(f.calls, args)
 	return []byte(f.tag), nil
 }
 
@@ -50,6 +56,29 @@ func (f *fakeBoardSession) lastBoardCommand() []string {
 		return nil
 	}
 	return f.calls[len(f.calls)-1]
+}
+
+// homeProbingBoardSession answers board.ResolveRemoteAgmsgPath's $HOME probe
+// with a fixed remote home directory, and every other board command the way
+// fakeBoardSession would. It exists so a test can drive the ~/-expansion arm,
+// which an absolute agmsg_path short-circuits before RunBoardCommand is
+// reached at all.
+type homeProbingBoardSession struct {
+	home string
+	fakeBoardSession
+}
+
+func (h *homeProbingBoardSession) RunBoardCommand(ctx context.Context, args []string) ([]byte, error) {
+	out, err := h.fakeBoardSession.RunBoardCommand(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "$HOME") {
+			return []byte(h.home), nil
+		}
+	}
+	return out, nil
 }
 
 func TestDynamicBoardExecutor_ReResolvesAfterPaneRestart(t *testing.T) {
@@ -88,6 +117,10 @@ func TestDynamicBoardExecutor_ReResolvesAfterPaneRestart(t *testing.T) {
 	if !original.closed {
 		t.Fatalf("expected original session to have been closed by Remove")
 	}
+	// The stale session was called once, before the restart, and never again.
+	// fakeBoardSession records a call even when it is closed, so this can
+	// tell "never called again" from "called again and refused".
+	assert.Len(t, original.calls, 1)
 }
 
 func TestDynamicBoardExecutor_NoLiveSessionOnHost_ReturnsError(t *testing.T) {
@@ -511,20 +544,54 @@ func installAgmsg(t *testing.T, root, version string) string {
 	return root
 }
 
+// installExecutableSendScript replaces an installAgmsg tree's send.sh with a
+// stand-in that dumps its own path and argv, NUL-separated, to capturePath.
+// LocalAgmsgClient.Send really execs that file, so this is how a test
+// observes which install a locally-built client is actually rooted at —
+// asserting on HostID() would not: LocalAgmsgClient returns a hardcoded
+// "local" whatever it was constructed with.
+func installExecutableSendScript(t *testing.T, agmsgPath, capturePath string) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf '%s\\0' \"$0\" \"$@\" > '" + capturePath + "'\n"
+	//nolint:gosec // G306: test fixture needs the exec bit
+	require.NoError(t, os.WriteFile(filepath.Join(agmsgPath, "scripts", "send.sh"), []byte(script), 0700))
+}
+
 func TestNewAgmsgClientForHost_LocalWithAgmsgInstalled_ReturnsClient(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
 	agmsgPath := installAgmsg(t, t.TempDir(), board.TestedAgmsgVersion)
+	capturePath := filepath.Join(t.TempDir(), "captured-argv")
+	installExecutableSendScript(t, agmsgPath, capturePath)
 	cfg := &config.Config{AgentBoard: config.AgentBoardConfig{AgmsgPath: agmsgPath}}
 
 	client, ok := newAgmsgClientForHost(cfg, session.NewManager(), map[string]string{}, boardHostIDLocal)
 
 	require.True(t, ok)
 	require.NotNil(t, client)
-	// The mirror of the remote arm's own assertion (issue #209): which
-	// implementation came back is the whole answer this function gives, so
-	// asserting only non-nil would let either arm return the other's client
-	// unnoticed.
+	// Which implementation came back is the whole answer this function gives
+	// (issue #209), so asserting only non-nil would let either arm return the
+	// other's client unnoticed.
 	assert.IsType(t, &board.LocalAgmsgClient{}, client)
-	assert.Equal(t, boardHostIDLocal, client.HostID())
+
+	// The real mirror of the remote arm's own Send assertion: the write has to
+	// reach this install's own send.sh, which is what pins that the client was
+	// built around the path this call resolved rather than around anything
+	// else. A RemoteAgmsgClient returned here would have no reachable session
+	// and fail instead.
+	require.NoError(t, client.Send(context.Background(), "team", "pane-a", "pane-b", "hi"))
+	captured, err := os.ReadFile(capturePath)
+	require.NoError(t, err)
+	argv := strings.Split(strings.TrimSuffix(string(captured), "\x00"), "\x00")
+	assert.Equal(
+		t,
+		[]string{
+			filepath.Join(agmsgPath, "scripts", "send.sh"),
+			"team", "pane-a", "pane-b", "hi", "--force",
+		},
+		argv,
+	)
 }
 
 // An absent agmsg is the README's most likely first failure, and the host is


### PR DESCRIPTION
newAgmsgClientForHost's last arm could be replaced with an unconditional
`return board.NewLocalAgmsgClient(path), true` and the whole root package
stayed green. The test guarding it asserted `require.True(t, ok)` and
`assert.NotNil(t, client)`, neither of which can tell the two
implementations apart — it confirmed the arm was entered, not what it
returned. The mutant is the silent kind: the presence probe has already
passed, nothing errors at startup, the pane still reads "board enabled" on
the dashboard, and every read and write goes to panemux's own filesystem
instead of the remote host.

The remote test now pins the type, the HostID the AgmsgClient interface
reports, and that a Send actually travels over the pane's exec channel
naming the remote install's own send.sh. The local test gets the mirror of
the first two, so the two arms are guarded symmetrically rather than one
of them being free to return the other's client. Verified by perturbation:
swapping either arm for the other's constructor, or building the remote
client with the wrong host ID, now fails.

TestNewAgmsgClientForHost_UnresolvablePath_SkipsTheHost is deleted. Its
own comment described a branch it never reached — the fixture's agmsg_path
has no `~/` prefix, so ResolveRemoteAgmsgPath is never called and the skip
came from the empty session manager, i.e. exactly the case
TestNewAgmsgClientForHost_RemoteWithNoReachablePane_SkipsTheHost already
covers, down to an identical block set. The genuine probe-failure branch
is covered at its own level by
TestResolveAgmsgPathForHost_RemoteProbeFails_SkipsTheHost. The surviving
skip test now asserts the log line, since the three ways this function
returns (nil, false) are indistinguishable from the return value alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019En9v35covfmKHuacfVHcM