### PR TITLE
fix: repair a macOS-bash-specific test and shell-script bug found while fixing it

### DIFF
--- a/internal/session/browseropen_test.go
+++ b/internal/session/browseropen_test.go
@@ -538,15 +538,16 @@ func TestSSHShellCommandIsValidShellSyntax(t *testing.T) {
 // SSH shell request and never depended on $SHELL at all.
 func TestRemoteLoginShellExecFallsBackWhenShellIsUnset(t *testing.T) {
 	tests := []struct {
-		name  string
-		wantX string
-		env   []string
+		name       string
+		wantX      string
+		env        []string
+		unsetShell bool
 	}{
 		{name: "bash gets a login shell", env: []string{"SHELL=/bin/bash"}, wantX: "login"},
 		{name: "zsh gets a login shell", env: []string{"SHELL=/usr/bin/zsh"}, wantX: "login"},
 		{name: "fish gets a login shell", env: []string{"SHELL=/usr/local/bin/fish"}, wantX: "login"},
 		{name: "unknown shell execs plainly", env: []string{"SHELL=/bin/ksh"}, wantX: "plain"},
-		{name: "unset shell falls back", env: nil, wantX: "fallback"},
+		{name: "unset shell falls back", unsetShell: true, wantX: "fallback"},
 		{name: "empty shell falls back", env: []string{"SHELL="}, wantX: "fallback"},
 	}
 
@@ -559,7 +560,18 @@ func TestRemoteLoginShellExecFallsBackWhenShellIsUnset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := exec.Command("sh", "-c", probe) //nolint:gosec // G204: fixed script under test
+			script := probe
+			if tt.unsetShell {
+				// A cmd.Env with no SHELL entry isn't enough to observe the
+				// "unset" branch on a system whose /bin/sh is bash: bash
+				// populates SHELL itself from the password database when the
+				// variable is absent from its environment (unlike an
+				// explicitly empty SHELL=, which it leaves alone). Unsetting
+				// it inside the script runs after that auto-population, so
+				// the case statement sees a genuinely empty value.
+				script = "unset SHELL; " + probe
+			}
+			cmd := exec.Command("sh", "-c", script) //nolint:gosec // G204: fixed script under test
 			cmd.Env = append([]string{"PATH=/usr/bin:/bin"}, tt.env...)
 			out, err := cmd.Output()
 			if err != nil {

--- a/scripts/scenarios_check.sh
+++ b/scripts/scenarios_check.sh
@@ -82,7 +82,7 @@ output=$(printf '%s\n' "$rows" | { seen=0
 			# (/ws/board-command) and absolute or home-relative paths are not
 			# references into this repository. Excluding them by shape keeps the
 			# check free of the false positives that would make it noise.
-			auto | manual | make | -* | /* | '~'/* | *+*) continue ;;
+			(auto | manual | make | -* | /* | '~'/* | *+*) continue ;;
 			esac
 
 			case "$token" in
@@ -90,11 +90,11 @@ output=$(printf '%s\n' "$rows" | { seen=0
 			# a source extension. `bin/panemux` is neither — it is a build
 			# artifact, and a gate that demanded it exist would fail on a clean
 			# checkout.
-			internal/* | frontend/* | docs/* | scripts/* | .github/* | testdata/* | \
+			(internal/* | frontend/* | docs/* | scripts/* | .github/* | testdata/* | \
 				*.go | *.ts | *.tsx | *.yml | *.yaml | *.sh)
 				case "$token" in
-				*/*) ;;
-				*) continue ;;
+				(*/*) ;;
+				(*) continue ;;
 				esac
 				target=${token%/}
 				if [ -e "$repo_root/$target" ]; then
@@ -121,7 +121,7 @@ output=$(printf '%s\n' "$rows" | { seen=0
 			# (TestFoo -> TestFoo_RemoteVariant), so a row naming the old,
 			# shorter name still matched the new, longer function and the gate
 			# passed on a row that no longer points anywhere.
-			Test*)
+			(Test*)
 				pattern=${token%\*}
 				if [ "$token" != "$pattern" ]; then
 					expr="^func ${pattern}[A-Za-z0-9_]*\("
@@ -136,7 +136,7 @@ output=$(printf '%s\n' "$rows" | { seen=0
 				;;
 			# The ledger's shorthand for "same prefix as the row above":
 			# `..._WriteError_RetriedUpToLimitThenGivesUp`.
-			...*)
+			(...*)
 				suffix=${token#...}
 				if grep -rqE "^func Test[A-Za-z0-9_]*${suffix}\(" --include='*_test.go' "$repo_root"; then
 					resolved=$((resolved + 1))


### PR DESCRIPTION
## Summary
- \`TestRemoteLoginShellExecFallsBackWhenShellIsUnset/unset_shell_falls_back\` in `internal/session/browseropen_test.go` failed on macOS because `/bin/sh` (bash 3.2) auto-populates `SHELL` from the password database when it is absent from the environment entirely — unlike an explicitly empty `SHELL=`, which it leaves alone. The test's "unset shell falls back" case now runs `unset SHELL;` inside the probed script, after that auto-population, so the case statement under test observes a genuinely empty value. No production code changed.
- While chasing this through `make check`'s pre-push hook, `scripts/scenarios_check.sh` turned out to already fail its own syntax check under macOS's `/bin/sh`/`/bin/bash` (bash 3.2): a `case ... esac` inside a `$(...)` command substitution fails to parse when a pattern's closing `)` isn't preceded by an opening one. Every `case` in the row-scanning loop hit this, since the whole loop runs inside `output=$(... | { ... })`. Fixed by prefixing each pattern with `(`, the POSIX-legal form — verified to parse under bash, dash, and this repository's own `scenarios_check_test.sh` suite. This is unrelated to the SHELL test fix; it just happened to be the first time this script was syntax-checked under this shell.

## Test plan
- [x] `go test ./internal/session/... -race` passes
- [x] `go test ./... -race` passes (all packages)
- [x] Reverting the test change reproduces the original failure (`branch = "login", want "fallback"`)
- [x] `make lint-go` — 0 issues
- [x] `gofmt -s` — no diff
- [x] `sh -n scripts/scenarios_check.sh` and `dash -n scripts/scenarios_check.sh` both parse cleanly
- [x] `make check-scenarios` resolves all 208 names across 92 auto rows
- [x] `make test-scenarios-check` — all 22 checks pass
- [x] `make check` passes end to end (Go tests, lint, coverage gates, mutation, scenarios check)

https://claude.ai/code/session_01R7XUVKRPNwM5xd8VoGEjap